### PR TITLE
BC break with PHP 5.2.x on json_encode

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -267,7 +267,7 @@ function twig_jsonencode_filter($value, $options = 0)
         array_walk_recursive($value, '_twig_markup2string');
     }
 
-    return json_encode($value, $options);
+    return (0 == $options) ? json_encode($value) : json_encode($value, $options);
 }
 
 function _twig_markup2string(&$value)


### PR DESCRIPTION
Hi,

The $options parameter of json_encode only appears in php 5.3.0. With php 5.2.x it raise a warning and return nothing. I've made a correction to make it usable with php 5.2.x when no option is specified. 

Cheers,

Bruno
