### PR TITLE
simplified some code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.12.0 (2012-XX-XX)
 
+ * changed the way extension filters/tests/functions/node visitors/globals/token parsers are registered (they were loaded as late as possible, they are now loaded as early as possible)
  * added the ability to set default values for macro arguments
  * added support for named arguments for filters, tests, and functions
  * moved filters/functions/tests syntax errors to the parser

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -317,10 +317,7 @@ Twig comes bundled with the following extensions:
 * *Twig_Extension_Optimizer*: Optimizers the node tree before compilation.
 
 The core, escaper, and optimizer extensions do not need to be added to the
-Twig environment, as they are registered by default. You can disable an
-already registered extension::
-
-    $twig->removeExtension('escaper');
+Twig environment, as they are registered by default.
 
 Built-in Extensions
 -------------------

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -12,3 +12,9 @@ Token Parsers
 
   * ``Twig_TokenParserBrokerInterface``
   * ``Twig_TokenParserBroker``
+
+Extensions
+----------
+
+* The ability to remove an extension is deprecated and the
+  ``Twig_Environment::removeExtension()`` method will be removed in 2.0.

--- a/lib/Twig/TokenParserBroker.php
+++ b/lib/Twig/TokenParserBroker.php
@@ -57,6 +57,19 @@ class Twig_TokenParserBroker implements Twig_TokenParserBrokerInterface
     }
 
     /**
+     * Removes a TokenParser.
+     *
+     * @param Twig_TokenParserInterface $parser A Twig_TokenParserInterface instance
+     */
+    public function removeTokenParser(Twig_TokenParserInterface $parser)
+    {
+        $name = $parser->getTag();
+        if (isset($this->parsers[$name]) && $parser === $this->parsers[$name]) {
+            unset($this->parsers[$name]);
+        }
+    }
+
+    /**
      * Adds a TokenParserBroker.
      *
      * @param Twig_TokenParserBroker $broker A Twig_TokenParserBroker instance
@@ -64,6 +77,18 @@ class Twig_TokenParserBroker implements Twig_TokenParserBrokerInterface
     public function addTokenParserBroker(Twig_TokenParserBroker $broker)
     {
         $this->brokers[] = $broker;
+    }
+
+    /**
+     * Removes a TokenParserBroker.
+     *
+     * @param Twig_TokenParserBroker $broker A Twig_TokenParserBroker instance
+     */
+    public function removeTokenParserBroker(Twig_TokenParserBroker $broker)
+    {
+        if (false !== $pos = array_search($broker, $this->brokers)) {
+            unset($this->brokers[$pos]);
+        }
     }
 
     /**

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -32,4 +32,135 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
     {
         return $filename;
     }
+
+    public function testGlobalsAreSetEvenIfGetGlobalsIsCalledFirst()
+    {
+        $twig = new Twig_Environment(new Twig_Loader_String());
+
+        $globals = $twig->getGlobals();
+        $twig->addGlobal('foo', 'foo');
+        $globals = $twig->getGlobals();
+
+        $this->assertArrayHasKey('foo', $globals);
+    }
+
+    public function testAddExtension()
+    {
+        $twig = new Twig_Environment(new Twig_Loader_String());
+        $twig->addExtension(new Twig_Tests_EnvironmentTest_Extension());
+
+        $this->assertArrayHasKey('test', $twig->getTags());
+        $this->assertArrayHasKey('foo_filter', $twig->getFilters());
+        $this->assertArrayHasKey('foo_function', $twig->getFunctions());
+        $this->assertArrayHasKey('foo_test', $twig->getTests());
+        $this->assertArrayHasKey('foo_unary', $twig->getUnaryOperators());
+        $this->assertArrayHasKey('foo_binary', $twig->getBinaryOperators());
+        $this->assertArrayHasKey('foo_global', $twig->getGlobals());
+        $visitors = $twig->getNodeVisitors();
+        $this->assertEquals('Twig_Tests_EnvironmentTest_NodeVisitor', get_class($visitors[2]));
+    }
+
+    public function testRemoveExtension()
+    {
+        $twig = new Twig_Environment(new Twig_Loader_String());
+        $twig->addExtension(new Twig_Tests_EnvironmentTest_Extension());
+        $twig->removeExtension('test');
+
+        $this->assertFalse(array_key_exists('test', $twig->getTags()));
+        $this->assertFalse(array_key_exists('foo_filter', $twig->getFilters()));
+        $this->assertFalse(array_key_exists('foo_function', $twig->getFunctions()));
+        $this->assertFalse(array_key_exists('foo_test', $twig->getTests()));
+        $this->assertFalse(array_key_exists('foo_unary', $twig->getUnaryOperators()));
+        $this->assertFalse(array_key_exists('foo_binary', $twig->getBinaryOperators()));
+        $this->assertFalse(array_key_exists('foo_global', $twig->getGlobals()));
+        $this->assertCount(2, $twig->getNodeVisitors());
+    }
+}
+
+class Twig_Tests_EnvironmentTest_Extension extends Twig_Extension
+{
+    public function getTokenParsers()
+    {
+        return array(
+            new Twig_Tests_EnvironmentTest_TokenParser(),
+        );
+    }
+
+    public function getNodeVisitors()
+    {
+        return array(
+            new Twig_Tests_EnvironmentTest_NodeVisitor(),
+        );
+    }
+
+    public function getFilters()
+    {
+        return array(
+            'foo_filter' => new Twig_Filter_Function('foo_filter'),
+        );
+    }
+
+    public function getTests()
+    {
+        return array(
+            'foo_test' => new Twig_Test_Function('foo_test'),
+        );
+    }
+
+    public function getFunctions()
+    {
+        return array(
+            'foo_function' => new Twig_Function_Function('foo_function'),
+        );
+    }
+
+    public function getOperators()
+    {
+        return array(
+            array('foo_unary' => array()),
+            array('foo_binary' => array()),
+        );
+    }
+
+    public function getGlobals()
+    {
+        return array(
+            'foo_global' => 'foo_global',
+        );
+    }
+
+    public function getName()
+    {
+        return 'test';
+    }
+}
+
+class Twig_Tests_EnvironmentTest_TokenParser extends Twig_TokenParser
+{
+    public function parse(Twig_Token $token)
+    {
+    }
+
+    public function getTag()
+    {
+        return 'test';
+    }
+}
+
+class Twig_Tests_EnvironmentTest_NodeVisitor implements Twig_NodeVisitorInterface
+{
+    public function enterNode(Twig_NodeInterface $node, Twig_Environment $env)
+    {
+        return $node;
+    }
+
+    public function leaveNode(Twig_NodeInterface $node, Twig_Environment $env)
+    {
+        return $node;
+    }
+
+    public function getPriority()
+    {
+        return 0;
+    }
 }

--- a/test/Twig/Tests/NodeVisitor/OptimizerTest.php
+++ b/test/Twig/Tests/NodeVisitor/OptimizerTest.php
@@ -13,7 +13,6 @@ class Twig_Tests_NodeVisitor_OptimizerTest extends PHPUnit_Framework_TestCase
     public function testRenderBlockOptimizer()
     {
         $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
-        $env->addExtension(new Twig_Extension_Optimizer());
 
         $stream = $env->parse($env->tokenize('{{ block("foo") }}', 'index'));
 
@@ -26,7 +25,6 @@ class Twig_Tests_NodeVisitor_OptimizerTest extends PHPUnit_Framework_TestCase
     public function testRenderParentBlockOptimizer()
     {
         $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
-        $env->addExtension(new Twig_Extension_Optimizer());
 
         $stream = $env->parse($env->tokenize('{% extends "foo" %}{% block content %}{{ parent() }}{% endblock %}', 'index'));
 
@@ -43,7 +41,6 @@ class Twig_Tests_NodeVisitor_OptimizerTest extends PHPUnit_Framework_TestCase
         }
 
         $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
-        $env->addExtension(new Twig_Extension_Optimizer());
         $stream = $env->parse($env->tokenize('{{ block(name|lower) }}', 'index'));
 
         $node = $stream->getNode('body')->getNode(0)->getNode(1);
@@ -58,7 +55,6 @@ class Twig_Tests_NodeVisitor_OptimizerTest extends PHPUnit_Framework_TestCase
     public function testForOptimizer($template, $expected)
     {
         $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false));
-        $env->addExtension(new Twig_Extension_Optimizer());
 
         $stream = $env->parse($env->tokenize($template, 'index'));
 


### PR DESCRIPTION
This PR changes the way extension filters/tests/functions/node visitors/globals/token parsers are registered (they were loaded as late as possible, they are now loaded as early as possible)

It mainly consists of a code cleanup by removing the horrible staging hack we have now.
