### PR TITLE
Fixed bug that was trucating integers large then PHP_INT_MAX

### DIFF
--- a/lib/Twig/Lexer.php
+++ b/lib/Twig/Lexer.php
@@ -222,10 +222,8 @@ class Twig_Lexer implements Twig_LexerInterface
         // numbers
         elseif (preg_match(self::REGEX_NUMBER, $this->code, $match, null, $this->cursor)) {
             $number = (float) $match[0];  // floats
-            if (ctype_digit($match[0])) {
-                if ($number <= PHP_INT_MAX) {
-                    $number = (int) $match[0]; // integers lower than the maximum
-                }
+            if (ctype_digit($match[0]) && $number <= PHP_INT_MAX) {
+                $number = (int) $match[0]; // integers lower than the maximum
             }
             $this->pushToken(Twig_Token::NUMBER_TYPE, $number);
             $this->moveCursor($match[0]);


### PR DESCRIPTION
The following code 

{% set sizes = [7077888, 452984832, 28991029248, 1855425871872, 9223372036854775807] %}
{% for i in sizes %}
   {{ i }} 
{% endfor %}

was generating the following output

7077888
452984832
2147483647
2147483647
2147483647

With the fix, the output looks like the following on Ubuntu 11.04

7077888
452984832
28991029248
1855425871872
9.2233720368548E+18
