### PR TITLE
[WIP] added getting the current element key

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -655,16 +655,17 @@ function twig_first(Twig_Environment $env, $item)
 /**
  * Returns the last element of the item.
  *
- * @param Twig_Environment $env  A Twig_Environment instance
- * @param mixed            $item A variable
+ * @param Twig_Environment $env    A Twig_Environment instance
+ * @param mixed            $item   A variable
+ * @param Boolean          $getKey Gets the key instead of the value
  *
  * @return mixed The last element of the item
  */
-function twig_last(Twig_Environment $env, $item)
+function twig_last(Twig_Environment $env, $item, $getKey = false)
 {
     $elements = twig_slice($env, $item, -1, 1, false);
 
-    return is_string($elements) ? $elements[0] : current($elements);
+    return is_string($elements) ? $elements[0] : ($getKey ? key($elements) : current($elements));
 }
 
 /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |

Todo.
- [ ] update documentation
- [ ] add tests
- [ ] add the same functionality for 'first' filter

This allows getting the last array key instead of only the value.
And yes I know its possible to just use [..]|keys|last but this is more clean.
