### PR TITLE
Ceil the size in batch filter

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1324,6 +1324,8 @@ function twig_array_batch($items, $size, $fill = null)
         $items = iterator_to_array($items, false);
     }
 
+    $size = ceil($size);
+
     $result = array_chunk($items, $size, true);
 
     if (null !== $fill) {

--- a/test/Twig/Tests/Fixtures/filters/batch.test
+++ b/test/Twig/Tests/Fixtures/filters/batch.test
@@ -10,9 +10,42 @@
   </tr>
 {% endfor %}
 </table>
+
+<table>
+{% for row in items|batch(2.1, '') %}
+  <tr>
+  {% for column in row %}
+    <td>{{ column }}</td>
+  {% endfor %}
+  </tr>
+{% endfor %}
+</table>
 --DATA--
 return array('items' => array('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'))
 --EXPECT--
+<table>
+  <tr>
+      <td>a</td>
+      <td>b</td>
+      <td>c</td>
+    </tr>
+  <tr>
+      <td>d</td>
+      <td>e</td>
+      <td>f</td>
+    </tr>
+  <tr>
+      <td>g</td>
+      <td>h</td>
+      <td>i</td>
+    </tr>
+  <tr>
+      <td>j</td>
+      <td></td>
+      <td></td>
+    </tr>
+</table>
+
 <table>
   <tr>
       <td>a</td>


### PR DESCRIPTION
Something, we want to batch in only two groups:

```
{% for projects in items|batch((items|length)/2) %}
```

So the value can be a float.
