### PR TITLE
Fixed notice in Twig_Error::guessTemplateLine

### DIFF
--- a/lib/Twig/Error.php
+++ b/lib/Twig/Error.php
@@ -164,7 +164,7 @@ class Twig_Error extends Exception
     protected function guessTemplateLine($trace)
     {
         foreach ($trace['object']->getDebugInfo() as $codeLine => $templateLine) {
-            if ($codeLine <= $trace['line']) {
+            if (isset($trace['line']) && $codeLine <= $trace['line']) {
                 return $templateLine;
             }
         }


### PR DESCRIPTION
Sometimes, `trace['line']` is not available and makes notice.

You can see tests in https://github.com/lyrixx/Silex-Kitchen-Edition/tree/composer.
