### PR TITLE
Fix filter name in doc

### DIFF
--- a/doc/02-Twig-for-Template-Designers.markdown
+++ b/doc/02-Twig-for-Template-Designers.markdown
@@ -1058,7 +1058,7 @@ The `format` filter formats a given string by replacing the placeholders
 
     [twig]
     {# string is a format string like: I like %this% and %that%. #}
-    {{ string|format(['%this%': foo, '%that%': "bar"]) }}
+    {{ string|replace(['%this%': foo, '%that%': "bar"]) }}
     {# returns I like foo and bar. (if the foo parameter equals to the foo string) #}
 
 ### `cycle`


### PR DESCRIPTION
Just a typo fix in documentation.
