### PR TITLE
Edited doc/templates.rst via GitHub

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -115,7 +115,7 @@ Twig always references the following variables:
 Filters
 -------
 
-Variables can by modified by **filters**. Filters are separated from the
+Variables can be modified by **filters**. Filters are separated from the
 variable by a pipe symbol (``|``) and may have optional arguments in
 parentheses. Multiple filters can be chained. The output of one filter is
 applied to the next.


### PR DESCRIPTION
I fixed a typo: Variables can by for Variables can be
