### PR TITLE
Use umask for mkdir too in lib/Twig/Environment.php

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -1196,7 +1196,7 @@ class Twig_Environment
     {
         $dir = dirname($file);
         if (!is_dir($dir)) {
-            if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
+            if (false === @mkdir($dir, 0777 & ~umask(), true) && !is_dir($dir)) {
                 throw new RuntimeException(sprintf("Unable to create the cache directory (%s).", $dir));
             }
         } elseif (!is_writable($dir)) {


### PR DESCRIPTION
Should writeCacheFile respect umask settings on mkdir similar as chmod?

On reviewing a Drupal permissions problem I checked twig implementation. Is doesn't seem right to omit the umask for mkdir.

Or am I missing something?
