### PR TITLE
Single quotes for strings

### DIFF
--- a/lib/Twig/Compiler.php
+++ b/lib/Twig/Compiler.php
@@ -130,7 +130,7 @@ class Twig_Compiler implements Twig_CompilerInterface
      */
     public function string($value)
     {
-        $this->source .= sprintf('\'%s\'', addcslashes($value, "\t'\\'"));
+        $this->source .= sprintf('\'%s\'', addcslashes($value, "'\\'"));
 
         return $this;
     }


### PR DESCRIPTION
Why do not use single quotes for strings? It is faster a little
