### PR TITLE
Use a type strict null check for GetAttr defined tests. Fixes #305

### DIFF
--- a/lib/Twig/Node/Expression/Test.php
+++ b/lib/Twig/Node/Expression/Test.php
@@ -32,7 +32,10 @@ class Twig_Node_Expression_Test extends Twig_Node_Expression
                 ;
             } elseif ($this->getNode('node') instanceof Twig_Node_Expression_GetAttr) {
                 $this->getNode('node')->setAttribute('is_defined_test', true);
-                $compiler->subcompile($this->getNode('node'));
+                $compiler
+                    ->raw('null !== ')
+                    ->subcompile($this->getNode('node'))
+                ;
             } else {
                 throw new Twig_Error_Syntax('The "defined" test only works with simple variables', $this->getLine());
             }

--- a/test/Twig/Tests/Fixtures/tests/defined.test
+++ b/test/Twig/Tests/Fixtures/tests/defined.test
@@ -6,9 +6,11 @@
 {{ foobar is not defined ? 'ok' : 'ko' }}
 {{ nested.foo is defined ? 'ok' : 'ko' }}
 {{ nested.bar is not defined ? 'ok' : 'ko' }}
+{{ nested.zero is defined ? 'ok' : 'ko' }}
 --DATA--
-return array('foo' => 'bar', 'bar' => null, 'nested' => array('foo' => 'foo'));
+return array('foo' => 'bar', 'bar' => null, 'nested' => array('foo' => 'foo', 'zero' => 0));
 --EXPECT--
+ok
 ok
 ok
 ok


### PR DESCRIPTION
Fix for issue #305. The only possible problem is that GetAttrs returning `null` will be considered undefined, too. Is this problematic?
