### PR TITLE
Fix sandbox duplicate method calls

### DIFF
--- a/lib/Twig/Extension/Sandbox.php
+++ b/lib/Twig/Extension/Sandbox.php
@@ -91,6 +91,15 @@ class Twig_Extension_Sandbox extends Twig_Extension
         }
     }
 
+    public function ensureToStringAllowed($obj)
+    {
+        if (is_object($obj)) {
+            $this->policy->checkMethodAllowed($obj, '__toString');
+        }
+
+        return $obj;
+    }
+
     /**
      * Returns the name of the extension.
      *

--- a/lib/Twig/Node/SandboxedPrint.php
+++ b/lib/Twig/Node/SandboxedPrint.php
@@ -36,18 +36,10 @@ class Twig_Node_SandboxedPrint extends Twig_Node_Print
     {
         $compiler
             ->addDebugInfo($this)
-            ->write('if (is_object(')
-            ->raw('$_tmp = ')
-            ->subcompile($this->removeNodeFilter($this->getNode('expr')))
-            ->raw(')) {'."\n")
-            ->indent()
-            ->write('$this->env->getExtension(\'sandbox\')->checkMethodAllowed(')
-            ->raw('$_tmp, \'__toString\');'."\n")
-            ->outdent()
-            ->write('}'."\n")
+            ->write('echo $this->env->getExtension(\'sandbox\')->ensureToStringAllowed(')
+            ->subcompile($this->getNode('expr'))
+            ->raw(");\n")
         ;
-
-        parent::compile($compiler);
     }
 
     /**

--- a/test/Twig/Tests/Node/SandboxedPrintTest.php
+++ b/test/Twig/Tests/Node/SandboxedPrintTest.php
@@ -37,10 +37,7 @@ class Twig_Tests_Node_SandboxedPrintTest extends Twig_Tests_Node_TestCase
         $tests = array();
 
         $tests[] = array(new Twig_Node_SandboxedPrint(new Twig_Node_Expression_Constant('foo', 0), 0), <<<EOF
-if (is_object(\$_tmp = "foo")) {
-    \$this->env->getExtension('sandbox')->checkMethodAllowed(\$_tmp, '__toString');
-}
-echo "foo";
+echo \$this->env->getExtension('sandbox')->ensureToStringAllowed("foo");
 EOF
         );
 


### PR DESCRIPTION
Fix for #264. I would appreciate if you could add something, that ensures that methods are called only once in sandbox mode. I think you can do this using Mock objects, but I don't know PHPUnit too well, so I let this part to you :)
