### PR TITLE
[2.0] removed parameter from url_encode filter and use rawurlencode() by default

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -518,17 +518,12 @@ function twig_number_format_filter(Twig_Environment $env, $number, $decimal = nu
  * URL encodes a string.
  *
  * @param string $url A URL
- * @param bool   $raw true to use rawurlencode() instead of urlencode
  *
  * @return string The URL encoded value
  */
-function twig_urlencode_filter($url, $raw = false)
+function twig_urlencode_filter($url)
 {
-    if ($raw) {
-        return rawurlencode($url);
-    }
-
-    return urlencode($url);
+    return rawurlencode($url);
 }
 
 if (version_compare(PHP_VERSION, '5.3.0', '<')) {


### PR DESCRIPTION
Bc break: yes

This parameter was not documented in the /docs. But should maybe only be merged for 2.0 because of the tiny bc break.

The filter now only uses the more appropriate rawurlencode() which is also more consistent with the escape('url') filter.
