### PR TITLE
Add {% with %} tag

### DIFF
--- a/doc/tags/index.rst
+++ b/doc/tags/index.rst
@@ -22,3 +22,4 @@ Tags
     spaceless
     use
     verbatim
+    with

--- a/doc/tags/with.rst
+++ b/doc/tags/with.rst
@@ -1,0 +1,26 @@
+``with``
+========
+
+Enforces a nested scope where you can safely set variables without bloating the main context and avoiding potential name collisions.
+
+.. code-block:: jinja
+
+    {% set greeting, name = "Hello", "World" %}
+    {% with %}
+        {% set name = "Twig" %}
+        {{ greeting }}, {{ name }} {# outputs "Hello, Twig" #}
+    {% endwith %}
+    {{ greeting }}, {{ name }} {# outputs "Hello, World" #}
+
+As is usual to set variables when entering the new scope, that can be done directly in the tag, like in the next example:
+
+.. code-block:: jinja
+
+    {% with name = "Twig" %}
+        Hello, {{ name }}
+    {% endwith %}
+    {# name here not defined anymore #}
+
+.. note::
+
+    It allows also for multiple sets at once, as does the :doc:`set <../tags/set>` tag.

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -114,6 +114,7 @@ class Twig_Extension_Core extends Twig_Extension
             new Twig_TokenParser_Flush(),
             new Twig_TokenParser_Do(),
             new Twig_TokenParser_Embed(),
+            new Twig_TokenParser_With(),
         );
     }
 

--- a/lib/Twig/Node/Extract.php
+++ b/lib/Twig/Node/Extract.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ * (c) 2013 Berny Cantos
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Twig_Node_Extract extends Twig_Node
+{
+    public function __construct(array $nodes, $lineno)
+    {
+        parent::__construct($nodes, array(), $lineno);
+    }
+
+    public function compile(Twig_Compiler $compiler)
+    {
+        $compiler->write("\$context = array_merge(\$context")->indent();
+        foreach ($this->nodes as $node) {
+            $compiler->raw(", \n")->write('(array) ')->subcompile($node);
+        }
+        $compiler->raw("\n")->outdent()->write(");\n");
+    }
+}

--- a/lib/Twig/Node/With.php
+++ b/lib/Twig/Node/With.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ * (c) 2013 Berny Cantos
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Represents a nested scope
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class Twig_Node_With extends Twig_Node
+{
+    public function __construct(Twig_NodeInterface $content, Twig_NodeInterface $setter, $lineno, $tag = null)
+    {
+        parent::__construct(array('content' => $content, 'setter' => $setter), array(), $lineno, $tag);
+    }
+
+    /**
+     * Compiles the node to PHP.
+     *
+     * @param Twig_Compiler A Twig_Compiler instance
+     */
+    public function compile(Twig_Compiler $compiler)
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->write("\$context['_parent'] = (array) \$context;\n")
+            ->subcompile($this->getNode('setter'))
+            ->subcompile($this->getNode('content'))
+            ->write("\$context = \$context['_parent'];\n")
+        ;
+    }
+}

