### PR TITLE
Fix crash in twig_template_get_attributes when input is not an array or object

### DIFF
--- a/ext/twig/twig.c
+++ b/ext/twig/twig.c
@@ -816,7 +816,14 @@ PHP_FUNCTION(twig_template_get_attributes)
 		if (ignoreStrictCheck || !TWIG_CALL_BOOLEAN(TWIG_PROPERTY_CHAR(template, "env" TSRMLS_CC), "isStrictVariables" TSRMLS_CC) TSRMLS_CC) {
 			RETURN_FALSE;
 		}
-		TWIG_THROW_EXCEPTION("Twig_Error_Runtime" TSRMLS_CC, "Item \"%s\" for \"%s\" does not exist", item, TWIG_IMPLODE_ARRAY_KEYS(", ", object TSRMLS_CC));
+		if (Z_TYPE_P(object) == IS_ARRAY) {
+			TWIG_THROW_EXCEPTION("Twig_Error_Runtime" TSRMLS_CC, "Item \"%s\" for \"Array\" does not exist", item);
+		} else {
+			Z_ADDREF_P(object);
+			convert_to_string_ex(&object);
+			TWIG_THROW_EXCEPTION("Twig_Error_Runtime" TSRMLS_CC, "Item \"%s\" for \"%s\" does not exist", item, Z_STRVAL_P(object));
+			zval_ptr_dtor(&object);
+		}
 		return;
 	}
 /*

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -26,7 +26,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider getGetAttributeTests
      */
-    public function testGetAttributeStrict($defined, $value, $object, $item, $arguments, $type, $useExt = false)
+    public function testGetAttributeStrict($defined, $value, $object, $item, $arguments, $type, $useExt = false, $exceptionMessage = null)
     {
         $template = new Twig_TemplateTest(
             new Twig_Environment(null, array('strict_variables' => true)),
@@ -40,7 +40,11 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
                 $this->assertEquals($value, $template->getAttribute($object, $item, $arguments, $type));
 
                 throw new Exception('Expected Twig_Error_Runtime exception.');
-            } catch (Twig_Error_Runtime $e) { }
+            } catch (Twig_Error_Runtime $e) {
+                if (null !== $exceptionMessage) {
+                    $this->assertSame($exceptionMessage, $e->getMessage());
+                }
+            }
         }
     }
 
@@ -166,11 +170,19 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
 
         ));
 
+        // tests when input is not an array or object
+        $tests = array_merge($tests, array(
+            array(false, null, 42, 'a', array(), $anyType, false, 'Item "a" for "42" does not exist'),
+            array(false, null, "string", 'a', array(), $anyType, false, 'Item "a" for "string" does not exist'),
+            array(false, null, array(), 'a', array(), $anyType, false, 'Item "a" for "Array" does not exist'),
+        ));
+
         // add twig_template_get_attributes tests
 
         if (function_exists('twig_template_get_attributes')) {
             foreach(array_slice($tests, 0) as $test) {
-                $test[] = true;
+                $test = array_pad($test, 7, null);
+                $test[6] = true;
                 $tests[] = $test;
             }
         }


### PR DESCRIPTION
This fixes a crash when the input of twig_template_get_attributes() is not an array or object, and strict mode is enabled.
