### PR TITLE
Removing array_shift for optimisation. 

### DIFF
--- a/lib/Twig/Error.php
+++ b/lib/Twig/Error.php
@@ -175,7 +175,10 @@ class Twig_Error extends Exception
             $tokens = token_get_all(file_get_contents($r->getFilename()));
             $templateline = -1;
             $template = null;
-            while ($token = array_shift($tokens)) {
+            $tokensSize = count($tokens);
+            for($j = 0; $j < $tokensSize; $j++) {
+                $token = $tokens[$j];
+                
                 if (isset($token[2]) && $token[2] >= $line) {
                     return array($templateline, $template);
                 }


### PR DESCRIPTION
For example we check if a template and use exception to redirect to a default template

Before : We checked ~1000 times => 100sec due to array_shift
After  : ~1sec
