### PR TITLE
fix storing of object properties in SafeAnalysis

### DIFF
--- a/lib/Twig/ExpressionParser.php
+++ b/lib/Twig/ExpressionParser.php
@@ -87,6 +87,8 @@ class Twig_ExpressionParser
             ($this->parser->getStream()->test(Twig_Token::NAME_TYPE, 'not') && $this->parser->getStream()->look()->test(Twig_Token::NAME_TYPE, 'in'))
             ||
             $this->parser->getStream()->test(Twig_Token::NAME_TYPE, 'in')
+            ||
+            $this->parser->getStream()->test(Twig_Token::NAME_TYPE, 'hasKey')
         ) {
             $this->parser->getStream()->rewind();
             if ($this->parser->getStream()->test(Twig_Token::NAME_TYPE, 'not')) {

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -63,6 +63,7 @@ class Twig_Extension_Core extends Twig_Extension
             'length'  => new Twig_Filter_Function('twig_length_filter', array('needs_environment' => true)),
             'sort'    => new Twig_Filter_Function('twig_sort_filter'),
             'in'      => new Twig_Filter_Function('twig_in_filter'),
+            'hasKey'  => new Twig_Filter_Function('twig_has_key_filter'),
             'range'   => new Twig_Filter_Function('twig_range_filter'),
             'cycle'   => new Twig_Filter_Function('twig_cycle_filter'),
 
@@ -182,6 +183,20 @@ function twig_in_filter($value, $compare)
         return false !== strpos($compare, (string) $value);
     } elseif (is_object($compare) && $compare instanceof Traversable) {
         return in_array($value, iterator_to_array($compare, false));
+    }
+
+    return false;
+}
+
+function twig_has_key_filter($compare, $key)
+{
+    if (is_array($compare)) {
+        return array_key_exists($key, $compare);
+    } else if (is_object($compare)) {
+        if ($compare instanceof ArrayAccess && isset($compare[$key])) {
+            return true;
+        }
+        return isset($compare->$key);
     }
 
     return false;

--- a/lib/Twig/Node/Expression/Compare.php
+++ b/lib/Twig/Node/Expression/Compare.php
@@ -20,6 +20,8 @@ class Twig_Node_Expression_Compare extends Twig_Node_Expression
     {
         if ('in' === $this->getNode('ops')->getNode('0')->getAttribute('value')) {
             return $this->compileIn($compiler);
+        } else if ('hasKey' === $this->getNode('ops')->getNode('0')->getAttribute('value')) {
+            return $this->compileHasKey($compiler);
         }
 
         $this->getNode('expr')->compile($compiler);
@@ -58,4 +60,16 @@ class Twig_Node_Expression_Compare extends Twig_Node_Expression
             ->raw(')')
         ;
     }
+
+    protected function compileHasKey($compiler)
+    {
+        $compiler
+            ->raw('twig_has_key_filter(')
+            ->subcompile($this->getNode('expr'))
+            ->raw(', ')
+            ->subcompile($this->getNode('ops')->getNode('1'))
+            ->raw(')')
+        ;
+    }
+
 }

--- a/test/Twig/Tests/Fixtures/expressions/has.test
+++ b/test/Twig/Tests/Fixtures/expressions/has.test
@@ -1,0 +1,19 @@
+--TEST--
+Twig supports the hasKey operator
+--TEMPLATE--
+{% if foo hasKey bar %}
+TRUE
+{% endif %}
+{% if not foo hasKey bar %}
+{% else %}
+TRUE
+{% endif %}
+{% if foo hasKey 'bar' %}
+TRUE
+{% endif %}
+--DATA--
+return array('bar' => 'bar', 'foo' => array('bar' => 'bar'))
+--EXPECT--
+TRUE
+TRUE
+TRUE

--- a/test/Twig/Tests/Fixtures/filters/has.test
+++ b/test/Twig/Tests/Fixtures/filters/has.test
@@ -1,0 +1,31 @@
+--TEST--
+"hasKey" filter
+--TEMPLATE--
+{{ [1:0, 2:0, 3:0]|hasKey(1) }}
+{{ [1:0, 2:0, 3:0]|hasKey(5) }}
+{{ foo|hasKey('foo') }}
+{{ foo|hasKey('bar') }}
+{{ bar|hasKey('foo') }}
+{{ bar|hasKey('bar') }}
+{{ bar|hasKey('baz') }}
+--DATA--
+class ArrayAccessImplForHasFilter implements ArrayAccess
+{
+    protected $values = array('foo' => 'bar');
+    public function offsetGet($name) { return $this->values[$name]; }
+    public function offsetSet($name, $value) { $this->values[$name] = $value; }
+    public function offsetExists($name) { return isset($this->values[$name]); }
+    public function offsetUnset($name) { unset($this->values[$name]); }
+}
+$foo = new ArrayAccessImplForHasFilter;
+$bar = new ArrayAccessImplForHasFilter;
+$bar->baz = 1;
+return array('foo' => $foo, 'bar' => $bar)
+--EXPECT--
+1
+
+1
+
+1
+
+1

--- a/test/Twig/Tests/integrationTest.php
+++ b/test/Twig/Tests/integrationTest.php
@@ -57,6 +57,7 @@ class Twig_Tests_IntegrationTest extends PHPUnit_Framework_TestCase
 
             throw $e;
         } catch (Exception $e) {
+            throw $e;
             throw new Twig_Error($e->getMessage().' (in '.$file.')');
         }
 


### PR DESCRIPTION
The use of spl_object_hash+array in SafeAnalysis may cause bugs as there may be collisions; here is a fix that uses SplObjectStorage instead.
