### PR TITLE
Add accessor to loaded templates to Environment

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -1150,4 +1150,12 @@ class Twig_Environment
 
         throw new RuntimeException(sprintf('Failed to write cache file "%s".', $file));
     }
+
+    /**
+     * @return array
+     */
+    public function getLoadedTemplates()
+    {
+        return $this->loadedTemplates;
+    }
 }


### PR DESCRIPTION
I needed to access loaded template to add a way to know wich template has been compiled and where to find it in the Symfony profiler.

It may exists a better way to do this, I opened a thread in the mailing list: https://groups.google.com/d/topic/twig-users/8FccpmNsbNg/discussion
