### PR TITLE
Avoid setting timezones on DateIntervals

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -388,7 +388,11 @@ function twig_date_format_filter(Twig_Environment $env, $date, $format = null, $
         $format = $date instanceof DateInterval ? $formats[1] : $formats[0];
     }
 
-    if ($date instanceof DateInterval || $date instanceof DateTime) {
+    if ($date instanceof DateInterval) {
+        return $date->format($format);
+    }
+
+    if ($date instanceof DateTime) {
         if (null !== $timezone) {
             $date = clone $date;
             $date->setTimezone($timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone));

--- a/test/Twig/Tests/Fixtures/filters/date.test
+++ b/test/Twig/Tests/Fixtures/filters/date.test
@@ -11,6 +11,7 @@
 {{ date2|date }}
 {{ date2|date('d/m/Y') }}
 {{ date2|date('d/m/Y H:i:s', 'Europe/Paris') }}
+{{ date2|date('d/m/Y H:i:s', timezone1) }}
 {{ date2|date('d/m/Y H:i:s') }}
 {{ date3|date }}
 {{ date3|date('d/m/Y') }}
@@ -31,6 +32,7 @@ return array(
     'date4' => 1286199900,
     'date5' => -86410,
     'date6' => new DateTime('2010-10-04 13:45', new DateTimeZone('America/New_York')),
+    'timezone1' => new DateTimeZone('America/New_York'),
 )
 --EXPECT--
 October 4, 2010 13:45
@@ -43,6 +45,7 @@ UTC
 October 4, 2010 13:45
 04/10/2010
 04/10/2010 15:45:00
+04/10/2010 09:45:00
 04/10/2010 13:45:00
 October 4, 2010 13:45
 04/10/2010

--- a/test/Twig/Tests/Fixtures/filters/date_interval.test
+++ b/test/Twig/Tests/Fixtures/filters/date_interval.test
@@ -3,14 +3,17 @@
 --CONDITION--
 version_compare(phpversion(), '5.3.0', '>=')
 --TEMPLATE--
-{{ date6|date }}
-{{ date6|date('%d days %h hours') }}
+{{ date1|date }}
+{{ date1|date('%d days %h hours') }}
+{{ date1|date('%d days %h hours', timezone1) }}
 --DATA--
 date_default_timezone_set('UTC');
 return array(
-    'date5' => -86410,
-    'date6' => new DateInterval('P2D'),
+    'date1' => new DateInterval('P2D'),
+    // This should have no effect on DateInterval formatting
+    'timezone1' => new DateTimeZone('America/New_York'),
 )
 --EXPECT--
 2 days
+2 days 0 hours
 2 days 0 hours


### PR DESCRIPTION
Edit: originally, I opened this to ensure the default Twig timezone was always set on incoming DateTime objects, but I came to realize why that behavior would be undesirable. The idea was prompted by this line from: http://twig.sensiolabs.org/doc/filters/date.html

> The default timezone can also be set globally by calling `setTimezone()`.

Anyway, I did notice an edge case where the code might call `DateInterval::setTimezone()`, so this PR attempts to correct that. Additionally, I added some tests for passing a DateTimeZone object to the `date` filter.
