### PR TITLE
Moved interfaces

### DIFF
--- a/lib/Twig/Node.php
+++ b/lib/Twig/Node.php
@@ -16,7 +16,7 @@
  * @package    twig
  * @author     Fabien Potencier <fabien@symfony.com>
  */
-class Twig_Node implements Twig_NodeInterface, Countable, IteratorAggregate
+class Twig_Node implements Twig_NodeInterface
 {
     protected $nodes;
     protected $attributes;

--- a/lib/Twig/NodeInterface.php
+++ b/lib/Twig/NodeInterface.php
@@ -15,7 +15,7 @@
  * @package    twig
  * @author     Fabien Potencier <fabien@symfony.com>
  */
-interface Twig_NodeInterface
+interface Twig_NodeInterface extends Countable, IteratorAggregate
 {
     /**
      * Compiles the node to PHP.


### PR DESCRIPTION
The Countable and IteratorAggregate interfaces have to be part of the Twig_NodeInterface as the Twig_NodeInterface is used as a typehint and the function tries to iterate over its elements. 

E.g:

Twig_NodeTraverser::traverseForVisitor

foreach ($node as $k => $n)
