### PR TITLE
'hasKey' filter (ticket #112)

### DIFF
--- a/lib/Twig/ExpressionParser.php
+++ b/lib/Twig/ExpressionParser.php
@@ -86,7 +86,7 @@ class Twig_ExpressionParser
             ||
             $this->parser->getStream()->test(Twig_Token::NAME_TYPE, 'in')
             ||
-            $this->parser->getStream()->test(Twig_Token::NAME_TYPE, 'has')
+            $this->parser->getStream()->test(Twig_Token::NAME_TYPE, 'hasKey')
         ) {
             $ops[] = new Twig_Node_Expression_Constant($this->parser->getStream()->next()->getValue(), $lineno);
             $ops[] = $this->parseAddExpression();

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -61,7 +61,7 @@ class Twig_Extension_Core extends Twig_Extension
             'length'  => new Twig_Filter_Function('twig_length_filter', array('needs_environment' => true)),
             'sort'    => new Twig_Filter_Function('twig_sort_filter'),
             'in'      => new Twig_Filter_Function('twig_in_filter'),
-            'has'     => new Twig_Filter_Function('twig_has_filter'),
+            'hasKey'  => new Twig_Filter_Function('twig_has_key_filter'),
             'range'   => new Twig_Filter_Function('twig_range_filter'),
             'cycle'   => new Twig_Filter_Function('twig_cycle_filter'),
 
@@ -186,7 +186,7 @@ function twig_in_filter($value, $compare)
     return false;
 }
 
-function twig_has_filter($compare, $key)
+function twig_has_key_filter($compare, $key)
 {
     if (is_array($compare)) {
         return array_key_exists($key, $compare);

--- a/lib/Twig/Node/Expression/Compare.php
+++ b/lib/Twig/Node/Expression/Compare.php
@@ -20,8 +20,8 @@ class Twig_Node_Expression_Compare extends Twig_Node_Expression
     {
         if ('in' === $this->ops->{0}['value']) {
             return $this->compileIn($compiler);
-        } else if ('has' === $this->ops->{0}['value']) {
-            return $this->compileHas($compiler);
+        } else if ('hasKey' === $this->ops->{0}['value']) {
+            return $this->compileHasKey($compiler);
         }
 
         $this->expr->compile($compiler);
@@ -61,10 +61,10 @@ class Twig_Node_Expression_Compare extends Twig_Node_Expression
         ;
     }
 
-    protected function compileHas($compiler)
+    protected function compileHasKey($compiler)
     {
         $compiler
-            ->raw('twig_has_filter(')
+            ->raw('twig_has_key_filter(')
             ->subcompile($this->expr)
             ->raw(', ')
             ->subcompile($this->ops->{1})

--- a/test/Twig/Tests/Fixtures/expressions/has.test
+++ b/test/Twig/Tests/Fixtures/expressions/has.test
@@ -1,14 +1,14 @@
 --TEST--
-Twig supports the has operator
+Twig supports the hasKey operator
 --TEMPLATE--
-{% if foo has bar %}
+{% if foo hasKey bar %}
 TRUE
 {% endif %}
-{% if not foo has bar %}
+{% if not foo hasKey bar %}
 {% else %}
 TRUE
 {% endif %}
-{% if foo has 'bar' %}
+{% if foo hasKey 'bar' %}
 TRUE
 {% endif %}
 --DATA--

--- a/test/Twig/Tests/Fixtures/filters/has.test
+++ b/test/Twig/Tests/Fixtures/filters/has.test
@@ -1,13 +1,13 @@
 --TEST--
-"has" filter
+"hasKey" filter
 --TEMPLATE--
-{{ [1:0, 2:0, 3:0]|has(1) }}
-{{ [1:0, 2:0, 3:0]|has(5) }}
-{{ foo|has('foo') }}
-{{ foo|has('bar') }}
-{{ bar|has('foo') }}
-{{ bar|has('bar') }}
-{{ bar|has('baz') }}
+{{ [1:0, 2:0, 3:0]|hasKey(1) }}
+{{ [1:0, 2:0, 3:0]|hasKey(5) }}
+{{ foo|hasKey('foo') }}
+{{ foo|hasKey('bar') }}
+{{ bar|hasKey('foo') }}
+{{ bar|hasKey('bar') }}
+{{ bar|hasKey('baz') }}
 --DATA--
 class ArrayAccessImplForHasFilter implements ArrayAccess
 {


### PR DESCRIPTION
These commits add a 'hasKey' filter, which can be used to test if an array contains the specified key. It also adds an 'hasKey' keyword for use as an infix operator, like the 'in' operator: `{% if user hasKey 'name' %}`.

Thanks!
