### PR TITLE
Reverse argument for number_format

### DIFF
--- a/doc/filters/number_format.rst
+++ b/doc/filters/number_format.rst
@@ -16,12 +16,12 @@ separator using the additional arguments:
 
 .. code-block:: jinja
 
-    {{ 9800.333|number_format(2, ',', '.') }}
+    {{ 9800.333|number_format(2, '.', ',') }}
 
 If no formatting options are provided then Twig will use the default formatting
 options of:
 
-- 0 decimal places.
+- 2 decimal places.
 - ``.`` as the decimal point.
 - ``,`` as the thousands separator.
 
@@ -30,7 +30,7 @@ These defaults can be easily changed through the core extension:
 .. code-block:: php
 
     $twig = new Twig_Environment($loader);
-    $twig->getExtension('core')->setNumberFormat(3, ',', '.');
+    $twig->getExtension('core')->setNumberFormat(3, '.', ',');
 
 The defaults set for ``number_format`` can be over-ridden upon each call using the
 additional parameters.


### PR DESCRIPTION
Just a little fix, the doc isn't following twig/php's argument order
