### PR TITLE
Change ASCII to UTF8 for internal parsing

### DIFF
--- a/lib/Twig/Lexer.php
+++ b/lib/Twig/Lexer.php
@@ -35,7 +35,7 @@ class Twig_Lexer implements Twig_LexerInterface
     const STATE_BLOCK = 1;
     const STATE_VAR   = 2;
 
-    const REGEX_NAME   = '/[A-Za-z_][A-Za-z0-9_]*/A';
+    const REGEX_NAME   = '/[\p{L}_][\p{L}\p{N}_]*/uA';
     const REGEX_NUMBER = '/[0-9]+(?:\.[0-9]+)?/A';
     const REGEX_STRING = '/"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\'/As';
     const PUNCTUATION  = '()[]{}?:.,|';
@@ -64,7 +64,7 @@ class Twig_Lexer implements Twig_LexerInterface
     {
         if (function_exists('mb_internal_encoding') && ((int) ini_get('mbstring.func_overload')) & 2) {
             $mbEncoding = mb_internal_encoding();
-            mb_internal_encoding('ASCII');
+            mb_internal_encoding('UTF-8');
         }
 
         $this->code = str_replace(array("\r\n", "\r"), "\n", $code);


### PR DESCRIPTION
With follow http://www.php.net/manual/fr/regexp.reference.unicode.php
- Permit to use accent for entities property (possible with doctrine but cutted by twig)
- Better locale support
- Phpunit tests successful, except one about timezone (failed before change too, maybe a specificity from my computer).

I know these littles modifications aren't very interessing or heady, but i change just what i see, after use it, with willpower to follow the framework functionment.

With hope this will be useful.
