### PR TITLE
added the template_from_string function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.11.0 (2012-XX-XX)
 
+ * added the template_from_string function
  * optimized the way Twig exceptions are managed (to make them faster)
  * added Twig_ExistsLoaderInterface (implementing this interface in your loader make the chain loader much faster)
 

--- a/doc/functions/index.rst
+++ b/doc/functions/index.rst
@@ -13,3 +13,4 @@ Functions
     parent
     dump
     date
+    template_from_string

--- a/doc/functions/template_from_string.rst
+++ b/doc/functions/template_from_string.rst
@@ -1,0 +1,27 @@
+``template_from_string``
+========================
+
+.. versionadded:: 1.11
+    The template_from_string function was added in Twig 1.11.
+
+The ``template_from_string`` function loads a template from a string:
+
+.. code-block:: jinja
+
+    {% include template_from_string("Hello {{ name }}") }}
+    {% include template_from_string(page.template) }}
+
+.. note::
+
+    The ``template_from_string`` function is not available by default. You
+    must add the ``Twig_Extension_StringLoader`` extension explicitly when
+    creating your Twig environment::
+
+        $twig = new Twig_Environment(...);
+        $twig->addExtension(new Twig_Extension_StringLoader());
+
+.. note::
+
+    Even if you will probably always use the ``template_from_string`` function
+    with the ``include`` tag, you can use it with any tag or function that
+    takes a template as an argument (like the ``embed`` or ``extends`` tags).

--- a/lib/Twig/Extension/StringLoader.php
+++ b/lib/Twig/Extension/StringLoader.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2012 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class Twig_Extension_StringLoader extends Twig_Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+            'template_from_string' => new Twig_Function_Function('twig_template_from_string', array('needs_environment' => true)),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'string_loader';
+    }
+}
+
+/**
+ * Loads a template from a string.
+ *
+ * <pre>
+ * {% include template_from_string("Hello {{ name }}") }}
+ * </pre>
+ *
+ * @param Twig_Environment $env      A Twig_Environment instance
+ * @param string           $template A template as a string
+ *
+ * @return Twig_Template A Twig_Template instance
+ */
+function twig_template_from_string(Twig_Environment $env, $template)
+{
+    static $loader;
+
+    if (null === $loader) {
+        $loader = new Twig_Loader_String();
+    }
+
+    $current = $env->getLoader();
+    $env->setLoader($loader);
+    try {
+        $template = $env->loadTemplate($template);
+    } catch (Exception $e) {
+        $env->setLoader($current);
+
+        throw $e;
+    }
+    $env->setLoader($current);
+
+    return $template;
+}

--- a/test/Twig/Tests/Fixtures/functions/template_from_string.test
+++ b/test/Twig/Tests/Fixtures/functions/template_from_string.test
@@ -1,0 +1,11 @@
+--TEST--
+"template_from_string" function
+--TEMPLATE--
+{% include template_from_string(template) %}
+
+{% include template_from_string("Hello {{ name }}") %}
+--DATA--
+return array('name' => 'Fabien', 'template' => "Hello {{ name }}")
+--EXPECT--
+Hello Fabien
+Hello Fabien

--- a/test/Twig/Tests/IntegrationTest.php
+++ b/test/Twig/Tests/IntegrationTest.php
@@ -25,6 +25,7 @@ class Twig_Tests_IntegrationTest extends Twig_Test_IntegrationTestCase
         return array(
             new Twig_Extension_Debug(),
             new Twig_Extension_Sandbox($policy, false),
+            new Twig_Extension_StringLoader(),
             new TwigTestExtension(),
         );
     }


### PR DESCRIPTION
One of the most often asked question is how someone can evaluate a template string from a template.

The template_from_string function solves this problem (more in the included docs).

I have two questions before merging this:
- What about the name? I find it quite long but also readable (`{% include template_from_string(template) %}`).
- Does it belongs to Twig core?
