### PR TITLE
Define lexer option via Twig_Environment

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -109,6 +109,7 @@ class Twig_Extension_Core extends Twig_Extension
             new Twig_TokenParser_Spaceless(),
             new Twig_TokenParser_Flush(),
             new Twig_TokenParser_Do(),
+            new Twig_TokenParser_Break(),
         );
     }
 

--- a/lib/Twig/Node/Break.php
+++ b/lib/Twig/Node/Break.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2012 Badlee Oshimin
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Represents a break node.
+ *
+ * @package    twig
+ * @author     Badlee Oshimin <badlee.oshimin@gmail.com>
+ */
+class Twig_Node_Break extends Twig_Node
+{
+    public function __construct($lineno, $tag){
+        parent::__construct(array(), array(), $lineno, $tag);
+    }
+
+    /**
+     * Compiles the node to PHP.
+     *
+     * @param Twig_Compiler A Twig_Compiler instance
+     */
+    public function compile(Twig_Compiler $compiler)
+    {
+    	
+    	$compiler->write("break;\n");
+    }
+}

--- a/lib/Twig/TokenParser/Break.php
+++ b/lib/Twig/TokenParser/Break.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2012 Badlee Oshimin
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * breaking a Loop.
+ *
+ * <pre>
+ * <i>Show letter a to n</i>
+ * <ul>
+ *  {% for i in 'a'..'z' %}
+ *    <li>{{ i }}</li>
+ *    {% if i == 'n'%}
+ *      {% break %}
+ *    {% endif %}
+ *  {% endfor %}
+ * </ul>
+ * </pre>
+ */
+class Twig_TokenParser_Break extends Twig_TokenParser
+{
+    /**
+     * Gets the tag name associated with this token parser.
+     *
+     * @return string The tag name
+     */
+    public function getTag()
+    {
+        return 'break';
+    }
+    
+    /**
+     * Parses a token and returns a node.
+     *
+     * @param Twig_Token $token A Twig_Token instance
+     *
+     * @return Twig_NodeInterface A Twig_NodeInterface instance
+     */
+    public function parse(Twig_Token $token)
+    {
+    	$lineno = $token->getLine();
+    	$this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
+        return new Twig_Node_Break($lineno,  $this->getTag());
+    }
+}

--- a/lib/Twig/TokenParser/For.php
+++ b/lib/Twig/TokenParser/For.php
@@ -6,8 +6,6 @@
  * (c) 2009 Fabien Potencier
  * (c) 2009 Armin Ronacher
  *
- * Updater Badlee Oshimin 2012 - add break tag
- * 
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -89,47 +87,3 @@ class Twig_TokenParser_For extends Twig_TokenParser
         return 'for';
     }
 }
-
-
-/**
- * breaking a Loop.
- *
- * <pre>
- * <i>Show letter a to n</i>
- * <ul>
- *  {% for i in 'a'..'z' %}
- *    <li>{{ i }}</li>
- *    {% if i == 'n'%}
- *      {% break %}
- *    {% endif %}
- *  {% endfor %}
- * </ul>
- * </pre>
- */
-class Twig_TokenParser_break extends Twig_TokenParser
-{
-    /**
-     * Gets the tag name associated with this token parser.
-     *
-     * @return string The tag name
-     */
-    public function getTag()
-    {
-        return 'break';
-    }
-    
-    /**
-     * Parses a token and returns a node.
-     *
-     * @param Twig_Token $token A Twig_Token instance
-     *
-     * @return Twig_NodeInterface A Twig_NodeInterface instance
-     */
-    public function parse(Twig_Token $token)
-    {
-    	$lineno = $token->getLine();
-    	$this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
-        return new Twig_Node_break($lineno,  $this->getTag());
-    }
-}
-


### PR DESCRIPTION
I update Twig_Environment in **Twig/Envirenment.php** for define lexer option on create Twig_Environment

now i can change lexer tag : 

``` php
<?php
$twig = new Twig_Environment($loader, array(
    'lexer' => array(
        'tag_comment'     => array('<cmt', '/>'),/*default array('{#', '#}')*/
        'tag_block'       => array('<twg', '/>'),/*default array('{%', '%}')*/
        'tag_variable'    => array('<var', '/>'),/*default array('{{', '}}')*/
    )
))
?>
```

*\* Twig syntax **

before  new lexer option

``` html
{# new twig syntax #}
<!-- html comment -->
{% macro input(name, value, type, size) %}
    <input
        type="{{ type|default('text') }}"
        name="{{ name }}"
        value="{{ value|e }}"
        size="{{ size|default(20) }}"
    />
{% endmacro %}
<p>{{ _self.input('username') }}</p>
```

after new lexer option

``` html
<cmt new twig syntax />
<!-- html comment -->
<twg macro input(name, value, type, size) />
    <input
        type="<var type|default('text') />"
        name="<var name />"
        value="<var value|e />"
        size="<var size|default(20) />"
    />
<twg endmacro />
<p><var _self.input('username') /></p>
```

You can add this update to **next version** ?

_**PS:_\* Excuse my english i'm french speaker*
