### PR TITLE
misspell function _twig_convert_encoding -> twig_convert_encoding

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -582,7 +582,7 @@ function _twig_escape_js_callback($matches)
     }
 
     // \uHHHH
-    $char = _twig_convert_encoding($char, 'UTF-16BE', 'UTF-8');
+    $char = twig_convert_encoding($char, 'UTF-16BE', 'UTF-8');
 
     return '\\u'.substr('0000'.bin2hex($char), -4);
 }


### PR DESCRIPTION
Located in _twig_escape_js_callback, the function call was misspelled and raised a PHP Fatal error:  Call to undefined function _twig_convert_encoding() in ~/www/project/vendors/Twig/Extension/Core.php on line 585
