### PR TITLE
[template_from_string]Fixed typo in docs

### DIFF
--- a/doc/functions/template_from_string.rst
+++ b/doc/functions/template_from_string.rst
@@ -8,8 +8,8 @@ The ``template_from_string`` function loads a template from a string:
 
 .. code-block:: jinja
 
-    {% include template_from_string("Hello {{ name }}") }}
-    {% include template_from_string(page.template) }}
+    {% include template_from_string("Hello {{ name }}") %}
+    {% include template_from_string(page.template) %}
 
 .. note::
 


### PR DESCRIPTION
Fix a typo in the template_from_string function docs
