### PR TITLE
Fixed typo in documentation.

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -399,7 +399,7 @@ Now, let's see the actual code of this class::
 
             $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
 
-            return new Project_Set_Node($name, $value, $lineno, $this->getTag());
+            return new Project_Set_Node($name, $value, $lineno);
             }
 
         public function getTag()


### PR DESCRIPTION
The signature of Project_Set_Node is : 

```
public function __construct($name, Twig_Node_Expression $value, $lineno)
```

 So it's useless to add `$this->$this->getTag()`
