### PR TITLE
Cache property on Twig_Environment should to be initialised.

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -103,9 +103,7 @@ class Twig_Environment
         );
         $this->strictVariables    = (bool) $options['strict_variables'];
         $this->runtimeInitialized = false;
-        if ($options['cache']) {
-            $this->setCache($options['cache']);
-        }
+        $this->setCache($options['cache']);
     }
 
     /**


### PR DESCRIPTION
If no 'cache' option is passed to the class constructer $this->cache is set to null, which in turn
results in an error creating directories ($this->getCacheFilename returns a filename with no directory prefix, which causes problems in $this->writeCacheFile).
