### PR TITLE
Fix backwards compatibility with 5.2.x

### DIFF
--- a/lib/Twig/NodeVisitor/SafeAnalysis.php
+++ b/lib/Twig/NodeVisitor/SafeAnalysis.php
@@ -11,7 +11,7 @@ class Twig_NodeVisitor_SafeAnalysis implements Twig_NodeVisitorInterface
 
     public function getSafe(Twig_NodeInterface $node)
     {
-        return isset($this->data->offsetGet($node)) ? $this->data->offsetGet($node) : null;
+        return $this->data->offsetExists($node) ? $this->data->offsetGet($node) : null;
     }
 
     protected function setSafe(Twig_NodeInterface $node, array $safe)


### PR DESCRIPTION
This should fix the unit tests. It's caused because SplObjectStorage didn't implement ArrayAccess until 5.3.
http://ci.symfony-project.org/project/twig
