### PR TITLE
Made macro documentation clearer

### DIFF
--- a/doc/tags/macro.rst
+++ b/doc/tags/macro.rst
@@ -20,7 +20,7 @@ Macros differs from native PHP functions in a few ways:
 
 * Arguments of a macro are always optional.
 
-But as PHP functions, macros don't have access to the current template
+But as with PHP functions, macros don't have access to the current template
 variables.
 
 .. tip::


### PR DESCRIPTION
Previous wording implied (to me at least) that macros _are_ PHP functions.
