### PR TITLE
[Core] Add === and !== operators

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -150,6 +150,8 @@ class Twig_Extension_Core extends Twig_Extension
             array(
                 'or'     => array('precedence' => 10, 'class' => 'Twig_Node_Expression_Binary_Or', 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
                 'and'    => array('precedence' => 15, 'class' => 'Twig_Node_Expression_Binary_And', 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
+                '==='    => array('precedence' => 20, 'class' => 'Twig_Node_Expression_Binary_Identical', 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
+                '!=='    => array('precedence' => 20, 'class' => 'Twig_Node_Expression_Binary_NotIdentical', 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
                 '=='     => array('precedence' => 20, 'class' => 'Twig_Node_Expression_Binary_Equal', 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
                 '!='     => array('precedence' => 20, 'class' => 'Twig_Node_Expression_Binary_NotEqual', 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
                 '<'      => array('precedence' => 20, 'class' => 'Twig_Node_Expression_Binary_Less', 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),

--- a/lib/Twig/Node/Expression/Binary/Identical.php
+++ b/lib/Twig/Node/Expression/Binary/Identical.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2010 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class Twig_Node_Expression_Binary_Identical extends Twig_Node_Expression_Binary
+{
+    public function operator(Twig_Compiler $compiler)
+    {
+        return $compiler->raw('===');
+    }
+}

--- a/lib/Twig/Node/Expression/Binary/NotIdentical.php
+++ b/lib/Twig/Node/Expression/Binary/NotIdentical.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2010 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class Twig_Node_Expression_Binary_NotIdentical extends Twig_Node_Expression_Binary
+{
+    public function operator(Twig_Compiler $compiler)
+    {
+        return $compiler->raw('!==');
+    }
+}

--- a/test/Twig/Tests/Fixtures/expressions/comparison.test
+++ b/test/Twig/Tests/Fixtures/expressions/comparison.test
@@ -5,6 +5,8 @@ Twig supports comparison operators (==, !=, <, >, >=, <=)
 {{ 1 < 2 }}/{{ 1 < 1 }}/{{ 1 <= 2 }}/{{ 1 <= 1 }}
 {{ 1 == 1 }}/{{ 1 == 2 }}
 {{ 1 != 1 }}/{{ 1 != 2 }}
+{{ "string" === 0 }}/{{ "string" == 0 }}
+{{ "string" !== 0 }}/{{ "string" != 0 }}
 --DATA--
 return array()
 --EXPECT--
@@ -12,3 +14,5 @@ return array()
 1//1/1
 1/
 /1
+/1
+1/


### PR DESCRIPTION
My use case:

```
{% for index, child in form.collection %}
    {% if index === '$$name$$' %}
        {# prototype #}
    {% endif %}
{% endfor %}
```

using `==` would enter the prototype specific block for the index 0.
