### PR TITLE
Added missing @throws in Twig_LoaderInterface

### DIFF
--- a/lib/Twig/LoaderInterface.php
+++ b/lib/Twig/LoaderInterface.php
@@ -45,6 +45,8 @@ interface Twig_LoaderInterface
      * @param string    $name The template name
      * @param timestamp $time The last modification time of the cached template
      *
+     * @return Boolean true if the template is fresh, false otherwise
+     *
      * @throws Twig_Error_Loader When $name is not found
      */
     function isFresh($name, $time);


### PR DESCRIPTION
Based on Twig_Loader_Chain implementation, this seems to be the possible exception that can be thrown by loaders.
