### PR TITLE
Make the $context argument for Template::render() optional

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ Changes:
  * added an exception when a macro uses a reserved name
  * the "default" filter now uses the "empty" test instead of just checking for null
  * added the "empty" test
+ * context argument for Template::display is now optional
 
 * 0.9.10 (2010-12-16)
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -52,6 +52,10 @@ To render the template with some variables, call the ``render()`` method::
 
     echo $template->render(array('the' => 'variables', 'go' => 'here'));
 
+If you do not want to pass any variables, you can call ``render()`` without arguments.
+
+    echo $template->render();
+
 .. note::
 
     The ``display()`` method is a shortcut to output the template directly.

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -92,7 +92,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
      *
      * @return string The rendered template
      */
-    public function render(array $context)
+    public function render(array $context = array())
     {
         ob_start();
         try {

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -91,7 +91,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
 
 class Twig_TemplateTest extends Twig_Template
 {
-    public function display(array $context)
+    public function display(array $context = array())
     {
     }
 


### PR DESCRIPTION
Currently it is required to pass the context arg to render. Making it optional allows for more concise syntax:

```
$template->render(array());
```

Becomes:

```
$template->render();
```
