### PR TITLE
issue parsing expressions in some cases

### DIFF
--- a/lib/Twig/ExpressionParser.php
+++ b/lib/Twig/ExpressionParser.php
@@ -69,13 +69,13 @@ class Twig_ExpressionParser
             $expr = $this->parseExpression($operator['precedence']);
             $class = $operator['class'];
 
-            return new $class($expr, $token->getLine());
+            return $this->parsePostfixExpression(new $class($expr, $token->getLine()));
         } elseif ($token->test(Twig_Token::PUNCTUATION_TYPE, '(')) {
             $this->parser->getStream()->next();
             $expr = $this->parseExpression();
             $this->parser->getStream()->expect(Twig_Token::PUNCTUATION_TYPE, ')');
 
-            return $expr;
+            return $this->parsePostfixExpression($expr);
         }
 
         return $this->parsePrimaryExpression();

--- a/test/Twig/Tests/Fixtures/expressions/expressions.test
+++ b/test/Twig/Tests/Fixtures/expressions/expressions.test
@@ -1,0 +1,21 @@
+--TEST--
+Twig parses postfix expressions
+--TEMPLATE--
+
+{% macro foo() %}foo{% endmacro %}
+
+{{ 'a' }}
+{{ 'a'|upper }}
+{{ ('a')|upper }}
+{{ -1|upper }}
+{{ _self.foo() }}
+{{ (_self).foo() }}
+--DATA--
+return array();
+--EXPECT--
+a
+A
+A
+-1
+foo
+foo


### PR DESCRIPTION
I found an issue when parsing expressions like `{{ (1)|filter }}` or `{{ -1|filter }}` or `{{ (_self).macro() }}`. This happens only when the left side has parentheses or is an unary expression. The attached pull request seems to fix the problem for me.
