### PR TITLE
defined test bug fix

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -400,7 +400,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
             $method = 'get'.$item;
         } elseif (isset(self::$cache[$class]['methods']['is'.$lcItem])) {
             $method = 'is'.$item;
-        } elseif (isset(self::$cache[$class]['methods']['__call'])) {
+        } elseif (!$isDefinedTest && isset(self::$cache[$class]['methods']['__call'])) {
             $method = $item;
         } else {
             if ($isDefinedTest) {


### PR DESCRIPTION
If you have a variable set to an instance of a class with a __call() method, and you want to see if a property exists on that method, the 'defined' test would always return true. This fixes that bug.
