### PR TITLE
Update lib/Twig/Autoloader.php

### DIFF
--- a/lib/Twig/Autoloader.php
+++ b/lib/Twig/Autoloader.php
@@ -19,11 +19,15 @@ class Twig_Autoloader
 {
     /**
      * Registers Twig_Autoloader as an SPL autoloader.
+     * 
+     * @param boolean $prepend (optional) Whether to add the autoloader to
+     * the start of the stack. Defaults to false so the autoloader will be
+     * appended to the stack.
      */
-    public static function register()
+    public static function register($prepend = false)
     {
         ini_set('unserialize_callback_func', 'spl_autoload_call');
-        spl_autoload_register(array(new self, 'autoload'));
+        spl_autoload_register(array(new self, 'autoload'), true, $prepend);
     }
 
     /**


### PR DESCRIPTION
Added the ability to register the autoloader at the top of the stack, useful in some situations.

Specifically, I need this because I want the last autoload function registered in my application to throw an exception instead of producing a class not found error, and I need _that_ autoloader to be registered before twig's.
