### PR TITLE
Minor for loop changes

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -482,7 +482,7 @@ provided in a variable called ``users``:
 .. note::
 
     A sequence can be either an array or an object implementing the
-    ``Iterator`` interface.
+    ``Traversable`` interface.
 
 If you do need to iterate over a sequence of numbers, you can use the ``..``
 operator (as of Twig 0.9.5):

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -428,11 +428,9 @@ else
     }
 }
 
-function twig_iterator_to_array($seq, $useKeys = true)
+function twig_ensure_traversable($seq)
 {
-    if (is_array($seq)) {
-        return $seq;
-    } elseif (is_object($seq) && $seq instanceof Traversable) {
+    if (is_array($seq) || (is_object($seq) && $seq instanceof Traversable)) {
         return $seq;
     } else {
         return array();

--- a/lib/Twig/Node/For.php
+++ b/lib/Twig/Node/For.php
@@ -33,32 +33,27 @@ class Twig_Node_For extends Twig_Node
         $compiler
             ->addDebugInfo($this)
             // the (array) cast bypasses a PHP 5.2.6 bug
-            ->write('$context[\'_parent\'] = (array) $context;'."\n")
-        ;
-
-        if (null !== $this->getNode('else')) {
-            $compiler->write("\$context['_iterated'] = false;\n");
-        }
-
-        $compiler
-            ->write("\$context['_seq'] = twig_iterator_to_array(")
+            ->write("\$context['_parent'] = (array) \$context;\n")
+            ->write("\$context['_seq'] = twig_ensure_traversable(")
             ->subcompile($this->getNode('seq'))
             ->raw(");\n")
         ;
+        
+        if (null !== $this->getNode('else') || null !== $this->getNode('joined_with')) {
+            $compiler->write("\$context['_iterated'] = false;\n");
+        }
 
         if ($this->getAttribute('with_loop')) {
             $compiler
-                ->write("\$countable = is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof Countable);\n")
-                ->write("\$length = \$countable ? count(\$context['_seq']) : null;\n")
-
                 ->write("\$context['loop'] = array(\n")
                 ->write("  'parent' => \$context['_parent'],\n")
                 ->write("  'index0' => 0,\n")
                 ->write("  'index'  => 1,\n")
                 ->write("  'first'  => true,\n")
                 ->write(");\n")
-                ->write("if (\$countable) {\n")
+                ->write("if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof Countable)) {\n")
                 ->indent()
+                ->write("\$length = count(\$context['_seq']);\n")
                 ->write("\$context['loop']['revindex0'] = \$length - 1;\n")
                 ->write("\$context['loop']['revindex'] = \$length;\n")
                 ->write("\$context['loop']['length'] = \$length;\n")
@@ -66,10 +61,6 @@ class Twig_Node_For extends Twig_Node
                 ->outdent()
                 ->write("}\n")
             ;
-        }
-
-        if (null !== $this->getNode('joined_with')) {
-            $compiler->write("\$context['_first_iteration'] = true;\n");
         }
 
         $compiler
@@ -81,17 +72,9 @@ class Twig_Node_For extends Twig_Node
             ->indent()
         ;
 
-        if (null !== $this->getNode('else')) {
-            $compiler->write("\$context['_iterated'] = true;\n");
-        }
-
         if (null !== $this->getNode('joined_with')) {
             $compiler
-                ->write("if (\$context['_first_iteration']) {\n")
-                ->indent()
-                ->write("\$context['_first_iteration'] = false;\n")
-                ->outdent()
-                ->write("} else {\n")
+                ->write("if (\$context['_iterated']) {\n")
                 ->indent()
                 ->write("echo ")
                 ->subcompile($this->getNode('joined_with'))
@@ -102,12 +85,16 @@ class Twig_Node_For extends Twig_Node
 
         $compiler->subcompile($this->getNode('body'));
 
+        if (null !== $this->getNode('else') || null !== $this->getNode('joined_with')) {
+            $compiler->write("\$context['_iterated'] = true;\n");
+        }
+        
         if ($this->getAttribute('with_loop')) {
             $compiler
                 ->write("++\$context['loop']['index0'];\n")
                 ->write("++\$context['loop']['index'];\n")
                 ->write("\$context['loop']['first'] = false;\n")
-                ->write("if (\$countable) {\n")
+                ->write("if (isset(\$context['loop']['length'])) {\n")
                 ->indent()
                 ->write("--\$context['loop']['revindex0'];\n")
                 ->write("--\$context['loop']['revindex'];\n")
@@ -132,12 +119,12 @@ class Twig_Node_For extends Twig_Node
             ;
         }
 
-        $compiler->write('$_parent = $context[\'_parent\'];'."\n");
+        $compiler->write("\$_parent = \$context['_parent'];\n");
 
         // remove some "private" loop variables (needed for nested loops)
-        $compiler->write('unset($context[\'_seq\'], $context[\'_iterated\'], $context[\''.$this->getNode('key_target')->getAttribute('name').'\'], $context[\''.$this->getNode('value_target')->getAttribute('name').'\'], $context[\'_parent\'], $context[\'loop\']);'."\n");
+        $compiler->write("unset(\$context['_parent'], \$context['_seq'], \$context['_iterated'], \$context['loop'], \$context['".$this->getNode('key_target')->getAttribute('name')."'], \$context['".$this->getNode('value_target')->getAttribute('name')."']);\n");
 
-        /// keep the values set in the inner context for variables defined in the outer context
-        $compiler->write('$context = array_merge($_parent, array_intersect_key($context, $_parent));'."\n");
+        // keep the values set in the inner context for variables defined in the outer context
+        $compiler->write("\$context = array_merge(\$_parent, array_intersect_key(\$context, \$_parent));\n");
     }
 }

--- a/test/Twig/Tests/Node/ForTest.php
+++ b/test/Twig/Tests/Node/ForTest.php
@@ -61,12 +61,12 @@ class Twig_Tests_Node_ForTest extends Twig_Tests_Node_TestCase
 
         $tests[] = array($node, <<<EOF
 \$context['_parent'] = (array) \$context;
-\$context['_seq'] = twig_iterator_to_array((isset(\$context['items']) ? \$context['items'] : null));
+\$context['_seq'] = twig_ensure_traversable((isset(\$context['items']) ? \$context['items'] : null));
 foreach (\$context['_seq'] as \$context['key'] => \$context['item']) {
     echo (isset(\$context['foo']) ? \$context['foo'] : null);
 }
 \$_parent = \$context['_parent'];
-unset(\$context['_seq'], \$context['_iterated'], \$context['key'], \$context['item'], \$context['_parent'], \$context['loop']);
+unset(\$context['_parent'], \$context['_seq'], \$context['_iterated'], \$context['loop'], \$context['key'], \$context['item']);
 \$context = array_merge(\$_parent, array_intersect_key(\$context, \$_parent));
 EOF
         );
@@ -82,40 +82,38 @@ EOF
 
         $tests[] = array($node, <<<EOF
 \$context['_parent'] = (array) \$context;
-\$context['_seq'] = twig_iterator_to_array((isset(\$context['values']) ? \$context['values'] : null));
-\$countable = is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof Countable);
-\$length = \$countable ? count(\$context['_seq']) : null;
+\$context['_seq'] = twig_ensure_traversable((isset(\$context['values']) ? \$context['values'] : null));
+\$context['_iterated'] = false;
 \$context['loop'] = array(
   'parent' => \$context['_parent'],
   'index0' => 0,
   'index'  => 1,
   'first'  => true,
 );
-if (\$countable) {
+if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof Countable)) {
+    \$length = count(\$context['_seq']);
     \$context['loop']['revindex0'] = \$length - 1;
     \$context['loop']['revindex'] = \$length;
     \$context['loop']['length'] = \$length;
     \$context['loop']['last'] = 1 === \$length;
 }
-\$context['_first_iteration'] = true;
 foreach (\$context['_seq'] as \$context['k'] => \$context['v']) {
-    if (\$context['_first_iteration']) {
-        \$context['_first_iteration'] = false;
-    } else {
+    if (\$context['_iterated']) {
         echo ", ";
     }
     echo (isset(\$context['foo']) ? \$context['foo'] : null);
+    \$context['_iterated'] = true;
     ++\$context['loop']['index0'];
     ++\$context['loop']['index'];
     \$context['loop']['first'] = false;
-    if (\$countable) {
+    if (isset(\$context['loop']['length'])) {
         --\$context['loop']['revindex0'];
         --\$context['loop']['revindex'];
         \$context['loop']['last'] = 0 === \$context['loop']['revindex0'];
     }
 }
 \$_parent = \$context['_parent'];
-unset(\$context['_seq'], \$context['_iterated'], \$context['k'], \$context['v'], \$context['_parent'], \$context['loop']);
+unset(\$context['_parent'], \$context['_seq'], \$context['_iterated'], \$context['loop'], \$context['k'], \$context['v']);
 \$context = array_merge(\$_parent, array_intersect_key(\$context, \$_parent));
 EOF
         );
@@ -130,29 +128,28 @@ EOF
 
         $tests[] = array($node, <<<EOF
 \$context['_parent'] = (array) \$context;
+\$context['_seq'] = twig_ensure_traversable((isset(\$context['values']) ? \$context['values'] : null));
 \$context['_iterated'] = false;
-\$context['_seq'] = twig_iterator_to_array((isset(\$context['values']) ? \$context['values'] : null));
-\$countable = is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof Countable);
-\$length = \$countable ? count(\$context['_seq']) : null;
 \$context['loop'] = array(
   'parent' => \$context['_parent'],
   'index0' => 0,
   'index'  => 1,
   'first'  => true,
 );
-if (\$countable) {
+if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof Countable)) {
+    \$length = count(\$context['_seq']);
     \$context['loop']['revindex0'] = \$length - 1;
     \$context['loop']['revindex'] = \$length;
     \$context['loop']['length'] = \$length;
     \$context['loop']['last'] = 1 === \$length;
 }
 foreach (\$context['_seq'] as \$context['k'] => \$context['v']) {
-    \$context['_iterated'] = true;
     echo (isset(\$context['foo']) ? \$context['foo'] : null);
+    \$context['_iterated'] = true;
     ++\$context['loop']['index0'];
     ++\$context['loop']['index'];
     \$context['loop']['first'] = false;
-    if (\$countable) {
+    if (isset(\$context['loop']['length'])) {
         --\$context['loop']['revindex0'];
         --\$context['loop']['revindex'];
         \$context['loop']['last'] = 0 === \$context['loop']['revindex0'];
@@ -162,7 +159,7 @@ if (!\$context['_iterated']) {
     echo (isset(\$context['foo']) ? \$context['foo'] : null);
 }
 \$_parent = \$context['_parent'];
-unset(\$context['_seq'], \$context['_iterated'], \$context['k'], \$context['v'], \$context['_parent'], \$context['loop']);
+unset(\$context['_parent'], \$context['_seq'], \$context['_iterated'], \$context['loop'], \$context['k'], \$context['v']);
 \$context = array_merge(\$_parent, array_intersect_key(\$context, \$_parent));
 EOF
         );


### PR DESCRIPTION
This makes the following changes:
- renames `twig_iterator_to_array` to `twig_ensure_traversable`, because that is what the function does. Furthermore I removed an unused argument to the function
- Do not create a `$countable` variable. This will fail if the outer loop is not countable but the inner is. In the outer loop `$countable` will be `true`, even though it should not. Instead check that `loop.length` is set in the second check.
- Remove the `_first_iteration` variable and instead reuse `_iterated`. I think polluting the context with loads of `_`-vars is a bad idea (especially as `_first_iteration` isn't even unset after the loop). And I think that `has iterated` isn't far away from `not first iteration`.
- In the doc, `Iterator` => `Traversable`.

All of it minor stuff, only one of the changes fixes a bug.

PS: Only the last commit contains changes. I hope you can select single commits.
