### PR TITLE
Exceptions should not be wrapped around TokenParser If's process

### DIFF
--- a/lib/Twig/TokenParser/If.php
+++ b/lib/Twig/TokenParser/If.php
@@ -29,34 +29,26 @@ class Twig_TokenParser_If extends Twig_TokenParser
 
         $end = false;
         while (!$end) {
-            try
-            {
-                switch ($this->parser->getStream()->next()->getValue()) {
-                    case 'else':
-                        $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
-                        $else = $this->parser->subparse(array($this, 'decideIfEnd'));
-                        break;
+            switch ($this->parser->getStream()->next()->getValue()) {
+                case 'else':
+                    $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
+                    $else = $this->parser->subparse(array($this, 'decideIfEnd'));
+                    break;
 
-                    case 'elseif':
-                        $expr = $this->parser->getExpressionParser()->parseExpression();
-                        $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
-                        $body = $this->parser->subparse(array($this, 'decideIfFork'));
-                        $tests[] = $expr;
-                        $tests[] = $body;
-                        break;
+                case 'elseif':
+                    $expr = $this->parser->getExpressionParser()->parseExpression();
+                    $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
+                    $body = $this->parser->subparse(array($this, 'decideIfFork'));
+                    $tests[] = $expr;
+                    $tests[] = $body;
+                    break;
 
-                    case 'endif':
-                        $end = true;
-                        break;
+                case 'endif':
+                    $end = true;
+                    break;
 
-                    default:
-                        throw new Twig_SyntaxError('', -1);
-                }
-            } catch (Twig_SyntaxError $e) {
-                if ($e->getCode() === -1 && $e->getMessage() === "") {
+                default:
                     throw new Twig_SyntaxError(sprintf('Unexpected end of template. Twig was looking for the following tags "else", "elseif", or "endif" to close the "if" block started at line %d)', $lineno), -1);
-                }
-                throw $e;
             }
         }
 


### PR DESCRIPTION
It was hard to identify template errors when an error was inside a "subparse" process

```
{% if name %}
    hi
{% elseif nick %}
    {% asdfasd3 %}
{% endif %}
```

Exception thrown was

```
Unexpected end of template. Twig was looking for the following tags "else", "elseif", or "endif" to close the "if" block started at line 16) in /home/angelo/..../views/test.html at line -1
```

When it should have been

```
Unknown tag name "asdfasd3" in /home/angelo/..../views/test.html at line 18
```
