### PR TITLE
Help the developer when they specify an invalid filter by providing some...

### DIFF
--- a/lib/Twig/Node/Expression/Filter.php
+++ b/lib/Twig/Node/Expression/Filter.php
@@ -19,22 +19,22 @@ class Twig_Node_Expression_Filter extends Twig_Node_Expression
     public function compile(Twig_Compiler $compiler)
     {
         $name = $this->getNode('filter')->getAttribute('value');
-        
+
         if (false === $filter = $compiler->getEnvironment()->getFilter($name)) {
             $alternativeFilters = array();
-            
+
             foreach ($compiler->getEnvironment()->getFilters() as $filterName => $filter) {
                 if (false !== strpos($filterName, $name)) {
                     $alternativeFilters[] = $filterName;
                 }
             }
-            
+
             $exceptionMessage = sprintf('The filter "%s" does not exist', $name);
-           
+
             if (count($alternativeFilters)) {
                 $exceptionMessage = sprintf('%s. Did you mean "%s"?', $exceptionMessage, implode('", "', $alternativeFilters));
             }
-            
+
             throw new Twig_Error_Syntax($exceptionMessage, $this->getLine());
         }
 


### PR DESCRIPTION
... alternatives.

Bug fix: no
Feature addition: yes
Backwards compatibility break: no

Uses a simple `strpos` search (no fancy diff to determine what the filter could be). There is no impact to runtime performance because this is all happening during template compilation.

Examples:

``` jinja
{{ my_entity|json }}
```

Shows exception:

`The filter "json" does not exist. Did you mean "json_encode"?`

``` jinja
{{ my_date|dat }}
```

Shows:

`The filter "dat" does not exist. Did you mean "date"?`

``` jinja
{{ my_var|f }}
```

Shows:

`The filter "f" does not exist. Did you mean "format", "default", "_default", "format_args", "format_args_as_text", "file_excerpt", "format_file", "format_file_from_text", "file_link"?`

Also good for custom filters created in your own domain `st_`:

``` jinja
{{ my_var|st_ }}
```

Shows:

`The filter "st_" does not exist. Did you mean "st_friendly_date", "st_site_test_url"?`
