### PR TITLE
Fixed exception on incorrect value for date filter

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -203,7 +203,7 @@ class Twig_Extension_Core extends Twig_Extension
 
 function twig_date_format_filter($date, $format = 'F j, Y H:i')
 {
-    if ((!$date instanceof DateTime)) {
+    if ( ! $date instanceof DateTime) {
         if (ctype_digit((string) $date)) {
             $date = new DateTime('@'.$date);
             $date->setTimezone(new DateTimeZone(date_default_timezone_get()));


### PR DESCRIPTION
For example: <input type="text" name="begin_time" id="begin_time" value="{{ trial.begin_time|date('Y-m-d') }}" class="x-datepicker" />.
This is an input tag.User input date and push submit button - we validate data on the server side, and, if value is incorrect, we show error message and set input value in current value. And we get an exception on date filter, because value in incorrect.

Please, sorry for my bad english.
