### PR TITLE
Adding json_decode filter as revert of json_encode filter

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -584,13 +584,6 @@ function _twig_markup2string(&$value)
     }
 }
 
-function _twig_markup2string(&$value)
-{
-    if ($value instanceof Twig_Markup) {
-        $value = (string) $value;
-    }
-}
-
 /**
  * Merges an array with another one.
  *


### PR DESCRIPTION
Giving opportunity to pass object/array at params in twig by encode them
by json_encode and decode, after passing them via param, via new
json_decode.

Thanks that we can encode array/object, pass them by include, macro, etc
and decode at new template.
