### PR TITLE
twig for template designers: NetBeans 7.2 supports twig natively

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -48,7 +48,7 @@ Many IDEs support syntax highlighting and auto-completion for Twig:
 
 * *Textmate* via the `Twig bundle`_
 * *Vim* via the `Jinja syntax plugin`_
-* *Netbeans* via the `Twig syntax plugin`_
+* *Netbeans* via the `Twig syntax plugin`_ (until 7.1, native as of 7.2)
 * *PhpStorm* (native as of 2.1)
 * *Eclipse* via the `Twig plugin`_
 * *Sublime Text* via the `Twig bundle`_


### PR DESCRIPTION
from NetBeans 7.2 twig support is native and does not have to be installed manually.

http://plugins.netbeans.org/plugin/40565/php-symfony2-framework
quote:
Yes; this extension will be part of NetBeans 7.2, more information here [1].
Tomas
[1] http://blogs.oracle.com/netbeansphp/entry/initial_support_for_symfony2

https://blogs.oracle.com/netbeansphp/entry/initial_support_for_symfony2

I checked it myself - installed NB7.2 and it wonderfully highlights twig.
