### PR TITLE
Fix date_modify filter for PHP 5.2

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -421,7 +421,9 @@ function twig_date_modify_filter(Twig_Environment $env, $date, $modifier)
         $date = twig_date_converter($env, $date);
     }
 
-    return $date->modify($modifier);
+    $date->modify($modifier);
+
+    return $date;
 }
 
 /**


### PR DESCRIPTION
The return of the object was added in 5.3, this hopefully fixes it.
