### PR TITLE
[RFC] Support foo.some_thing === foo.someThing

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -405,12 +405,20 @@ abstract class Twig_Template implements Twig_TemplateInterface
         }
 
         $lcItem = strtolower($item);
+        $deunderscoreItem = str_replace('_', '', $lcItem);
+        $checkDecamelItem = $lcItem !== $deunderscoreItem;
         if (isset(self::$cache[$class]['methods'][$lcItem])) {
             $method = $item;
         } elseif (isset(self::$cache[$class]['methods']['get'.$lcItem])) {
             $method = 'get'.$item;
         } elseif (isset(self::$cache[$class]['methods']['is'.$lcItem])) {
             $method = 'is'.$item;
+        } elseif ($checkDecamelItem && isset(self::$cache[$class]['methods'][$deunderscoreItem])) {
+            $method = $deunderscoreItem;
+        } elseif ($checkDecamelItem && isset(self::$cache[$class]['methods']['get'.$deunderscoreItem])) {
+            $method = 'get'.$deunderscoreItem;
+        } elseif ($checkDecamelItem && isset(self::$cache[$class]['methods']['is'.$deunderscoreItem])) {
+            $method = 'is'.$deunderscoreItem;
         } elseif (isset(self::$cache[$class]['methods']['__call'])) {
             $method = $item;
         } else {

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -289,6 +289,15 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
             array(false, null, $methodAndPropObject, 'c', array(), $methodType),
             array(false, null, $methodAndPropObject, 'c', array(), $arrayType),
 
+            array(true, 'camelcase', $methodAndPropObject, 'camelcase', array(), $anyType),
+            array(true, 'camelcase', $methodAndPropObject, 'camelcase', array(), $methodType),
+
+            array(true, 'camelcase', $methodAndPropObject, 'camelCase', array(), $anyType),
+            array(true, 'camelcase', $methodAndPropObject, 'camelCase', array(), $methodType),
+
+            array(true, 'camelcase', $methodAndPropObject, 'camel_case', array(), $anyType),
+            array(true, 'camelcase', $methodAndPropObject, 'camel_case', array(), $methodType),
+            array(false, null, $methodAndPropObject, 'a', array(), $arrayType),
         ));
 
         // tests when input is not an array or object
@@ -522,6 +531,12 @@ class Twig_TemplateMethodAndPropObject
     private function getC()
     {
         return 'c';
+    }
+
+    private $camelCase = 'camelcase_prop';
+    public function getCamelCase()
+    {
+        return 'camelcase';
     }
 }
 


### PR DESCRIPTION
I want to be able to support all underscores in my Twig templates. Most of my data in one of my projects comes from YAML files that are usually formatted `like_this` so it is a little jarring when in my template I need to mix with `someMethod` on an object:

    paginated_items.theFirstItem.some_description

This PR allows for mapping `the_first_item` to `theFirstItem`.

    paginated_items.the_first_item.some_description

I started a simple implementation of this. Happy to change it if there is a better way to go about it. I understand speed is a factor here so ideas on how I can minimize impact would be helpful.

The testing is pretty complicated. I did the bes tI could to try and figure out how to test this. Suggestions on how I can do that better would be helpful as well.