### PR TITLE
Whitespace

### DIFF
--- a/lib/Twig/Node/Text.php
+++ b/lib/Twig/Node/Text.php
@@ -33,7 +33,7 @@ class Twig_Node_Text extends Twig_Node implements Twig_NodeOutputInterface
         $compiler
             ->addDebugInfo($this)
             ->write('echo ')
-            ->string(rtrim($this->getAttribute('data'), " \t"))
+            ->string(preg_replace("/^[ \t]+\z/m", "", $this->getAttribute('data')))
             ->raw(";\n")
         ;
     }


### PR DESCRIPTION
This will strip spaces and tabs from a trailing empty line in raw text. The intended effect is that the indentation of Twig tags in a template will be removed from the result text.

This patch is in response to an [old thread](http://groups.google.com/group/twig-devs/browse_thread/thread/41cad5221d934717/bb7f4475d171774b) on the mailing list concerning whitespace control. Some objections were raised that this might not be in the interest of all users, but I wanted to offer it regardless.
