### PR TITLE
Updated 'convert_encoding' filter documentation

### DIFF
--- a/doc/filters/convert_encoding.rst
+++ b/doc/filters/convert_encoding.rst
@@ -14,8 +14,9 @@ is the input charset:
 
 .. note::
 
-    This filter relies on the `iconv`_ or `mbstring`_ extension. So one of
-    them must be installed.
+    This filter relies on the `iconv`_ or `mbstring`_ extension, so one of
+    them must be installed. In case both are installed, `iconv`_ is used
+    by default.
 
 .. _`iconv`:    http://php.net/iconv
 .. _`mbstring`: http://php.net/mbstring


### PR DESCRIPTION
Updated 'convert_encoding' filter documentation to clarify which extension will be used in case both `iconv` and `mbstring` are installed.
