### PR TITLE
Force timezone setting in date filter

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -473,7 +473,9 @@ function twig_date_converter(Twig_Environment $env, $date = null, $timezone = nu
         return $date;
     }
 
-    return new DateTime($date, $defaultTimezone);
+    $date = new DateTime($date, $defaultTimezone);
+    $date->setTimezone($defaultTimezone);
+    return $date;
 }
 
 /**


### PR DESCRIPTION
In instances where the $time parameter to the DateTime ctor includes a timezone, the $timezone argument is ignored. This functionality extends to the date filter.

http://uk3.php.net/manual/en/datetime.construct.php

"The $timezone parameter and the current timezone are ignored when the $time parameter either is a UNIX timestamp (e.g. @946684800) or specifies a timezone (e.g. 2010-01-28T15:00:00+02:00)."

Accepting this pull request is dependent on whether the desired functionality of the date filter should honour the PHP way of doing things, or the more logical and natural functionality anticipated by a Twig template designer; always ensuring the timezone passed into the date filter is applied.
