### PR TITLE
fixed SimpleTokenParser treat comma as constant.

### DIFF
--- a/lib/Twig/Grammar/Operator.php
+++ b/lib/Twig/Grammar/Operator.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2010 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class Twig_Grammar_Operator extends Twig_Grammar_Constant
+{
+    public function parse(Twig_Token $token)
+    {
+        $this->parser->getStream()->expect(Twig_Token::OPERATOR_TYPE, $this->name);
+
+        return $this->name;
+    }
+}

--- a/lib/Twig/Grammar/Optional.php
+++ b/lib/Twig/Grammar/Optional.php
@@ -39,15 +39,11 @@ class Twig_Grammar_Optional extends Twig_Grammar
     {
         // test if we have the optional element before consuming it
         if ($this->grammar[0] instanceof Twig_Grammar_Constant) {
-            if (!$this->parser->getStream()->test($this->grammar[0]->getName())) {
-                return array();
-            }
-        } elseif ($this->grammar[0] instanceof Twig_Grammar_Name) {
-            if (!$this->parser->getStream()->test(Twig_Token::NAME_TYPE)) {
+            if (!$this->parser->getStream()->test($this->grammar[0] instanceof Twig_Grammar_Operator ? Twig_Token::OPERATOR_TYPE : Twig_Token::NAME_TYPE, $this->grammar[0]->getName())) {
                 return array();
             }
         } elseif ($this->parser->getStream()->test(Twig_Token::BLOCK_END_TYPE)) {
-            // if this is not a Constant or a Name, it must be the last element of the tag
+            // if this is not a Constant, it must be the last element of the tag
 
             return array();
         }

--- a/lib/Twig/SimpleTokenParser.php
+++ b/lib/Twig/SimpleTokenParser.php
@@ -108,8 +108,8 @@ abstract class Twig_SimpleTokenParser extends Twig_TokenParser
                 }
                 $grammar->addGrammar(new $class($match[1]));
                 $cursor += strlen($match[0]);
-            } elseif (preg_match('/(\w+|,)/A', $str, $match, null, $cursor)) {
-                $grammar->addGrammar(new Twig_Grammar_Constant($match[1]));
+            } elseif (preg_match('/(\w+|(,))/A', $str, $match, null, $cursor)) {
+                $grammar->addGrammar(isset($match[2]) ? new Twig_Grammar_Operator($match[2]) : new Twig_Grammar_Constant($match[1]));
                 $cursor += strlen($match[0]);
             } elseif (preg_match('/\[/A', $str, $match, null, $cursor)) {
                 $cursor += strlen($match[0]);

--- a/test/Twig/Tests/SimpleTokenParser.php
+++ b/test/Twig/Tests/SimpleTokenParser.php
@@ -34,15 +34,24 @@ class SimpleTokenParser extends Twig_SimpleTokenParser
     {
         $nodes = array();
         $nodes[] = new Twig_Node_Print(new Twig_Node_Expression_Constant('|', $line), $line);
+        
+        $this->doGetNode($nodes, $values, $line);
+
+        return new Twig_Node($nodes);
+    }
+
+    protected function doGetNode(array &$nodes, array $values, $line)
+    {
         foreach ($values as $value) {
             if ($value instanceof Twig_NodeInterface) {
                 $nodes[] = new Twig_Node_Print($value, $line);
+            } elseif (is_array($value)) {
+                $this->doGetNode($nodes, $value, $line);
+                continue;
             } else {
                 $nodes[] = new Twig_Node_Print(new Twig_Node_Expression_Constant($value, $line), $line);
             }
             $nodes[] = new Twig_Node_Print(new Twig_Node_Expression_Constant('|', $line), $line);
         }
-
-        return new Twig_Node($nodes);
     }
 }

--- a/test/Twig/Tests/SimpleTokenParserTest.php
+++ b/test/Twig/Tests/SimpleTokenParserTest.php
@@ -102,7 +102,7 @@ class Twig_Tests_SimpleTokenParserTest extends PHPUnit_Framework_TestCase
                     new Twig_Grammar_Constant('with'),
                     new Twig_Grammar_Array('arguments'),
                     new Twig_Grammar_Optional(
-                        new Twig_Grammar_Constant(','),
+                        new Twig_Grammar_Operator(','),
                         new Twig_Grammar_Expression('optional')
                     )
                 )

--- a/test/Twig/Tests/grammarTest.php
+++ b/test/Twig/Tests/grammarTest.php
@@ -58,6 +58,10 @@ class grammarTest extends PHPUnit_Framework_TestCase
             array('foo9', '<foo> with <bar>', '{% foo9 "bar" with "foobar" %}', '|bar|with|foobar|', false),
             array('foo10', '<foo> [with <bar>]', '{% foo10 "bar" with "foobar" %}', '|bar|with|foobar|', false),
             array('foo11', '<foo> [with <bar>]', '{% foo11 "bar" %}', '|bar|', false),
+            array('foo12', '<foo> [with <bar> [, <baz>]]', '{% foo12 "bar" with "baz", "foobar" %}', '|bar|with|baz|,|foobar|', false),
+            array('foo13', '<foo> [with <bar> [, <baz>]]', '{% foo13 "bar" with "baz" %}', '|bar|with|baz|', false),
+            array('foo14', '<foo> [with <bar> [, <baz>]]', '{% foo14 "bar" %}', '|bar|', false),
+            array('foo15', '<foo> [with <bar> [, <baz>]]', '{% foo14 "bar", "foobar" %}', '|', 'Twig_SyntaxError'),
         );
     }
 }


### PR DESCRIPTION
fixed SimpleTokenParser treat comma as constant.

My previous commit a115a0667db82412749d6af8a4e730364d602b2e was modified SimpleTokenParser::parseGrammer() to accept comma, but cannot to parse tokens include comma because comma tokenize as an OPERATOR.
