### PR TITLE
Adding YAML frontmatter support to the lexer and parser

### DIFF
--- a/lib/Twig/Node/Yaml.php
+++ b/lib/Twig/Node/Yaml.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ * (c) 2009 Armin Ronacher
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Represents a text node.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Twig_Node_Yaml extends Twig_Node
+{
+    public function compile(Twig_Compiler $compiler)
+      {
+        $compiler
+          ->addDebugInfo($this)
+          ->write('$context = array_merge($context, ')
+          ->repr($this->getAttribute('frontmatter'))
+          ->raw(');'."\n")
+        ;
+      }
+}

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -194,6 +194,13 @@ class Twig_Parser implements Twig_ParserInterface
                     }
                     break;
 
+                case Twig_Token::YAML_TYPE:
+                    $yaml = $this->getCurrentToken()->getValue();
+                    $frontmatter = \Symfony\Component\Yaml\Yaml::parse($yaml);
+                    $this->stream->next();
+                    $rv[] = new \Twig_Node_Yaml(array(), array('frontmatter' => $frontmatter), $this->getCurrentToken()->getLine());
+                    break;
+
                 default:
                     throw new Twig_Error_Syntax('Lexer or parser ended up in unsupported state.', 0, $this->getFilename());
             }

--- a/lib/Twig/Token.php
+++ b/lib/Twig/Token.php
@@ -34,6 +34,7 @@ class Twig_Token
     const PUNCTUATION_TYPE          = 9;
     const INTERPOLATION_START_TYPE  = 10;
     const INTERPOLATION_END_TYPE    = 11;
+    const YAML_TYPE                 = 56;
 
     /**
      * Constructor.


### PR DESCRIPTION
I'm not really expecting this to make it into the core as is. I wanted to highlight some of the areas that I'd love to see some extensibility though. Right now there's no way to add in additional language constructs outside of the default tag delimiters: {#, {%, {{, #{. It'd be great if there was some way to augment this list with additional delimiters providing a means to add in things like YAML frontmatter.

This addition feels more like an extension to me, but I don't see any way to implement it as an extension within the current codebase.
