### PR TITLE
Expression parser

### DIFF
--- a/lib/Twig/ExpressionParser.php
+++ b/lib/Twig/ExpressionParser.php
@@ -336,13 +336,8 @@ class Twig_ExpressionParser
 
     public function parseMultitargetExpression()
     {
-        $lineno = $this->parser->getCurrentToken()->getLine();
         $targets = array();
-        $is_multitarget = false;
         while (true) {
-            if (!empty($targets)) {
-                $this->parser->getStream()->expect(Twig_Token::PUNCTUATION_TYPE, ',', 'Multiple assignments must be separated by a comma (,)');
-            }
             if ($this->parser->getStream()->test(Twig_Token::PUNCTUATION_TYPE, ')') ||
                     $this->parser->getStream()->test(Twig_Token::VAR_END_TYPE) ||
                     $this->parser->getStream()->test(Twig_Token::BLOCK_END_TYPE))
@@ -353,9 +348,9 @@ class Twig_ExpressionParser
             if (!$this->parser->getStream()->test(Twig_Token::PUNCTUATION_TYPE, ',')) {
                 break;
             }
-            $is_multitarget = true;
+            $this->parser->getStream()->next();
         }
 
-        return array($is_multitarget, new Twig_Node($targets));
+        return new Twig_Node($targets);
     }
 }

--- a/lib/Twig/TokenParser/Set.php
+++ b/lib/Twig/TokenParser/Set.php
@@ -26,7 +26,7 @@ class Twig_TokenParser_Set extends Twig_TokenParser
         $capture = false;
         if ($stream->test(Twig_Token::OPERATOR_TYPE, '=')) {
             $stream->next();
-            list(, $values) = $this->parser->getExpressionParser()->parseMultitargetExpression();
+            $values = $this->parser->getExpressionParser()->parseMultitargetExpression();
 
             $stream->expect(Twig_Token::BLOCK_END_TYPE);
 


### PR DESCRIPTION
Fixes that too many things may be assigned to: `{% set 7 = 5 %}`. Furthermore some minor changes.
