### PR TITLE
Remove optimization (covered by Optimization VAR_ACCESS anyway)

### DIFF
--- a/lib/Twig/Node/Expression/Name.php
+++ b/lib/Twig/Node/Expression/Name.php
@@ -35,29 +35,18 @@ class Twig_Node_Expression_Name extends Twig_Node_Expression
         } elseif ($this->isSpecial()) {
             $compiler->raw($this->specialVars[$name]);
         } else {
-            if (version_compare(phpversion(), '5.4.0RC1', '>=') && ($this->getAttribute('ignore_strict_check') || !$compiler->getEnvironment()->isStrictVariables())) {
-                // PHP 5.4 ternary operator performance was optimized
-                $compiler
-                    ->raw('(isset($context[')
-                    ->string($name)
-                    ->raw(']) ? $context[')
-                    ->string($name)
-                    ->raw('] : null)')
-                ;
-            } else {
-                $compiler
-                    ->raw('$this->getContext($context, ')
-                    ->string($name)
-                ;
+            $compiler
+                ->raw('$this->getContext($context, ')
+                ->string($name)
+            ;
 
-                if ($this->getAttribute('ignore_strict_check')) {
-                    $compiler->raw(', true');
-                }
-
-                $compiler
-                    ->raw(')')
-                ;
+            if ($this->getAttribute('ignore_strict_check')) {
+                $compiler->raw(', true');
             }
+
+            $compiler
+                ->raw(')')
+            ;
         }
     }
 


### PR DESCRIPTION
I have an own template class implementing getContext() and this one drove me completely mad after a twig upgrade.

After compilation the resulting templates have:

isset($context['bla'])

vs.

$this->getContext('bla')

Changing the Name Node however didn't have any effect and i saw that due to the optimizations by the SetTemp class twig doesn't even reach the Name Node. In fact SetTemp has the isset optimization hardcoded (which is ok).

I could simply fix my issue by setting optimizations to -9 (all optimizations except VAR_ACCESS). However the issue will reappear immediately when using PHP 5.4. Please remove the isset stuff from the non optimized node and let the optimization handler handle it (which i would disable in my case)
