### PR TITLE
Prevent extensions from clobbering all globals.

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -1100,9 +1100,10 @@ class Twig_Environment
         $globals = array();
         foreach ($this->extensions as $extension) {
             $extGlob = $extension->getGlobals();
-            if(!is_array($extGlob)){
-                throw new UnexpectedValueException(sprintf('"%s::getGlobals()" does not return a valid globals array.', get_class($extension)));
+            if (!is_array($extGlob)) {
+                throw new UnexpectedValueException(sprintf('"%s::getGlobals()" must return an array of globals.', get_class($extension)));
             }
+            
             $globals = array_merge($globals, $extGlob);
         }
 


### PR DESCRIPTION
It's possible for a poorly written extension to destroy all global variables by returning nothing.  This prevents that and throws an E_WARNING to notify the developer.
