### PR TITLE
Allow null filenames

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -259,7 +259,7 @@ class Twig_Environment
         $lexer->setEnvironment($this);
     }
 
-    public function tokenize($source, $name)
+    public function tokenize($source, $name = null)
     {
         return $this->getLexer()->tokenize($source, $name);
     }
@@ -304,7 +304,7 @@ class Twig_Environment
         return $this->getCompiler()->compile($node)->getSource();
     }
 
-    public function compileSource($source, $name)
+    public function compileSource($source, $name = null)
     {
         return $this->compile($this->parse($this->tokenize($source, $name)));
     }

--- a/lib/Twig/Lexer.php
+++ b/lib/Twig/Lexer.php
@@ -59,7 +59,7 @@ class Twig_Lexer implements Twig_LexerInterface
      *
      * @return Twig_TokenStream A token stream instance
      */
-    public function tokenize($code, $filename = 'n/a')
+    public function tokenize($code, $filename = null)
     {
         if (function_exists('mb_internal_encoding') && ((int) ini_get('mbstring.func_overload')) & 2) {
             $mbEncoding = mb_internal_encoding();
@@ -132,11 +132,11 @@ class Twig_Lexer implements Twig_LexerInterface
             return $tokens;
         }
         // empty array, call again
-        else if (empty($tokens)) {
+        elseif (empty($tokens)) {
             return $this->nextToken();
         }
         // if we have multiple items we push them to the buffer
-        else if (count($tokens) > 1) {
+        elseif (count($tokens) > 1) {
             $first = array_shift($tokens);
             $this->pushedBack = $tokens;
 


### PR DESCRIPTION
If tokenizing templates for testing or debugging purposes it is annoying to always specify some pseudo-filename ("foo"). Especially now that you fixed `Twig_Error_Syntax` to not show the file if it is `null` this makes more sense.
