### PR TITLE
Issue 165

### DIFF
--- a/lib/Twig/NodeVisitor/SafeAnalysis.php
+++ b/lib/Twig/NodeVisitor/SafeAnalysis.php
@@ -2,21 +2,36 @@
 
 class Twig_NodeVisitor_SafeAnalysis implements Twig_NodeVisitorInterface
 {
-    protected $data;
-
-    public function __construct()
-    {
-        $this->data = array();
-    }
+    protected $data = array();
 
     public function getSafe(Twig_NodeInterface $node)
     {
-        return isset($this->data[spl_object_hash($node)]) ? $this->data[spl_object_hash($node)] : null;
+        $hash = spl_object_hash($node);
+        if (isset($this->data[$hash])) {
+            foreach($this->data[$hash] as $bucket) {
+                if ($bucket['key'] === $node) {
+                    return $bucket['value'];
+                }
+            }
+        }
+        return null;
     }
 
     protected function setSafe(Twig_NodeInterface $node, array $safe)
     {
-        $this->data[spl_object_hash($node)] = $safe;
+        $hash = spl_object_hash($node);
+        if (isset($this->data[$hash])) {
+            foreach($this->data[$hash] as &$bucket) {
+                if ($bucket['key'] === $node) {
+                    $bucket['value'] = $safe;
+                    return;
+                }
+            }
+        }
+        $this->data[$hash][] = array(
+            'key' => $node,
+            'value' => $safe,
+        );
     }
 
     public function enterNode(Twig_NodeInterface $node, Twig_Environment $env)


### PR DESCRIPTION
Here is an alternative fix for @62551da95e6d4aa3a347 which keeps compatibility with php 5.2.

@62551da95e6d4aa3a347 fixed a possible collision in spl_object_hash(). spl_object_hash() returns a md5 hash of object's address (at least in php 5.2) and two objects can have the same hash if they have the same address (which happens when an object is freed and an other is allocated at the same address) or in case of md5 collision (probably rare, but unpredictable).

The first case happens when compiling two or more templates (nodes of the first template are freed and nodes of subsequent templates are sometimes allocated at the same addresses). This could be handled by clearing the "data" array before reusing the NodeVisitor.

The second case happens unpredictably and requires to store a reference to all objects so they can be compared in getSafe(). Keeping a reference to these objects also fixes the first case, so it is not needed to clear the "data" array, but this could be considered to free some memory (currently filter nodes, print nodes, and their childs are stored during an analysis).
