### PR TITLE
Improve performance of is defined in non strict mode

### DIFF
--- a/lib/Twig/Node/Expression/GetAttr.php
+++ b/lib/Twig/Node/Expression/GetAttr.php
@@ -20,7 +20,9 @@ class Twig_Node_Expression_GetAttr extends Twig_Node_Expression
     {
         $compiler->raw('$this->getAttribute(');
 
-        if ($this->hasAttribute('is_defined_test')) {
+        if ($this->hasAttribute('is_defined_test')
+            && $compiler->getEnvironment()->isStrictVariables()
+        ) {
             $compiler->subcompile(new Twig_Node_Expression_Filter(
                 $this->getNode('node'),
                 new Twig_Node_Expression_Constant('default', $this->getLine()),


### PR DESCRIPTION
Addresses issue #380: This gives a good performance improvement on defined tests in non-strict code. About 2x.

Reasoning: It doesn't make sense to propagate the `is_defined_test` flag into deeper levels in non-strict mode, because all getAttr functions and name accesses will just return `null` if it doesn't exist and `null` is just as good as `false`.
