### PR TITLE
Add "chunk" to core extensions

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -152,6 +152,7 @@ class Twig_Extension_Core extends Twig_Extension
             new Twig_SimpleFilter('split', 'twig_split_filter'),
             new Twig_SimpleFilter('sort', 'twig_sort_filter'),
             new Twig_SimpleFilter('merge', 'twig_array_merge'),
+            new Twig_SimpleFilter('chunk', 'array_chunk'),
 
             // string/array filters
             new Twig_SimpleFilter('reverse', 'twig_reverse_filter', array('needs_environment' => true)),


### PR DESCRIPTION
This update aims to facilitate the grid layout creation using arrays/collections.
### Example:

**data**:

``` jinja
{% set images = [
    'img1.jpg', 'img2.jpg', 'img3.jpg',
    'img4.jpg', 'img5.jpg', 'img6.jpg',
    'img7.jpg', 'img8.jpg', 'img9.jpg',
] %}
```

**before _chunk_:**

``` jinja
<div class=row>
    {% for image in images %}
        <img src={{ image }}>

        {# note the weird indentation #}
        {% if loop.index is divisibleby(3) %}
        </div>
        <div class=row>
        {% endif %}
    {% endfor %}
</div>
```

**after _chunk_:**

``` jinja
{% for images_row in images|chunk(3) %}
    <div class=row>
        {% for image in images_row %}
            <img src={{ image }}>
        {% endfor %}
    </div>
{% endfor %}
```
