### PR TITLE
Example of patch for an Twig_Error_Loader

### DIFF
--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -120,6 +120,10 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface
 
         $this->validateName($name);
 
+        if (is_file($name)) {
+            return $this->cache[$name] = $name;
+        }
+
         foreach ($this->paths as $path) {
             if (is_file($path.'/'.$name)) {
                 return $this->cache[$name] = $path.'/'.$name;


### PR DESCRIPTION
cf. https://github.com/sensio/SensioGeneratorBundle/issues/13 :

With fresh Symfony Standard 2.0 RC1 on Windows XP environment, the generate:bundle command cause an Twig_Error_Loader

[...]\NetBeansProjects\symfony-sandbox>php app/console generate:bundle

[Twig_Error_Loader]

Unable to find template "[...]/NetBeansProjects/symfony-sandbox/src/Astrimmo/UserBundle/AstrimmoUserBundle.php" (looked into: /).
