### PR TITLE
Silence chmod() warnings (operation not permitted) when using CIFS

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -1069,7 +1069,7 @@ class Twig_Environment
         if (false !== @file_put_contents($tmpFile, $content)) {
             // rename does not work on Win32 before 5.2.6
             if (@rename($tmpFile, $file) || (@copy($tmpFile, $file) && unlink($tmpFile))) {
-                chmod($file, 0644);
+                @chmod($file, 0644);
 
                 return;
             }


### PR DESCRIPTION
When using chmod() in a CIFS mount (NTFS) in Linux, Twig 1.6.5 in PHP 5.3.3 throws a warning:

```
Warning: chmod(): Operation not permitted in /smb/.../Twig/Environment.php on line 1052
```

There may be other combinations that trigger this warning. Related Symfony issue: https://github.com/symfony/symfony/issues/2125
