### PR TITLE
fixed getting attribute value for an ArrayObject

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -330,8 +330,10 @@ abstract class Twig_Template implements Twig_TemplateInterface
 
         // array
         if (Twig_TemplateInterface::METHOD_CALL !== $type) {
-            if ((is_array($object) && array_key_exists($item, $object))
-                || ($object instanceof ArrayAccess && isset($object[$item]))
+            if (
+                ((is_array($object) || $object instanceof ArrayObject) && array_key_exists($item, $object))
+                ||
+                ($object instanceof ArrayAccess && isset($object[$item]))
             ) {
                 if ($isDefinedTest) {
                     return true;

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -97,6 +97,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
             '1'       => 1,
         );
 
+        $arrayObject         = new ArrayObject($array);
         $objectArray         = new Twig_TemplateArrayAccessObject();
         $stdObject           = (object) $array;
         $magicPropertyObject = new Twig_TemplateMagicPropertyObject();
@@ -122,6 +123,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
         $testObjects = array(
             // array(object, type of fetch)
             array($array,               $arrayType),
+            array($arrayObject,         $arrayType),
             array($objectArray,         $arrayType),
             array($stdObject,           $anyType),
             array($magicPropertyObject, $anyType),


### PR DESCRIPTION
For

``` php
$object = new ArrayObject(array('null' => null));
```

Twig tries to get value as object property instead of array element
