### PR TITLE
Avoid creating unnecessary Twig_Markup instances

### DIFF
--- a/lib/Twig/Node/Set.php
+++ b/lib/Twig/Node/Set.php
@@ -67,7 +67,7 @@ class Twig_Node_Set extends Twig_Node
             $compiler->subcompile($this->getNode('names'), false);
 
             if ($this->getAttribute('capture')) {
-                $compiler->raw(" = new Twig_Markup(ob_get_clean(), \$this->env->getCharset())");
+                $compiler->raw(" = ('' === \$tmp = ob_get_clean()) ? '' : new Twig_Markup(\$tmp, \$this->env->getCharset())");
             }
         }
 
@@ -87,9 +87,9 @@ class Twig_Node_Set extends Twig_Node
             } else {
                 if ($this->getAttribute('safe')) {
                     $compiler
-                        ->raw("new Twig_Markup(")
+                        ->raw("('' === \$tmp = ")
                         ->subcompile($this->getNode('values'))
-                        ->raw(", \$this->env->getCharset())")
+                        ->raw(") ? '' : new Twig_Markup(\$tmp, \$this->env->getCharset())")
                     ;
                 } else {
                     $compiler->subcompile($this->getNode('values'));

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -429,7 +429,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
 
         // hack to be removed when macro calls are refactored
         if ($object instanceof Twig_TemplateInterface) {
-            return new Twig_Markup($ret, $this->env->getCharset());
+            return $ret === '' ? '' : new Twig_Markup($ret, $this->env->getCharset());
         }
 
         return $ret;

--- a/test/Twig/Tests/Fixtures/tags/set/capture-empty.test
+++ b/test/Twig/Tests/Fixtures/tags/set/capture-empty.test
@@ -1,0 +1,9 @@
+--TEST--
+"set" tag block empty capture
+--TEMPLATE--
+{% set foo %}{% endset %}
+
+{% if foo %}FAIL{% endif %}
+--DATA--
+return array()
+--EXPECT--

--- a/test/Twig/Tests/Node/SetTest.php
+++ b/test/Twig/Tests/Node/SetTest.php
@@ -51,14 +51,14 @@ class Twig_Tests_Node_SetTest extends Twig_Tests_Node_TestCase
         $tests[] = array($node, <<<EOF
 ob_start();
 echo "foo";
-\$context["foo"] = new Twig_Markup(ob_get_clean(), \$this->env->getCharset());
+\$context["foo"] = ('' === \$tmp = ob_get_clean()) ? '' : new Twig_Markup(\$tmp, \$this->env->getCharset());
 EOF
         );
 
         $names = new Twig_Node(array(new Twig_Node_Expression_AssignName('foo', 0)), array(), 0);
         $values = new Twig_Node_Text('foo', 0);
         $node = new Twig_Node_Set(true, $names, $values, 0);
-        $tests[] = array($node, '$context["foo"] = new Twig_Markup("foo", $this->env->getCharset());');
+        $tests[] = array($node, '$context["foo"] = (\'\' === $tmp = "foo") ? \'\' : new Twig_Markup($tmp, $this->env->getCharset());');
 
         $names = new Twig_Node(array(new Twig_Node_Expression_AssignName('foo', 0), new Twig_Node_Expression_AssignName('bar', 0)), array(), 0);
         $values = new Twig_Node(array(new Twig_Node_Expression_Constant('foo', 0), new Twig_Node_Expression_Name('bar', 0)), array(), 0);


### PR DESCRIPTION
This allows testing for falsiness of an empty output:

``` jinja
{% set foo %}{% block lala %}{% endblock %}{% endset %}

{% if foo %}
   some output with {{ foo }} 
{% endif %}
```

Currently this requires `{% if foo|length %}` since the set tag will always return a Twig_Markup.
