### PR TITLE
[composer] Add branch alias for dev-master, adjust some other things

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "description": "Twig, the flexible, fast, and secure template language for PHP",
     "keywords": ["templating"],
     "homepage": "http://twig.sensiolabs.org",
-    "version": "1.7.0",
-    "license": "BSD",
+    "license": "BSD-3",
     "authors": [
         {
             "name": "Fabien Potencier",
@@ -22,6 +21,11 @@
     "autoload": {
         "psr-0" : {
             "Twig_" : "lib/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.7-dev"
         }
     }
 }


### PR DESCRIPTION
- branch alias allows installation of dev-master by requiring 1.7.*, which is important since most packages depend on twig "<2.0.0"
- remove the version field, the version is determined by branch names and tags only
- change license to BSD-3, this is more explicit and the preferred format for BSD licenses
