### PR TITLE
Refactor GetAttr defined implementation to consider null defined

### DIFF
--- a/lib/Twig/Node/Expression/Test.php
+++ b/lib/Twig/Node/Expression/Test.php
@@ -33,9 +33,7 @@ class Twig_Node_Expression_Test extends Twig_Node_Expression
             } elseif ($this->getNode('node') instanceof Twig_Node_Expression_GetAttr) {
                 $this->getNode('node')->setAttribute('is_defined_test', true);
                 $compiler
-                    ->raw('(null !== ')
                     ->subcompile($this->getNode('node'))
-                    ->raw(')')
                 ;
             } else {
                 throw new Twig_Error_Syntax('The "defined" test only works with simple variables', $this->getLine());

--- a/test/Twig/Tests/Fixtures/tests/defined.test
+++ b/test/Twig/Tests/Fixtures/tests/defined.test
@@ -5,24 +5,27 @@
 {{ definedVar          is not defined ? 'ko' : 'ok' }}
 {{ undefinedVar        is     defined ? 'ko' : 'ok' }}
 {{ undefinedVar        is not defined ? 'ok' : 'ko' }}
-{{ nullVar             is     defined ? 'ok' : 'ko' }}
 {{ zeroVar             is     defined ? 'ok' : 'ko' }}
+{{ nullVar             is     defined ? 'ok' : 'ko' }}
 {{ nested.definedVar   is     defined ? 'ok' : 'ko' }}
 {{ nested.definedVar   is not defined ? 'ko' : 'ok' }}
 {{ nested.undefinedVar is     defined ? 'ko' : 'ok' }}
 {{ nested.undefinedVar is not defined ? 'ok' : 'ko' }}
 {{ nested.zeroVar      is     defined ? 'ok' : 'ko' }}
+{{ nested.nullVar      is     defined ? 'ok' : 'ko' }}
 --DATA--
 return array(
-    'definedVar' => 'bar',
-    'nullVar'    => null,
+    'definedVar' => 'defined',
     'zeroVar'    => 0,
-    'nested'     => array(
-        'definedVar' => 'foo',
-        'zeroVar'    => 0
+    'nullVar'    => null,
+    'nested'      => array(
+        'definedVar' => 'defined',
+        'zeroVar'    => 0,
+        'nullVar'    => null,
     )
 );
 --EXPECT--
+ok
 ok
 ok
 ok


### PR DESCRIPTION
This is a followup to pull request #322.

It uses a different approach to handle null values correctly (as defined ones): This time it doesn't listen to exceptions in GetAttr (which was slow and partially not fully correct still), but adds a execution path for defined tests in the GetAttr method (`$isDefinedTest`).

I covered this change with a very extensive test suite, which tests pretty much any constellation of possible values.
