### PR TITLE
Added a notice in the `nl2br` filter documentation ...

### DIFF
--- a/doc/filters/nl2br.rst
+++ b/doc/filters/nl2br.rst
@@ -1,6 +1,9 @@
 ``nl2br``
 =========
 
+.. versionadded:: 1.5
+    The nl2br filter was added in Twig 1.5.
+
 The ``nl2br`` filter inserts HTML line breaks before all newlines in a string:
 
 .. code-block:: jinja


### PR DESCRIPTION
... about the proper Twig version to use it (1.5)
