### PR TITLE
Make compiled template cache name depends on baseTemplateClass too

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -256,7 +256,7 @@ class Twig_Environment
      */
     public function getTemplateClass($name)
     {
-        return $this->templateClassPrefix.md5($this->loader->getCacheKey($name));
+        return $this->templateClassPrefix.md5($this->loader->getCacheKey($name) . $this->baseTemplateClass);
     }
 
     /**


### PR DESCRIPTION
Make compiled template cache name depends on baseTemplateClass too. So we don't need to remove old cache on baseTemplateClass is switched.
Thank you!
