### PR TITLE
Minor typo in sort filter documentation

### DIFF
--- a/doc/filters/sort.rst
+++ b/doc/filters/sort.rst
@@ -5,7 +5,7 @@ The ``sort`` filter sorts an array:
 
 .. code-block:: jinja
 
-    {% for use in users|sort %}
+    {% for user in users|sort %}
         ...
     {% endfor %}
 


### PR DESCRIPTION
I've found this small typo while working on shuffle filter documentation in https://github.com/fabpot/Twig/pull/1038

I decided to create separate PR in case https://github.com/fabpot/Twig/pull/1038 got rejected

Best regards!
