### PR TITLE
Compiler outdent step validation moved up and modified

### DIFF
--- a/lib/Twig/Compiler.php
+++ b/lib/Twig/Compiler.php
@@ -239,11 +239,12 @@ class Twig_Compiler implements Twig_CompilerInterface
      */
     public function outdent($step = 1)
     {
-        $this->indentation -= $step;
-
-        if ($this->indentation < 0) {
+        // can't outdent by more steps that the current indentation level
+        if ($this->indentation < $step) {
             throw new Twig_Error('Unable to call outdent() as the indentation would become negative');
         }
+
+        $this->indentation -= $step;
 
         return $this;
     }


### PR DESCRIPTION
The Compiler outdent method will now only reduce the indentation if it's OK 
to do so, It moves and modifies the check up above the indentation modification.
It's a small improvement but saves a wasted decrement of a variable, when you know an exception will be thrown immediately following it.