--- a/lib/Twig/TokenParser/With.php
+++ b/lib/Twig/TokenParser/With.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ * (c) 2013 Berny Cantos
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Enforces a nested scope
+ *
+ * <pre>
+ * {% set foo = 'Hello', separator = ', ', bar = 'Twig' %}
+ * {% with foo = 'Goodbye' %} {# Optional setter #}
+ *     {% set bar = 'World' %}
+ *     {{ foo ~ separator ~ bar }} {# This should print "Goodbye, World" #}
+ * {% endwith %}
+ * {{ foo ~ separator ~ bar }} {# This should print "Hello, Twig" #}
+ * </pre>
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class Twig_TokenParser_With extends Twig_TokenParser
+{
+    /**
+     * Parses a token and returns a node.
+     *
+     * @param Twig_Token $token A Twig_Token instance
+     *
+     * @return Twig_NodeInterface A Twig_NodeInterface instance
+     */
+    public function parse(Twig_Token $token)
+    {
+        $lineno = $token->getLine();
+        $stream = $this->parser->getStream();
+
+        if ($stream->test(Twig_Token::BLOCK_END_TYPE) === false) {
+            $names = $this->parser->getExpressionParser()->parseAssignmentExpression();
+            $stream->expect(Twig_Token::OPERATOR_TYPE, '=');
+            $values = $this->parser->getExpressionParser()->parseMultitargetExpression();
+
+            if (count($names) !== count($values)) {
+                throw new Twig_Error_Syntax("When using set, you must have the same number of variables and assignments.", $stream->getCurrent()->getLine(), $stream->getFilename());
+            }
+
+            $setter = new Twig_Node_Set(false, $names, $values, $lineno);
+        } else {
+            $setter = new Twig_Node();
+        }
+
+        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+        $body = $this->parser->subparse(array($this, 'decideWithEnd'), true);
+
+        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+        return new Twig_Node_With($body, $setter, $lineno, $this->getTag());
+    }
+
+    public function decideWithEnd(Twig_Token $token)
+    {
+        return $token->test('endwith');
+    }
+
+    /**
+     * Gets the tag name associated with this token parser.
+     *
+     * @return string The tag name
+     */
+    public function getTag()
+    {
+        return 'with';
+    }
+}

--- a/test/Twig/Tests/Fixtures/tags/with/basic.test
+++ b/test/Twig/Tests/Fixtures/tags/with/basic.test
@@ -1,0 +1,14 @@
+--TEST--
+"with" tag
+--TEMPLATE--
+{% set foo, bar = 'foo', 'bar' %}
+{% with %}
+    {% set bar = 'BAZ' %}
+    {{ foo }}{{ bar }}
+{% endwith %}
+{{ foo }}{{ bar }}
+--DATA--
+return array()
+--EXPECT--
+fooBAZ
+foobar

--- a/test/Twig/Tests/Fixtures/tags/with/expression.test
+++ b/test/Twig/Tests/Fixtures/tags/with/expression.test
@@ -1,0 +1,11 @@
+--TEST--
+"with" tag with expression
+--TEMPLATE--
+{% set vars = {foo: 'foo', bar: 'BAZ'} %}
+{% with not_found|default(vars) %}
+    {{ foo }}{{ bar }}
+{% endwith %}
+--DATA--
+return array()
+--EXPECT--
+fooBAZ

--- a/test/Twig/Tests/Fixtures/tags/with/inline_object.test
+++ b/test/Twig/Tests/Fixtures/tags/with/inline_object.test
@@ -1,0 +1,11 @@
+--TEST--
+"with" tag with inline object
+--TEMPLATE--
+{% set foo = 'baz' %}
+{% with {foo: 'foo', bar: 'BAZ'} %}
+    {{ foo }}{{ bar }}
+{% endwith %}
+--DATA--
+return array()
+--EXPECT--
+fooBAZ

--- a/test/Twig/Tests/Fixtures/tags/with/multisetter.test
+++ b/test/Twig/Tests/Fixtures/tags/with/multisetter.test
@@ -1,0 +1,13 @@
+--TEST--
+"with" tag with inlined multi-setter
+--TEMPLATE--
+{% set foo, bar = 'foo', 'bar' %}
+{% with foo, bar = 'FOO', 'BAZ' %}
+    {{ foo }}{{ bar }}
+{% endwith %}
+{{ foo }}{{ bar }}
+--DATA--
+return array()
+--EXPECT--
+FOOBAZ
+foobar

--- a/test/Twig/Tests/Fixtures/tags/with/nested.test
+++ b/test/Twig/Tests/Fixtures/tags/with/nested.test
@@ -1,0 +1,15 @@
+--TEST--
+nested "with" tags
+--TEMPLATE--
+{% set foo, bar = 'foo', 'bar' %}
+{% with bar = 'BAZ' %}
+  {% with foo = 'FOO' %}
+    {{ foo }}{{ bar }}
+  {% endwith %}
+{% endwith %}
+{{ foo }}{{ bar }}
+--DATA--
+return array()
+--EXPECT--
+FOOBAZ
+  foobar

--- a/test/Twig/Tests/Fixtures/tags/with/object.test
+++ b/test/Twig/Tests/Fixtures/tags/with/object.test
@@ -1,0 +1,11 @@
+--TEST--
+"with" tag with object
+--TEMPLATE--
+{% set vars = {foo: 'foo', bar: 'BAZ'} %}
+{% with vars %}
+    {{ foo }}{{ bar }}
+{% endwith %}
+--DATA--
+return array()
+--EXPECT--
+fooBAZ

--- a/test/Twig/Tests/Fixtures/tags/with/setter.test
+++ b/test/Twig/Tests/Fixtures/tags/with/setter.test
@@ -1,0 +1,13 @@
+--TEST--
+"with" tag with inlined setter
+--TEMPLATE--
+{% set foo, bar = 'foo', 'bar' %}
+{% with bar = 'BAZ' %}
+    {{ foo }}{{ bar }}
+{% endwith %}
+{{ foo }}{{ bar }}
+--DATA--
+return array()
+--EXPECT--
+fooBAZ
+foobar

--- a/test/Twig/Tests/Node/WithTest.php
+++ b/test/Twig/Tests/Node/WithTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Twig_Tests_Node_WithTest extends Twig_Test_NodeTestCase
+{
+    /**
+     * @covers Twig_Node_With::__construct
+     */
+    public function testConstructor()
+    {
+        $setter = new Twig_Node();
+        $content = new Twig_Node();
+        $node = new Twig_Node_With($content, $setter, 1);
+
+        $this->assertSame($setter, $node->getNode('setter'));
+        $this->assertSame($content, $node->getNode('content'));
+        $this->assertEquals(1, $node->getLine());
+    }
+
+    /**
+     * @covers Twig_Node_With::compile
+     * @dataProvider getTests
+     */
+    public function testCompile($node, $source, $environment = null)
+    {
+        parent::testCompile($node, $source, $environment);
+    }
+
+    public function getTests()
+    {
+        $tests = array();
+
+        $content = new Twig_Node();
+        $node = new Twig_Node_With($content, $content, 1);
+        $tests[] = array($node, <<<EOF
+// line 1
+\$context['_parent'] = (array) \$context;
+\$context = \$context['_parent'];
+EOF
+        );
+
+        $content = new Twig_Node();
+        $names = new Twig_Node(array(new Twig_Node_Expression_AssignName('foo', 1)), array(), 1);
+        $values = new Twig_Node(array(new Twig_Node_Expression_Constant('foo', 1)), array(), 1);
+        $setter = new Twig_Node_Set(false, $names, $values, 1);
+        $node = new Twig_Node_With($content, $setter, 1);
+        $tests[] = array($node, <<<EOF
+// line 1
+\$context['_parent'] = (array) \$context;
+\$context["foo"] = "foo";
+\$context = \$context['_parent'];
+EOF
+        );
+
+        $content = new Twig_Node_Text('content', 1);
+        $names = new Twig_Node(array(new Twig_Node_Expression_AssignName('foo', 1)), array(), 1);
+        $values = new Twig_Node(array(new Twig_Node_Expression_Constant('foo', 1)), array(), 1);
+        $setter = new Twig_Node_Set(false, $names, $values, 1);
+        $node = new Twig_Node_With($content, $setter, 1);
+        $tests[] = array($node, <<<EOF
+// line 1
+\$context['_parent'] = (array) \$context;
+\$context["foo"] = "foo";
+echo "content";
+\$context = \$context['_parent'];
+EOF
+        );
+
+        return $tests;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #719 |
| License | MIT |
| Doc PR | - |

Jinja flavoured `{% with %}` tag implementation.
PR related to issue https://github.com/fabpot/Twig/issues/719
