### PR TITLE
Fixed issue #622: strings slice filter w/ no length

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -550,7 +550,15 @@ function twig_slice(Twig_Environment $env, $item, $start, $length = null)
     $item = (string) $item;
 
     if (function_exists('mb_get_info') && null !== $charset = $env->getCharset()) {
+    	if (null === $length) {
+    	    $length = mb_strlen($item, $charset) - $start;
+    	}
+    	
         return mb_substr($item, $start, $length, $charset);
+    }
+    
+    if (null === $length) {
+        return substr($item, $start);
     }
 
     return substr($item, $start, $length);


### PR DESCRIPTION
Fixed issue [#622](https://github.com/fabpot/Twig/issues/622)
