### PR TITLE
deprecated the token parser broker sub-system

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -1,0 +1,14 @@
+Deprecated Features
+===================
+
+This document lists all deprecated features in Twig 1.x. They are kept for
+backward compatibility but they will be removed in Twig 2.0.
+
+Token Parsers
+-------------
+
+* The token parser broker sub-system is deprecated; the following class and
+  interface will be removed in 2.0:
+
+  * ``Twig_TokenParserBrokerInterface``
+  * ``Twig_TokenParserBroker``

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,3 +15,4 @@ Twig
     filters/index
     functions/index
     tests/index
+    deprecated

--- a/lib/Twig/TokenParserBroker.php
+++ b/lib/Twig/TokenParserBroker.php
@@ -15,6 +15,8 @@
  *
  * @package twig
  * @author  Arnaud Le Blanc <arnaud.lb@gmail.com>
+ *
+ * @deprecated
  */
 class Twig_TokenParserBroker implements Twig_TokenParserBrokerInterface
 {

--- a/lib/Twig/TokenParserBrokerInterface.php
+++ b/lib/Twig/TokenParserBrokerInterface.php
@@ -17,6 +17,8 @@
  *
  * @package twig
  * @author  Arnaud Le Blanc <arnaud.lb@gmail.com>
+ *
+ * @deprecated
  */
 interface Twig_TokenParserBrokerInterface
 {


### PR DESCRIPTION
This is the first of a series of PRs where I want to deprecate some features that made sense at some point but do not anymore or features that are barely used. Deprecated features will still work in all versions of Twig 1.x but they will be removed in Twig 2.0.

This first one should not be controversial. The token parser broker was added at a time where functions in Twig were not available. Nowadays, creating a new tag is so rare that I cannot see any usage for the broker system.

As far as I know, nobody uses the broker system anyway (this feature is not even documented), except [Zwig](https://github.com/arnaud-lb/Zwig). And Zwig should probably create functions instead of tags for ZF helpers anyways.

ping @arnaud-lb
