### PR TITLE
fix example autoescape for javascript

### DIFF
--- a/doc/recipes.rst
+++ b/doc/recipes.rst
@@ -328,7 +328,7 @@ you have some dynamic JavaScript files thanks to the ``autoescape`` tag:
 
 .. code-block:: jinja
 
-    {% autoescape js %}
+    {% autoescape 'js' %}
         ... some JS ...
     {% endautoescape %}
 


### PR DESCRIPTION
{% autoescape js %} triggers an exception "An escaping strategy must be a string or a Boolean in .."
