### PR TITLE
Adding a section about the slice filter to doc/tags/for.rst

### DIFF
--- a/doc/tags/for.rst
+++ b/doc/tags/for.rst
@@ -159,7 +159,7 @@ You can also access both keys and values:
 Iterating over Subset
 ---------------------
 
-You might want to iterate over a subset of values. This can be achieved using the ``slice`` filter:
+You might want to iterate over a subset of values. This can be achieved using the :doc:`slice<../filters/slice>` filter:
 
 .. code-block:: jinja
 


### PR DESCRIPTION
This code example shows how to loop over a subset of values in order to implement one common use-case of "break" in PHP. I decided to use the "full" notation of slice rather than the sugared version (that example would just be "for user in users[:10]")
