### PR TITLE
Added Capability to format DateInterval via twig date filter

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -221,7 +221,7 @@ function twig_cycle($values, $i)
  */
 function twig_date_format_filter($date, $format = 'F j, Y H:i', $timezone = null)
 {
-    if (!$date instanceof DateTime) {
+    if (!$date instanceof DateTime && !$date instanceof DateInterval) {
         if (ctype_digit((string) $date)) {
             $date = new DateTime('@'.$date);
             $date->setTimezone(new DateTimeZone(date_default_timezone_get()));


### PR DESCRIPTION
hi, 
i was wondering why twig couldn't format my DateInterval and added it.

Either this is ok for you or we should add something similar for DateInterval because it uses a little bit different syntax to format its string (e.g. prepend with "%")

Cheers Phil
