### PR TITLE
Make long var/block tests faster

### DIFF
--- a/test/Twig/Tests/LexerTest.php
+++ b/test/Twig/Tests/LexerTest.php
@@ -119,9 +119,9 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
         // should not throw an exception
     }
 
-    public function testLongBlock()
+    public function testLongVar()
     {
-        $template = '{{ '.str_repeat('*', 100000).' }}';
+        $template = '{{ '.str_repeat('x', 100000).' }}';
 
         $lexer = new Twig_Lexer(new Twig_Environment());
         $stream = $lexer->tokenize($template);
@@ -129,9 +129,9 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
         // should not throw an exception
     }
 
-    public function testLongBlock1()
+    public function testLongBlock()
     {
-        $template = '{% '.str_repeat('*', 100000).' %}';
+        $template = '{% '.str_repeat('x', 100000).' %}';
 
         $lexer = new Twig_Lexer(new Twig_Environment());
         $stream = $lexer->tokenize($template);


### PR DESCRIPTION
When using `*` every single character is a different token, whereas with `x` there is only a single token. I don't think this hurts the actual test, but it improves the test runtime by something like 2/3 seconds on my machine.
