### PR TITLE
Fix props detection for instances implementing Iterator or similar cases

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -357,9 +357,11 @@ abstract class Twig_Template implements Twig_TemplateInterface
         // object property
         if (Twig_TemplateInterface::METHOD_CALL !== $type) {
             if (!isset(self::$cache[$class]['properties'])) {
-                foreach ($object as $k => $v) {
-                    self::$cache[$class]['properties'][$k] = true;
+                $props = get_object_vars($object);
+                foreach ($props as &$v) {
+                    $v = true;
                 }
+                self::$cache[$class]['properties'] = $props;
             }
 
             if (isset(self::$cache[$class]['properties'][$item])


### PR DESCRIPTION
Fix property access when the instance implements Iterator or similar cases, by using get_object_vars instead, thx Arnaud Leblanc for the hint.
