### PR TITLE
Bug when calling getGlobals() before addGlobal() on Twig_Environment.

### DIFF
--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -81,6 +81,12 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $globals = $twig->getGlobals();
         $this->assertEquals('bar', $globals['foo']);
 
+        $twig = new Twig_Environment(new Twig_Loader_String());
+        $twig->getGlobals();
+        $twig->addGlobal('foo', 'bar');
+        $template = $twig->loadTemplate('{{foo}}');
+        $this->assertEquals('bar', $template->render(array()));
+
         /* to be uncomment in Twig 2.0
         // globals cannot be added after runtime init
         $twig = new Twig_Environment(new Twig_Loader_String());


### PR DESCRIPTION
There seems to be an issue when calling getGlobals() before addGlobal(), the globals wont get updated. It doesn't seem to matter if the global existed before the call to getGlobals(). An update of the globals can be forced by calling an additional getGlobals() after the addGlobal() call.

I believe the problem has something to do with runtimeInitialized/extensionInitialized being set to true during rendering, but globals don't get updated during that phase.

Not sure how to fix it so I'm just sending you a unit test showcasing the bug.
