### PR TITLE
The macros second argument is value and 3rd one is type. Also type= not ...

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -450,6 +450,14 @@ namespace via the :doc:`from<tags/from>` tag:
     </dl>
     <p>{{ textarea('comment') }}</p>
 
+Inorder to see textarea rendered you want to add the below macro 
+
+.. code-block:: jinja
+
+    {% macro textarea(name, value, rows, cols) %}
+        <textarea name="{{ name }}" rows="{{ rows|default(5) }}" cols="{{ cols|default(10) }}" >{{ value|e }}</textarea>
+    {% endmacro %}
+
 Expressions
 -----------
 


### PR DESCRIPTION
...supported and throwing error. textarea is not coming . Do we need to write another macro here ? Didn't noticed any wordings like that
