### PR TITLE
Added a link to the documentation site

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,3 +6,9 @@ and documentation).
 
 Twig uses a syntax similar to the Django and Jinja template languages which
 inspired the Twig runtime environment.
+
+## More Information
+
+Read the [documentation][1] for more information.
+
+[1]: http://twig.sensiolabs.org/documentation


### PR DESCRIPTION
Now, on the github project page, there is a link to http://twig.sensiolabs.org/documentation. (like silex)
