### PR TITLE
cast $name to a string ...

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -98,6 +98,8 @@ abstract class Twig_Template implements Twig_TemplateInterface
      */
     public function displayParentBlock($name, array $context, array $blocks = array())
     {
+        $name = (string) $name;
+        
         if (isset($this->traits[$name])) {
             $this->traits[$name][0]->displayBlock($name, $context, $blocks);
         } elseif (false !== $parent = $this->getParent($context)) {
@@ -119,6 +121,8 @@ abstract class Twig_Template implements Twig_TemplateInterface
      */
     public function displayBlock($name, array $context, array $blocks = array())
     {
+        $name = (string) $name;
+        
         if (isset($blocks[$name])) {
             $b = $blocks;
             unset($b[$name]);
@@ -189,7 +193,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
      */
     public function hasBlock($name)
     {
-        return isset($this->blocks[$name]);
+        return isset($this->blocks[(string) $name]);
     }
 
     /**


### PR DESCRIPTION
... because $name can be an object implementing __toString. I have Enum type implementation which implements __toString. Without the cast I'm getting the following exception:
"An exception has been thrown during the rendering of a template ("Warning: Illegal offset type in isset or empty in... "
