### PR TITLE
added {% line \d+ %} directive

### DIFF
--- a/lib/Twig/Lexer.php
+++ b/lib/Twig/Lexer.php
@@ -162,6 +162,11 @@ class Twig_Lexer implements Twig_LexerInterface
                     $this->moveCursor($match[0]);
                     $this->lexRawData();
                     $this->state = self::STATE_DATA;
+                // {% line \d+ %}
+                } else if (preg_match('/\s*line\s+(\d+)\s*'.preg_quote($this->options['tag_block'][1], '/').'/As', $this->code, $match, null, $this->cursor)) {
+                    $this->moveCursor($match[0]);
+                    $this->lineno = (int) $match[1];
+                    $this->state = self::STATE_DATA;
                 } else {
                     $this->pushToken(Twig_Token::BLOCK_START_TYPE);
                     $this->state = self::STATE_BLOCK;

--- a/test/Twig/Tests/LexerTest.php
+++ b/test/Twig/Tests/LexerTest.php
@@ -36,4 +36,44 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
 
         return $count;
     }
+
+    public function testLineDirective()
+    {
+        $template = "foo\n"
+            . "bar\n"
+            . "{% line 10 %}\n"
+            . "{{\n"
+            . "baz\n"
+            . "}}\n";
+
+        $lexer = new Twig_Lexer(new Twig_Environment());
+        $stream = $lexer->tokenize($template);
+
+        // foo\nbar\n
+        $this->assertSame(1, $stream->expect(Twig_Token::TEXT_TYPE)->getLine());
+        // \n (after {% line %})
+        $this->assertSame(10, $stream->expect(Twig_Token::TEXT_TYPE)->getLine());
+        // {{
+        $this->assertSame(11, $stream->expect(Twig_Token::VAR_START_TYPE)->getLine());
+        // baz
+        $this->assertSame(12, $stream->expect(Twig_Token::NAME_TYPE)->getLine());
+    }
+
+    public function testLineDirectiveInline()
+    {
+        $template = "foo\n"
+            . "bar{% line 10 %}{{\n"
+            . "baz\n"
+            . "}}\n";
+
+        $lexer = new Twig_Lexer(new Twig_Environment());
+        $stream = $lexer->tokenize($template);
+
+        // foo\nbar
+        $this->assertSame(1, $stream->expect(Twig_Token::TEXT_TYPE)->getLine());
+        // {{
+        $this->assertSame(10, $stream->expect(Twig_Token::VAR_START_TYPE)->getLine());
+        // baz
+        $this->assertSame(11, $stream->expect(Twig_Token::NAME_TYPE)->getLine());
+    }
 }


### PR DESCRIPTION
This directive allows to change the current line number in the tokenizer.

This allows to generate Twig code from some other Twig or partially-Twig script, and still get relevant line numbers in error messages, when the line numbers of the generated Twig script do not match those of the original script.

For example in the following script:

```
foo
{% line 10 %}
bar
{{ baz }}
```

`"foo"` is on line 1, `"bar"` is considered to be on line 10 and `{{ baz }}` is considered to be on line 11.

This is similar to `# line ...` directives in C.
