### PR TITLE
[Ext] Removed useless code

### DIFF
--- a/ext/twig/php_twig.h
+++ b/ext/twig/php_twig.h
@@ -22,28 +22,10 @@
 extern zend_module_entry twig_module_entry;
 #define phpext_twig_ptr &twig_module_entry
 
-#ifdef PHP_WIN32
-#define PHP_TWIG_API __declspec(dllexport)
-#else
-#define PHP_TWIG_API
-#endif
-
 #ifdef ZTS
 #include "TSRM.h"
 #endif
 
 PHP_FUNCTION(twig_template_get_attributes);
-
-PHP_MINIT_FUNCTION(twig);
-PHP_MSHUTDOWN_FUNCTION(twig);
-PHP_RINIT_FUNCTION(twig);
-PHP_RSHUTDOWN_FUNCTION(twig);
-PHP_MINFO_FUNCTION(twig);
-
-#ifdef ZTS
-#define TWIG_G(v) TSRMG(twig_globals_id, zend_twig_globals *, v)
-#else
-#define TWIG_G(v) (twig_globals.v)
-#endif
 
 #endif

--- a/ext/twig/twig.c
+++ b/ext/twig/twig.c
@@ -17,8 +17,6 @@
 #endif
 
 #include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
 #include "php_twig.h"
 #include "ext/standard/php_string.h"
 #include "ext/standard/php_smart_str.h"
@@ -47,19 +45,15 @@ zend_function_entry twig_functions[] = {
 
 
 zend_module_entry twig_module_entry = {
-#if ZEND_MODULE_API_NO >= 20010901
 	STANDARD_MODULE_HEADER,
-#endif
 	"twig",
 	twig_functions,
-	PHP_MINIT(twig),
-	PHP_MSHUTDOWN(twig),
-	PHP_RINIT(twig),
-	PHP_RSHUTDOWN(twig),
-	PHP_MINFO(twig),
-#if ZEND_MODULE_API_NO >= 20010901
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
 	PHP_TWIG_VERSION,
-#endif
 	STANDARD_MODULE_PROPERTIES
 };
 
@@ -67,50 +61,6 @@ zend_module_entry twig_module_entry = {
 #ifdef COMPILE_DL_TWIG
 ZEND_GET_MODULE(twig)
 #endif
-
-PHP_INI_BEGIN()
-PHP_INI_END()
-
-PHP_MINIT_FUNCTION(twig)
-{
-	REGISTER_INI_ENTRIES();
-
-	return SUCCESS;
-}
-
-
-PHP_MSHUTDOWN_FUNCTION(twig)
-{
-	UNREGISTER_INI_ENTRIES();
-
-	return SUCCESS;
-}
-
-
-
-PHP_RINIT_FUNCTION(twig)
-{
-	return SUCCESS;
-}
-
-
-
-PHP_RSHUTDOWN_FUNCTION(twig)
-{
-	return SUCCESS;
-}
-
-
-PHP_MINFO_FUNCTION(twig)
-{
-	php_info_print_table_start();
-	php_info_print_table_header(2, "Twig support", "enabled");
-	php_info_print_table_row(2, "Version", PHP_TWIG_VERSION);
-	php_info_print_table_end();
-
-	DISPLAY_INI_ENTRIES();
-
-}
 
 int TWIG_ARRAY_KEY_EXISTS(zval *array, char* key, int key_len)
 {


### PR DESCRIPTION
All init hooks could be bypassed (just return `SUCESS`)
There is no `ini` entries and no globals
Phpinfo automatically get the version when `MINFO` is null
Twig don't work with PHP 4 (ref to `20010901`)
