### PR TITLE
Before using array_key_exists, check if needle is of correct type.

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -262,7 +262,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
     {
         // array
         if (Twig_TemplateInterface::METHOD_CALL !== $type) {
-            if ((is_array($object) && (is_string($item) || is_integer($item)) && array_key_exists($item, $object))
+            if ((is_array($object) && (is_string($item) || is_int($item)) && array_key_exists($item, $object))
                 || ($object instanceof ArrayAccess && isset($object[$item]))
             ) {
                 if ($isDefinedTest) {


### PR DESCRIPTION
Avoiding PHP error message.
