### PR TITLE
Improve defined/default on method call

### DIFF
--- a/lib/Twig/Node/Expression/DefaultFilter.php
+++ b/lib/Twig/Node/Expression/DefaultFilter.php
@@ -16,7 +16,15 @@ class Twig_Node_Expression_DefaultFilter extends Twig_Node_Expression
             throw new Twig_Error('The default filter node cannot be created from the given node.', $node->getLine());
         }
 
-        $test = new Twig_Node_Expression_Test(clone $node->getNode('node'), 'defined', new Twig_Node(), $node->getLine());
+        // clone node for use in is defined test
+        $nodeToTest = clone $node->getNode('node');
+
+        // remove arguments for is defined test as it works only on methods without args
+        if ($nodeToTest instanceof Twig_Node_Expression_GetAttr) {
+            $nodeToTest->setNode('arguments', new Twig_Node());
+        }
+
+        $test = new Twig_Node_Expression_Test($nodeToTest, 'defined', new Twig_Node(), $node->getLine());
         $default = count($node->getNode('arguments')) ? $node->getNode('arguments')->getNode(0) : new Twig_Node_Expression_Constant('', $node->getLine());
 
         $node = new Twig_Node_Expression_Conditional($test, $node, $default, $node->getLine());

--- a/lib/Twig/Node/Expression/Test.php
+++ b/lib/Twig/Node/Expression/Test.php
@@ -19,20 +19,22 @@ class Twig_Node_Expression_Test extends Twig_Node_Expression
             if ($node instanceof Twig_Node_Expression_Name) {
                 $node->setAttribute('is_defined_test', true);
             } elseif ($node instanceof Twig_Node_Expression_GetAttr) {
-                $node->setAttribute('is_defined_test', true);
+                if (count($node->getNode('arguments'))) {
+                    throw new Twig_Error_Syntax('The "defined" test only works with simple variables', $this->getLine());
+                }
 
-                $this->changeIgnoreStrictCheck($node);
+                $node->setAttribute('is_defined_test', true);
+                $this->changeIgnoreStrictCheck($node->getNode('node'));
             } else {
                 throw new Twig_Error_Syntax('The "defined" test only works with simple variables', $this->getLine());
             }
         }
     }
 
-    protected function changeIgnoreStrictCheck(Twig_Node_Expression_GetAttr $node)
+    protected function changeIgnoreStrictCheck(Twig_Node $node)
     {
-        $node->setAttribute('ignore_strict_check', true);
-
-        if ($node->getNode('node') instanceof Twig_Node_Expression_GetAttr) {
+        if ($node instanceof Twig_Node_Expression_GetAttr) {
+            $node->setAttribute('ignore_strict_check', true);
             $this->changeIgnoreStrictCheck($node->getNode('node'));
         }
     }

--- a/test/Twig/Tests/Fixtures/filters/default.test
+++ b/test/Twig/Tests/Fixtures/filters/default.test
@@ -30,7 +30,8 @@ Object methods:
 {{ object.getFoo()             |default('default') is sameas('default') ? 'ko' : 'ok' }}
 {{ object.getFoo('a')          |default('default') is sameas('default') ? 'ko' : 'ok' }}
 {{ object.undefinedMethod()    |default('default') is sameas('default') ? 'ok' : 'ko' }}
-{{ object.undefinedMethod('a') |default('default') is sameas('default') ? 'ok' : 'ko' }}
+{{ object.undefinedMethod(undefinedVar)|default('default') is sameas('default') ? 'ok' : 'ko' }}
+{{ object.getSelf('a').undefinedMethod(undefinedVar)|default('default') is sameas('default') ? 'ok' : 'ko' }}
 Deep nested:
 {{ nested.undefinedVar.foo.bar |default('default') is sameas('default') ? 'ok' : 'ko' }}
 {{ nested.definedArray.0       |default('default') is sameas('default') ? 'ko' : 'ok' }}
@@ -86,6 +87,7 @@ ok
 ok
 ok
 ok
+ok
 Deep nested:
 ok
 ok
@@ -135,6 +137,7 @@ Precedence:
 ok
 ok
 Object methods:
+ok
 ok
 ok
 ok

--- a/test/Twig/Tests/Fixtures/tests/defined.test
+++ b/test/Twig/Tests/Fixtures/tests/defined.test
@@ -20,9 +20,7 @@
 {{ object.foo                     is     defined ? 'ok' : 'ko' }}
 {{ object.undefinedMethod         is     defined ? 'ko' : 'ok' }}
 {{ object.getFoo()                is     defined ? 'ok' : 'ko' }}
-{{ object.getFoo('a')             is     defined ? 'ok' : 'ko' }}
 {{ object.undefinedMethod()       is     defined ? 'ko' : 'ok' }}
-{{ object.undefinedMethod('a')    is     defined ? 'ko' : 'ok' }}
 {{ object.self.foo                is     defined ? 'ok' : 'ko' }}
 {{ object.self.undefinedMethod    is     defined ? 'ko' : 'ok' }}
 {{ object.undefinedMethod.self    is     defined ? 'ko' : 'ok' }}
@@ -63,8 +61,6 @@ ok
 ok
 ok
 ok
-ok
-ok
 --DATA--
 return array(
     'definedVar' => 'defined',
@@ -81,8 +77,6 @@ return array(
 --CONFIG--
 return array('strict_variables' => false)
 --EXPECT--
-ok
-ok
 ok
 ok
 ok


### PR DESCRIPTION
This is a followup to #490.

The following changes are made:
- defined test is only allowed on method calls without arguments
- default filter on method calls with arguments removes the arguments in the defined test
- ignore_strict_check is not set if is_defined_test is already set

`a.b() is defined` will work, but `a.b(c) is defined()` will not.
`a.b(c)|default(d)` will be compiled to `a.b() is defined ? a.b(c)|default(d) : d`

I hope I got everything right.
