### PR TITLE
Fixed small typo in link for "pre-built DLL"

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -161,4 +161,4 @@ filesystem loader::
 
 .. _`download page`: https://github.com/fabpot/Twig/tags
 .. _`online documentation`: http://getcomposer.org/doc
-.. _`pre-build DLL`: https://github.com/stealth35/stealth35.github.com/downloads
+.. _`pre-built DLL`: https://github.com/stealth35/stealth35.github.com/downloads


### PR DESCRIPTION
Hey!

Very easy - this fixes a link that wasn't generating correctly.

Thanks!
