### PR TITLE
Added "normalize_whitespace" filter

### DIFF
--- a/doc/filters/index.rst
+++ b/doc/filters/index.rst
@@ -30,6 +30,7 @@ Filters
     round
     slice
     sort
+    spaceless
     split
     striptags
     title

--- a/doc/filters/index.rst
+++ b/doc/filters/index.rst
@@ -22,6 +22,7 @@ Filters
     lower
     merge
     nl2br
+    normalize_whitespace
     number_format
     raw
     replace

--- a/doc/filters/normalize_whitespace.rst
+++ b/doc/filters/normalize_whitespace.rst
@@ -1,0 +1,27 @@
+``normalize_whitespace``
+========
+
+.. versionadded:: 1.25.1
+    The normalize_whitespace filter was added in Twig 1.25.1.
+
+The ``normalize_whitespace`` filter replaces duplicated spaces and/or linebreaks with single space. It also remove whitespace from the beginning
+and end of a string:
+
+.. code-block:: jinja
+
+    {# <title> generation #}
+    {% block title %}
+        {%- filter normalize_whitespace %}
+            {% if foo %}
+                {{ foo.title }}
+                {% if bar %}
+                    / {{ bar.title }}
+                {% endif %}
+                /
+            {% endif %}
+
+            {{ baz }} / {{ parent() }}
+        {% endfilter -%}
+    {% endblock %}
+
+    {# outputs something like 'foo.title / bar.title / baz / parent' #}

--- a/doc/filters/spaceless.rst
+++ b/doc/filters/spaceless.rst
@@ -1,0 +1,40 @@
+``spaceless``
+========
+
+.. versionadded:: 1.25.1
+    The spaceless filter was added in Twig 1.25.1.
+
+The ``spaceless`` filter removes whitespace *between HTML tags*, not
+whitespace within HTML tags or whitespace in plain text:
+
+.. code-block:: jinja
+
+    {% filter spaceless %}
+        <div>
+            <strong>foo</strong>
+        </div>
+    {% endspaceless %}
+
+    {# output will be <div><strong>foo</strong></div> #}
+
+This filter is not meant to "optimize" the size of the generated HTML content but
+merely to avoid extra whitespace between HTML tags to avoid browser rendering
+quirks under some circumstances.
+
+.. tip::
+
+    If you want to optimize the size of the generated HTML content, gzip
+    compress the output instead.
+
+.. tip::
+
+    If you want to create a tag that actually removes all extra whitespace in
+    an HTML string, be warned that this is not as easy as it seems to be
+    (think of ``textarea`` or ``pre`` tags for instance). Using a third-party
+    library like Tidy is probably a better idea.
+
+.. tip::
+
+    For more information on whitespace control, read the
+    :ref:`dedicated section <templates-whitespace-control>` of the documentation and learn how
+    you can also use the whitespace control modifier on your tags.

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -160,6 +160,7 @@ class Twig_Extension_Core extends Twig_Extension
             new Twig_SimpleFilter('striptags', 'strip_tags'),
             new Twig_SimpleFilter('trim', 'trim'),
             new Twig_SimpleFilter('nl2br', 'nl2br', array('pre_escape' => 'html', 'is_safe' => array('html'))),
+            new Twig_SimpleFilter('normalize_whitespace', 'twig_normalize_whitespace_filter', array('preserves_safety' => array('html'))),
 
             // array helpers
             new Twig_SimpleFilter('join', 'twig_join_filter'),
@@ -1374,6 +1375,18 @@ else {
     {
         return ucfirst(strtolower($string));
     }
+}
+
+/**
+ * Replaces duplicated spaces and/or linebreaks with single space.
+ *
+ * @param string $string A string
+ *
+ * @return string The normalized string
+ */
+function twig_normalize_whitespace_filter($string)
+{
+    return trim(preg_replace('/\s+/u', ' ', $string));
 }
 
 /**

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -160,7 +160,7 @@ class Twig_Extension_Core extends Twig_Extension
             new Twig_SimpleFilter('striptags', 'strip_tags'),
             new Twig_SimpleFilter('trim', 'trim'),
             new Twig_SimpleFilter('nl2br', 'nl2br', array('pre_escape' => 'html', 'is_safe' => array('html'))),
-            new Twig_SimpleFilter('spaceless', 'twig_spaceless_filter', array('preserves_safety' => array('html'))),
+            new Twig_SimpleFilter('spaceless', 'twig_spaceless_filter', array('is_safe' => array('html'))),
             new Twig_SimpleFilter('normalize_whitespace', 'twig_normalize_whitespace_filter', array('preserves_safety' => array('html'))),
 
             // array helpers

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -160,6 +160,7 @@ class Twig_Extension_Core extends Twig_Extension
             new Twig_SimpleFilter('striptags', 'strip_tags'),
             new Twig_SimpleFilter('trim', 'trim'),
             new Twig_SimpleFilter('nl2br', 'nl2br', array('pre_escape' => 'html', 'is_safe' => array('html'))),
+            new Twig_SimpleFilter('spaceless', 'twig_spaceless_filter', array('preserves_safety' => array('html'))),
             new Twig_SimpleFilter('normalize_whitespace', 'twig_normalize_whitespace_filter', array('preserves_safety' => array('html'))),
 
             // array helpers
@@ -1387,6 +1388,18 @@ else {
 function twig_normalize_whitespace_filter($string)
 {
     return trim(preg_replace('/\s+/u', ' ', $string));
+}
+
+/**
+ * Remove whitespaces between HTML tags.
+ *
+ * @param string $string A string
+ *
+ * @return string The normalized string
+ */
+function twig_spaceless_filter($string)
+{
+    return trim(preg_replace('/>\s+</', '><', $string));
 }
 
 /**

--- a/test/Twig/Tests/Fixtures/filters/normalize_whitespace.test
+++ b/test/Twig/Tests/Fixtures/filters/normalize_whitespace.test
@@ -1,0 +1,13 @@
+--TEST--
+"normalize_whitespace" filter
+--TEMPLATE--
+{% filter normalize_whitespace %}
+  {{ a }}
+		b
+c & &mdash;  {{ d }}
+e {{ amp }}
+{% endfilter %}
+--DATA--
+return array('a' => 'a', 'd' => ' д		', 'amp' => '&')
+--EXPECT--
+a b c & &mdash; д e &amp;

--- a/test/Twig/Tests/Fixtures/filters/normalize_whitespace_html.test
+++ b/test/Twig/Tests/Fixtures/filters/normalize_whitespace_html.test
@@ -1,0 +1,15 @@
+--TEST--
+"normalize_whitespace" filter with html
+--TEMPLATE--
+{% filter normalize_whitespace %}
+<table
+  for="for"
+  javascript="javascript"
+  frameworks="framework"
+  like="like"
+  angular="angular">
+{% endfilter %}
+--DATA--
+return array()
+--EXPECT--
+<table for="for" javascript="javascript" frameworks="framework" like="like" angular="angular">

--- a/test/Twig/Tests/Fixtures/filters/spaceless_html.test
+++ b/test/Twig/Tests/Fixtures/filters/spaceless_html.test
@@ -1,0 +1,12 @@
+--TEST--
+"spaceless" filter with html
+--TEMPLATE--
+{% filter spaceless %}
+<div>
+    <strong>foo</strong>
+</div>
+{% endfilter %}
+--DATA--
+return array()
+--EXPECT--
+<div><strong>foo</strong></div>

--- a/test/Twig/Tests/Fixtures/filters/spacelessl.test
+++ b/test/Twig/Tests/Fixtures/filters/spacelessl.test
@@ -1,0 +1,8 @@
+--TEST--
+"spaceless" filter with html inside variable
+--TEMPLATE--
+{{ html|spaceless }}
+--DATA--
+return array('html' => '<div>     <strong>foo</strong>  </div>')
+--EXPECT--
+<div><strong>foo</strong></div>


### PR DESCRIPTION
Fixed tickets: #1003

Use case:

``` jinja
{# <title> generation #}
{% block title %}
    {%- filter normalize_whitespace %}
        {% if foo %}
            {{ foo.title }}
            {% if bar %}
                / {{ bar.title }}
            {% endif %}
            /
        {% endif %}

        {{ baz }} / {{ parent() }}
    {% endfilter -%}
{% endblock %}
```

TODO:
- [x] add documentation if this PR can be accepted
- [ ] consider adding "spaceless" filter (IMHO actually it is filter, not tag)
