### PR TITLE
Remove the charset from htmlspecialchars

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -501,7 +501,7 @@ function twig_escape_filter(Twig_Environment $env, $string, $type = 'html', $cha
             return $string;
 
         case 'html':
-            return htmlspecialchars($string, ENT_QUOTES, $charset);
+            return htmlspecialchars($string, ENT_QUOTES);
 
         default:
             throw new Twig_Error_Runtime(sprintf('Invalid escape type "%s".', $type));


### PR DESCRIPTION
Remove the charset from htmlspecialchars.
If a string contains invalid characters (ex: ISO-8859-1 when charset is set to UTF-8), the returned string is blank.
