### PR TITLE
Improve attribute retrieval for templates

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -332,6 +332,9 @@ abstract class Twig_Template implements Twig_TemplateInterface
             $method = 'is'.$item;
         } elseif (isset(self::$cache[$class]['methods']['__call'])) {
             $method = $item;
+        } elseif (isset(self::$cache[$class]['methods']['__get'])) {
+             $method = '__get';
+             array_unshift($arguments, $item);
         } else {
             if ($isDefinedTest) {
                 return false;


### PR DESCRIPTION
Allow the use of __get() method for attribute retrieval if it's present in the target object.
