### PR TITLE
Registration a Twig_SimpleFunction after extensions initialized throw not LogicException, but Fatal Error

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -756,10 +756,6 @@ class Twig_Environment
      */
     public function addFilter($name, $filter = null)
     {
-        if ($this->extensionInitialized) {
-            throw new LogicException(sprintf('Unable to add filter "%s" as extensions have already been initialized.', $name));
-        }
-
         if (!$name instanceof Twig_SimpleFilter && !($filter instanceof Twig_SimpleFilter || $filter instanceof Twig_FilterInterface)) {
             throw new LogicException('A filter must be an instance of Twig_FilterInterface or Twig_SimpleFilter');
         }
@@ -768,7 +764,11 @@ class Twig_Environment
             $filter = $name;
             $name = $filter->getName();
         }
-
+        
+        if ($this->extensionInitialized) {
+            throw new LogicException(sprintf('Unable to add filter "%s" as extensions have already been initialized.', $name));
+        }
+        
         $this->staging->addFilter($name, $filter);
     }
 
@@ -845,10 +845,6 @@ class Twig_Environment
      */
     public function addTest($name, $test = null)
     {
-        if ($this->extensionInitialized) {
-            throw new LogicException(sprintf('Unable to add test "%s" as extensions have already been initialized.', $name));
-        }
-
         if (!$name instanceof Twig_SimpleTest && !($test instanceof Twig_SimpleTest || $test instanceof Twig_TestInterface)) {
             throw new LogicException('A test must be an instance of Twig_TestInterface or Twig_SimpleTest');
         }
@@ -856,6 +852,10 @@ class Twig_Environment
         if ($name instanceof Twig_SimpleTest) {
             $test = $name;
             $name = $test->getName();
+        }
+        
+        if ($this->extensionInitialized) {
+            throw new LogicException(sprintf('Unable to add test "%s" as extensions have already been initialized.', $name));
         }
 
         $this->staging->addTest($name, $test);


### PR DESCRIPTION
Registration a Twig_SimpleFunction after extensions initialized throw not LogicException, but Fatal Error:

$environment->addFunction(new Twig_SimpleFunction(...))
after 
$environment->render(...)
throws Fatal Error: 
object of Twig_SimpleFunction could not be converted to string
