### PR TITLE
"switch" statement

### DIFF
--- a/lib/Twig/Node/Switch.php
+++ b/lib/Twig/Node/Switch.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ * (c) 2009 Armin Ronacher
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Represents an if node.
+ *
+ * @package    twig
+ * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
+ */
+class Twig_Node_Switch extends Twig_Node
+{
+    public function __construct(Twig_NodeInterface $value, Twig_NodeInterface $cases, Twig_NodeInterface $default = null, $lineno, $tag = null)
+    {
+        parent::__construct(array('value' => $value, 'cases' => $cases, 'default' => $default), array(), $lineno, $tag);
+    }
+
+    /**
+     * Compiles the node to PHP.
+     *
+     * @param Twig_Compiler A Twig_Compiler instance
+     */
+    public function compile($compiler)
+    {
+        $compiler->addDebugInfo($this);
+		$compiler
+			->write("switch (")
+			->subcompile($this->getNode('value'))
+			->raw(") {\n")
+			->indent
+		;
+        for ($i = 0; $i < count($this->getNode('cases')); $i += 2) {
+            $compiler
+				->write('case ')
+                ->subcompile($this->getNode('cases')->getNode($i))
+                ->raw(":\n")
+                ->indent()
+                ->subcompile($this->getNode('cases')->getNode($i + 1))
+				->outdent()
+            ;
+        }
+
+        if ($this->hasNode('default') && null !== $this->getNode('default')) {
+            $compiler
+                ->write("default:\n")
+                ->indent()
+                ->subcompile($this->getNode('default'))
+				->outdent()
+            ;
+        }
+
+        $compiler
+            ->outdent()
+            ->write("}\n");
+    }
+}

--- a/lib/Twig/TokenParser/Switch.php
+++ b/lib/Twig/TokenParser/Switch.php
@@ -21,16 +21,14 @@ class Twig_TokenParser_Switch extends Twig_TokenParser
     public function parse(Twig_Token $token)
     {
         $lineno = $token->getLine();
-        $expr = $this->parser->getExpressionParser()->parseExpression();
+        $name = $this->parser->getExpressionParser()->parseExpression();
         $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
         $default = null;
-		$cases=array();
+        $cases=array();
         $end = false;
-		echo 'expr : '.$expr;
-			$this->parser->getStream()->expect(Twig_Token::BLOCK_START_TYPE);
+        $this->parser->getStream()->expect(Twig_Token::BLOCK_START_TYPE);
         while (!$end) {
-			$v=$this->parser->getStream()->next();
-			echo "value : ".$v->getValue()."\n";
+            $v=$this->parser->getStream()->next();
             switch ($v->getValue()) {
                 case 'default':
                     $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
@@ -50,18 +48,18 @@ class Twig_TokenParser_Switch extends Twig_TokenParser
                     break;
 
                 default:
-                    throw new Twig_Error_Syntax(sprintf('Unexpected end of template. Twig was looking for the following tags "else", "elseif", or "endif" to close the "if" block started at line %d) Got value %s', $lineno, $v), -1);
+                    throw new Twig_Error_Syntax(sprintf('Unexpected end of template. Twig was looking for the following tags "case", "default", or "endswitch" to close the "switch" block started at line %d)', $lineno), -1);
             }
         }
 
         $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
 
-        return new Twig_Node_Switch($expr,new Twig_Node($cases), $default, $lineno, $this->getTag());
+        return new Twig_Node_Switch($name,new Twig_Node($cases), $default, $lineno, $this->getTag());
     }
 
     public function decideIfFork($token)
     {
-        return $token->test(array('case', 'default', 'endswitch', 'break'));
+        return $token->test(array('case', 'default', 'endswitch'));
     }
 
     public function decideIfEnd($token)

--- a/lib/Twig/TokenParser/Switch.php
+++ b/lib/Twig/TokenParser/Switch.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ * (c) 2009 Armin Ronacher
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class Twig_TokenParser_Switch extends Twig_TokenParser
+{
+    /**
+     * Parses a token and returns a node.
+     *
+     * @param Twig_Token $token A Twig_Token instance
+     *
+     * @return Twig_NodeInterface A Twig_NodeInterface instance
+     */
+    public function parse(Twig_Token $token)
+    {
+        $lineno = $token->getLine();
+        $expr = $this->parser->getExpressionParser()->parseExpression();
+        $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
+        $default = null;
+		$cases=array();
+        $end = false;
+		echo 'expr : '.$expr;
+			$this->parser->getStream()->expect(Twig_Token::BLOCK_START_TYPE);
+        while (!$end) {
+			$v=$this->parser->getStream()->next();
+			echo "value : ".$v->getValue()."\n";
+            switch ($v->getValue()) {
+                case 'default':
+                    $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
+                    $default = $this->parser->subparse(array($this, 'decideIfEnd'));
+                    break;
+
+                case 'case':
+                    $expr = $this->parser->getExpressionParser()->parseExpression();
+                    $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
+                    $body = $this->parser->subparse(array($this, 'decideIfFork'));
+                    $cases[] = $expr;
+                    $cases[] = $body;
+                    break;
+
+                case 'endswitch':
+                    $end = true;
+                    break;
+
+                default:
+                    throw new Twig_Error_Syntax(sprintf('Unexpected end of template. Twig was looking for the following tags "else", "elseif", or "endif" to close the "if" block started at line %d) Got value %s', $lineno, $v), -1);
+            }
+        }
+
+        $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
+
+        return new Twig_Node_Switch($expr,new Twig_Node($cases), $default, $lineno, $this->getTag());
+    }
+
+    public function decideIfFork($token)
+    {
+        return $token->test(array('case', 'default', 'endswitch', 'break'));
+    }
+
+    public function decideIfEnd($token)
+    {
+        return $token->test(array('endswitch'));
+    }
+
+    /**
+     * Gets the tag name associated with this token parser.
+     *
+     * @param string The tag name
+     */
+    public function getTag()
+    {
+        return 'switch';
+    }
+}

--- a/test/Twig/Tests/Fixtures/switch/basic.test
+++ b/test/Twig/Tests/Fixtures/switch/basic.test
@@ -1,0 +1,23 @@
+--TEST--
+"switch" creates a condition
+--TEMPLATE--
+{% switch a %}
+{% case 'a' %}
+  'a'
+{% case 'b' %}
+  'b'
+{% default %}
+  OTHER {{ a }}
+{% endswitch %}
+--DATA--
+return array('a' => 'a')
+--EXPECT--
+  a
+--DATA--
+return array('b' => 'b')
+--EXPECT--
+  b
+--DATA--
+return array()
+--EXPECT--
+  NOTHING


### PR DESCRIPTION
Hello,

While testing Twig, I have added a "switch" statement, that can enable tests such as :
{% switch a %}
{% case 1 %}
Action 1
{% case 2 %}
Action 2
{% default %}
Default display
{% endswitch %}

It is copied from php syntax (except that the "break" is always inserted after each case), and heavily inspired from the "if" statement.

Regards,
Bruno
