### PR TITLE
PHP5.2 compatibility issue

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -37,7 +37,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
         if (false !== $parent = $this->getParent($context)) {
             return $parent->getBlock($name, $context, $blocks);
         } else {
-            throw new \LogicException('This template has no parent.');
+            throw new LogicException('This template has no parent.');
         }
     }
 


### PR DESCRIPTION
The global space prefix on the LogicException causes a warning in PHP 5.2.
