### PR TITLE
Alternative fix for 792

### DIFF
--- a/ext/twig/twig.c
+++ b/ext/twig/twig.c
@@ -675,7 +675,8 @@ PHP_FUNCTION(twig_template_get_attributes)
         Z_TYPE(zitem) = IS_LONG;
         break;
     case IS_DOUBLE:
-        ZVAL_LONG(&zitem, zend_dval_to_lval(Z_DVAL(zitem)));
+        Z_TYPE(zitem) = IS_DOUBLE;
+        convert_to_long(&zitem);
         break;
     }
 

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -320,7 +320,7 @@ class Twig_TemplatePropertyObjectAndIterator extends Twig_TemplatePropertyObject
     }
 }
 
-class Twig_TemplatePropertyObjectAndArrayAccess extends Twig_TemplatePropertyObject implements \ArrayAccess
+class Twig_TemplatePropertyObjectAndArrayAccess extends Twig_TemplatePropertyObject implements ArrayAccess
 {
     private $data = array();
 


### PR DESCRIPTION
This fixes #792 as described in https://github.com/fabpot/Twig/issues/792#issuecomment-7482480
- 228d2b0 removes the _object-to-array convertion_ trick, since the bug comes from there, and it doesn't appear to be needed
- 6704227 is the equivalent of aa6b8358161e4ef35299be06a5ff61bfcba46f6a + 8ec73cf4759f90b961de1732da1732e60c1dbfff (this were not needed before because the bug was hidden by the object to array trick: numeric strings and integers are treated equally in arrays keys)
