### PR TITLE
Add Autoloadig instructions for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     ],
     "require": {
         "php": ">=5.2.4"
+    },
+    "autoload": {
+        "psr-0" : {
+            "Twig_" : "lib/"
+        }
     }
 }


### PR DESCRIPTION
Add psr-0 autoload directive to composer.json for easier Autoloading
when using Composer as a package management tool
