### PR TITLE
Update docs concerning loop.last.

### DIFF
--- a/doc/tags/for.rst
+++ b/doc/tags/for.rst
@@ -72,7 +72,8 @@ Variable              Description
 
     The ``loop.length``, ``loop.revindex``, ``loop.revindex0``, and
     ``loop.last`` variables are only available for PHP arrays, or objects that
-    implement the ``Countable`` interface.
+    implement the ``Countable`` interface. They are also not available when
+    looping with a condition.
 
 .. versionadded:: 1.2
     The ``if`` modifier support has been added in Twig 1.2.
@@ -93,7 +94,8 @@ items. The following example skips all the users which are not active:
     </ul>
 
 The advantage is that the special loop variable will count correctly thus not
-counting the users not iterated over.
+counting the users not iterated over. Keep in mind that properties like
+``loop.last`` will not be defined when using loop conditions.
 
 .. note::
 


### PR DESCRIPTION
Add docs for #687. `loop.last` is not defined when looping with conditions.
