### PR TITLE
fix a bug where when an error would be thrown through the loader

### DIFF
--- a/lib/Twig/Error.php
+++ b/lib/Twig/Error.php
@@ -165,7 +165,7 @@ class Twig_Error extends Exception
     {
         if (isset($trace['line'])) {
             foreach ($trace['object']->getDebugInfo() as $codeLine => $templateLine) {
-                if (isset($trace['line']) && $codeLine <= $trace['line']) {
+                if ($codeLine <= $trace['line']) {
                     return $templateLine;
                 }
             }


### PR DESCRIPTION
(Twig_Error_Loader by Twig_Loader_Filesystem, ie) the $trace['line'] would not be set (since we're not in a template)

thanks
