### PR TITLE
Added missing abs and date_modify functions to the filters toctree

### DIFF
--- a/doc/filters/index.rst
+++ b/doc/filters/index.rst
@@ -5,6 +5,7 @@ Filters
     :maxdepth: 1
 
     date
+    date_modify
     format
     replace
     number_format
@@ -19,6 +20,7 @@ Filters
     striptags
     join
     reverse
+    abs
     length
     sort
     default


### PR DESCRIPTION
Both abs.rst and date_modify.rst were createad, but were not linked on the filters toctree
