### PR TITLE
[RFC] Add shuffle filter for Twig

### DIFF
--- a/doc/filters/index.rst
+++ b/doc/filters/index.rst
@@ -27,6 +27,7 @@ Filters
     raw
     replace
     reverse
+    shuffle
     slice
     sort
     split

--- a/doc/filters/shuffle.rst
+++ b/doc/filters/shuffle.rst
@@ -1,0 +1,10 @@
+``shuffle``
+===========
+
+The ``shuffle`` filter shuffles an array:
+
+.. code-block:: jinja
+
+    {% for user in users|shuffle %}
+        ...
+    {% endfor %}

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -151,6 +151,7 @@ class Twig_Extension_Core extends Twig_Extension
             new Twig_SimpleFilter('join', 'twig_join_filter'),
             new Twig_SimpleFilter('split', 'twig_split_filter'),
             new Twig_SimpleFilter('sort', 'twig_sort_filter'),
+            new Twig_SimpleFilter('shuffle', 'twig_shuffle_filter'),
             new Twig_SimpleFilter('merge', 'twig_array_merge'),
             new Twig_SimpleFilter('batch', 'twig_array_batch'),
 
@@ -1341,4 +1342,21 @@ function twig_array_batch($items, $size, $fill = null)
     }
 
     return $result;
+}
+
+/**
+ * Shuffles an array.
+ *
+ * @param array|Traversable $array An array
+ * @return array
+ */
+function twig_shuffle_filter($array)
+{
+    if ($array instanceof Traversable) {
+        $array = iterator_to_array($array, false);
+    }
+
+    shuffle($array);
+
+    return $array;
 }

--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -112,4 +112,37 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($output, 'éÄ');
     }
+
+    /**
+     * @dataProvider getShuffleFilterTestData
+     */
+    public function testShuffleFilter($data, $expectedElements)
+    {
+        foreach ($expectedElements as $element) {
+            $this->assertTrue(in_array($element, twig_shuffle_filter($data), true)); // assertContains() would not consider the type
+        }
+    }
+
+    public function testShuffleFilterOnEmptyArray()
+    {
+        $this->assertEquals(array(), twig_shuffle_filter(array()));
+    }
+
+    public function getShuffleFilterTestData()
+    {
+        return array(
+            array(
+                array(1, 2, 3),
+                array(1, 2, 3)
+            ),
+            array(
+                array('a' => 'apple', 'b' => 'orange', 'c' => 'citrus'),
+                array('apple', 'orange', 'citrus'),
+            ),
+            array(
+                new ArrayObject(array('apple', 'orange', 'citrus')),
+                array('apple', 'orange', 'citrus'),
+            ),
+        );
+    }
 }

--- a/test/Twig/Tests/Fixtures/filters/shuffle.test
+++ b/test/Twig/Tests/Fixtures/filters/shuffle.test
@@ -1,0 +1,21 @@
+--TEST--
+"shuffle" filter
+--TEMPLATE--
+{% for elem in array1 | shuffle %}
+    {{ elem }}
+{% else %}
+No elems in array1
+{% endfor %}
+
+{% for elem in array2 | shuffle %}
+    {{- elem -}}
+{% endfor %}
+--DATA--
+return array('array1' => array(), 'array2' => array('foo'))
+--EXPECT--
+No elems in array1
+
+foo
+
+
+


### PR DESCRIPTION
This is related to an issue I opened some days ago regarding the possibility to have such filter at https://github.com/fabpot/Twig/issues/1035

There are quite a bunch use cases for it, but I don't know if you will consider to add it to core.

As it has been quite easy to implement, I have decided to send a PR with it, no worries if you find it to be rejected.

Thinks missing if accepted:
- Add a note in which Twig version this would be added

Waiting for your comments
