### PR TITLE
Added support to disable slow parsing of the exception trace

### DIFF
--- a/lib/Twig/Error/Loader.php
+++ b/lib/Twig/Error/Loader.php
@@ -17,4 +17,11 @@
  */
 class Twig_Error_Loader extends Twig_Error
 {
+    /**
+     * {@inheritdoc}
+     */
+    static public function setRaw($raw)
+    {
+        return self::doSetRaw(__CLASS__, $raw);
+    }
 }

--- a/lib/Twig/Error/Runtime.php
+++ b/lib/Twig/Error/Runtime.php
@@ -18,4 +18,11 @@
  */
 class Twig_Error_Runtime extends Twig_Error
 {
+    /**
+     * {@inheritdoc}
+     */
+    static public function setRaw($raw)
+    {
+        return self::doSetRaw(__CLASS__, $raw);
+    }
 }

--- a/lib/Twig/Error/Syntax.php
+++ b/lib/Twig/Error/Syntax.php
@@ -18,4 +18,11 @@
  */
 class Twig_Error_Syntax extends Twig_Error
 {
+    /**
+     * {@inheritdoc}
+     */
+    static public function setRaw($raw)
+    {
+        return self::doSetRaw(__CLASS__, $raw);
+    }
 }

--- a/lib/Twig/Loader/Chain.php
+++ b/lib/Twig/Loader/Chain.php
@@ -51,12 +51,17 @@ class Twig_Loader_Chain implements Twig_LoaderInterface
      */
     public function getSource($name)
     {
+        $old = Twig_Error_Loader::setRaw(true);
         foreach ($this->loaders as $loader) {
             try {
                 return $loader->getSource($name);
             } catch (Twig_Error_Loader $e) {
+            } catch (Exception $e) {
+                Twig_Error_Loader::setRaw($old);
+                throw $e;
             }
         }
+        Twig_Error_Loader::setRaw($old);
 
         throw new Twig_Error_Loader(sprintf('Template "%s" is not defined.', $name));
     }
@@ -70,12 +75,17 @@ class Twig_Loader_Chain implements Twig_LoaderInterface
      */
     public function getCacheKey($name)
     {
+        $old = Twig_Error_Loader::setRaw(true);
         foreach ($this->loaders as $loader) {
             try {
                 return $loader->getCacheKey($name);
             } catch (Twig_Error_Loader $e) {
+            } catch (Exception $e) {
+                Twig_Error_Loader::setRaw($old);
+                throw $e;
             }
         }
+        Twig_Error_Loader::setRaw($old);
 
         throw new Twig_Error_Loader(sprintf('Template "%s" is not defined.', $name));
     }
@@ -88,12 +98,17 @@ class Twig_Loader_Chain implements Twig_LoaderInterface
      */
     public function isFresh($name, $time)
     {
+        $old = Twig_Error_Loader::setRaw(true);
         foreach ($this->loaders as $loader) {
             try {
                 return $loader->isFresh($name, $time);
             } catch (Twig_Error_Loader $e) {
+            } catch (Exception $e) {
+                Twig_Error_Loader::setRaw($old);
+                throw $e;
             }
         }
+        Twig_Error_Loader::setRaw($old);
 
         throw new Twig_Error_Loader(sprintf('Template "%s" is not defined.', $name));
     }

--- a/test/Twig/Tests/ErrorTest.php
+++ b/test/Twig/Tests/ErrorTest.php
@@ -48,6 +48,36 @@ class Twig_Tests_ErrorTest extends Twig_Tests_TestCase
             $this->assertEquals('index', $e->getTemplateFile());
         }
     }
+
+    public function testRawExceptions()
+    {
+        $loader = new Twig_Loader_Array(array('index' => "\n\n\n{{ foo.bar }}"));
+        $twig = new Twig_Environment($loader, array('strict_variables' => true, 'debug' => true, 'cache' => $this->getTempDir()));
+
+        $template = $twig->loadTemplate('index');
+
+        $old = Twig_Error_Runtime::setRaw(true);
+        $this->assertFalse($old);
+        try {
+            $template->render(array('foo' => new Twig_Tests_ErrorTest_Foo()));
+
+            $this->fail();
+        } catch (Twig_Error_Runtime $e) {
+            $this->assertFalse($e->isProcessed());
+            $this->assertEquals('An exception has been thrown during the rendering of a template ("Runtime error...").', $e->getMessage());
+            $this->assertEquals(-1, $e->getTemplateLine());
+            $this->assertNull($e->getTemplateFile());
+        }
+
+        Twig_Error_Runtime::setRaw($old);
+        try {
+            $template->render(array('foo' => new Twig_Tests_ErrorTest_Foo()));
+
+            $this->fail();
+        } catch (Twig_Error_Runtime $e) {
+            $this->assertTrue($e->isProcessed());
+        }
+    }
 }
 
 class Twig_Tests_ErrorTest_Foo

--- a/test/Twig/Tests/Loader/ChainTest.php
+++ b/test/Twig/Tests/Loader/ChainTest.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname(__FILE__).'/../TestCase.php';
+
 /*
  * This file is part of Twig.
  *
@@ -9,7 +11,7 @@
  * file that was distributed with this source code.
  */
 
-class Twig_Tests_Loader_ChainTest extends PHPUnit_Framework_TestCase
+class Twig_Tests_Loader_ChainTest extends Twig_Tests_TestCase
 {
     public function testGetSource()
     {
@@ -59,5 +61,25 @@ class Twig_Tests_Loader_ChainTest extends PHPUnit_Framework_TestCase
         $loader->addLoader(new Twig_Loader_Array(array('foo' => 'bar')));
 
         $this->assertEquals('bar', $loader->getSource('foo'));
+    }
+
+    public function testException()
+    {
+        $loader = new Twig_Loader_Chain(array(
+            new Twig_loader_Array(array('index' => '{% include "foo" %}')),
+            new Twig_Loader_Array(array('foo' => "\n{{ foo }}")),
+        ));
+
+        $twig = new Twig_Environment($loader, array('strict_variables' => true, 'debug' => true, 'cache' => $this->getTempDir()));
+
+        $template = $twig->loadTemplate('index');
+
+        try {
+            $template->render(array());
+
+            $this->fail();
+        } catch (Exception $e) {
+            $this->assertTrue($e->isProcessed());
+        }
     }
 }


### PR DESCRIPTION
The slowest part of Twig is the chain loader. Each nested loader throws Twig_Loader_Error. I want to disable automatic parsing of the exception trace.
