### PR TITLE
Date filter should treat strict integers as Unix timestamps

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -203,7 +203,7 @@ class Twig_Extension_Core extends Twig_Extension
 function twig_date_format_filter($date, $format = 'F j, Y H:i')
 {
     if (!$date instanceof DateTime) {
-        $date = new DateTime((ctype_digit($date) ? '@' : '').$date);
+        $date = new DateTime((ctype_digit((string) $date) ? '@' : '').$date);
     }
 
     return $date->format($format);


### PR DESCRIPTION
Date filter should treat strict integers as Unix timestamps (same as all-digit strings)

Without a string cast, ctype_digit() will return false for an integer.
