### PR TITLE
APC recipe

### DIFF
--- a/doc/recipes.rst
+++ b/doc/recipes.rst
@@ -246,14 +246,34 @@ Validating the Template Syntax
 When template code is providing by a third-party (through a web interface for
 instance), it might be interesting to validate the template syntax before
 saving it. If the template code is stored in a `$template` variable, here is
-how you can do it:
+how you can do it::
 
-try {
-     $twig->parse($twig->tokenize($template));
+    try {
+        $twig->parse($twig->tokenize($template));
+        // the $template is valid
+    } catch (Twig_Error_Syntax $e) {
+        // $template contains one or more syntax errors
+    }
 
-     // the $template is valid
-} catch (Twig_Error_Syntax $e) {
-     // $template contains one or more syntax errors
-}
+Refreshing modified templates when APC is switched on with apc.stat = 0
+-----------------------------------------------------------------------
+
+When using APC to cache, apc.stat is 0 and PHP caching of templates is enabled
+the result won't show until cache is cleared. To get around this one can extend
+Twig_Environment and force update cache when Twig rewrites the cache::
+
+    /**
+     *  Modified Twig Environment for APC bytecode cache support
+     */
+    class Twig_Environment_APC extends Twig_Environment
+    {
+
+        protected function writeCacheFile($file, $content) {
+            parent::writeCacheFile($file, $content);
+
+            // Compile cached file into bytecode cache
+            apc_compile_file($file);
+        }
+    }
 
 .. _callback: http://www.php.net/manual/en/function.is-callable.php


### PR DESCRIPTION
A new recipe to support cache invalidation when using _APC_ with _apc.stat_ = 0 and compiled code caching turned on. One sometimes want to test things without restarting apache. This recipe overrides _writeCacheFile_ in _Twig_Environment_ and calls *apc_compile_file to refresh cache.
