### PR TITLE
Added an example of escaping "at" to the date filter docs.

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -1137,6 +1137,12 @@ word "now":
 
     {{ "now"|date("m/d/Y") }}
 
+To escape words and characters in the date format use ``\\`` in front of each character:
+
+.. code-block:: jinja
+
+    {{ post.published_at|date("F jS \\a\\t g:ia") }}
+
 ``format``
 ~~~~~~~~~~
 


### PR DESCRIPTION
Relates to https://github.com/fabpot/Twig/issues/330
