### PR TITLE
Fixed a typo in the 'escape' filter documentation.

### DIFF
--- a/doc/filters/escape.rst
+++ b/doc/filters/escape.rst
@@ -74,7 +74,7 @@ The ``escape`` filter supports the following escaping strategies:
         {% endautoescape %}
 
     When using a variable as the escaping strategy, you should disable
-    automatic escaping::
+    automatic escaping:
 
     .. code-block:: jinja
 


### PR DESCRIPTION
This typo prevents the proper rendering of one code block.
