### PR TITLE
Fixed a bug with sub-templates and strict variables

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -411,7 +411,11 @@ abstract class Twig_Template implements Twig_TemplateInterface
                 return null;
             }
 
-            throw new Twig_Error_Runtime(sprintf('Method "%s" for object "%s" does not exist', $item, get_class($object)));
+            if ($e instanceof Twig_Error_Runtime) {
+                throw $e;
+            } else {
+                throw new Twig_Error_Runtime(sprintf('Method "%s" for object "%s" does not exist', $item, get_class($object)));
+            }
         }
 
         if ($isDefinedTest) {


### PR DESCRIPTION
When you have a variable with a method that ends up initializing Twig for a sub-template, if an exception gets thrown in that sub template and Strict Variables is enabled, Twig_Template would catch that Twig_Error_Runtime exception and think that the problem was with the parent template's variable.

This fix allows the original Twig_Error_Runtime exception to get thrown.
