### PR TITLE
PHP 5.3.0 fix

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -375,7 +375,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
 
         // object property
         if (Twig_TemplateInterface::METHOD_CALL !== $type) {
-            if (isset($object->$item) || array_key_exists($item, $object)) {
+            if (isset($object->$item) || property_exists($object, $item)) {
                 if ($isDefinedTest) {
                     return true;
                 }


### PR DESCRIPTION
Since php 5.3.0 array_key_exists() doesn't work with objects anymore, property_exists() should be used in this case.
