### PR TITLE
Support of negative timestamps

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -238,7 +238,7 @@ function twig_date_format_filter($date, $format = 'F j, Y H:i', $timezone = null
 {
     if (!$date instanceof DateTime && !$date instanceof DateInterval) {
         if (ctype_digit((string) $date)
-            || (!empty($date[0])
+            || (!empty($date)
                 && ('-' === $date[0])
                 && ctype_digit(substr($date, 1)))
         ) {


### PR DESCRIPTION
Date could be checked against this condition, as proposed in my patch:

``` php
ctype_digit((string) $date) 
|| (('-' === $date[0])
    && (ctype_digit(substr($date, 1))))
```

or this:

``` php
preg_match('/^\-?\d+/', $date)
```

Second is maybe more readable, but 20% slower.
