### PR TITLE
Added support for compiled templates to be cached

### DIFF
--- a/lib/Twig/StaticCache/Memcached.php
+++ b/lib/Twig/StaticCache/Memcached.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Manages cache entries from the Memcache.
+ *
+ * @package    twig
+ * @author     Vladimir Cvetic <vladimir@ferdinand.rs>
+ */
+class Twig_StaticCache_Memcached implements Twig_StaticCacheInterface
+{
+    protected $memcached;
+    protected $path;
+    
+    public function __construct($memcached)
+    {
+        $this->memcached = $memcached;
+    }
+    
+    public function set($key, $content, $ttl = 0)
+    {
+        if (!$this->memcached->set($key, $content, $ttl)) {
+            throw new Twig_Error_Runtime(sprintf('Failed to write to Memcache: "%s".', $this->memcached->getResultMessage()));
+        }
+    }
+    
+    public function get($key)
+    {
+        return $this->memcached->get($key);
+    }
+}

--- a/lib/Twig/StaticCacheInterface.php
+++ b/lib/Twig/StaticCacheInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ * (c) 2009 Armin Ronacher
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Interface all static caches must implement.
+ *
+ * @package    twig
+ * @author     Vladimir Cvetic <vladimir@ferdinand.rs>
+ */
+interface Twig_StaticCacheInterface
+{
+    public function set($key, $content, $ttl);
+    public function get($key);
+}

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -261,7 +261,15 @@ abstract class Twig_Template implements Twig_TemplateInterface
     protected function displayWithErrorHandling(array $context, array $blocks = array())
     {
         try {
-            $this->doDisplay($context, $blocks);
+            if (false !== $this->getEnvironment()->getStaticCache()) {
+                ob_start();
+                $this->doDisplay($context, $blocks);
+                $output = ob_get_clean(); 
+                $this->getEnvironment()->getStaticCache()->set($this->getEnvironment()->getStaticCacheKey($this->getTemplateName()), $output);
+                print $output;
+            } else {
+                $this->doDisplay($context, $blocks);
+            }            
         } catch (Twig_Error $e) {
             if (!$e->getTemplateFile()) {
                 $e->setTemplateFile($this->getTemplateName());

--- a/test/Twig/Tests/MemcacheStaticCachingTest.php
+++ b/test/Twig/Tests/MemcacheStaticCachingTest.php
@@ -1,0 +1,31 @@
+<?php
+
+class Twig_Tests_MemcacheCachingTest extends PHPUnit_Framework_TestCase
+{
+    protected $memcache;
+    protected $twig;
+
+    public function setUp()
+    {
+        if (!class_exists('Memcached')) {
+            $this->markTestSkipped('Your environment does not have Memcached installed.');
+        }
+        
+        $this->memcache = new Memcached;
+        $this->memcache->addServer('127.0.0.1', 11211);   
+
+        $this->twig = new Twig_Environment(new Twig_Loader_String(), array('static_cache' => new Twig_StaticCache_Memcached($this->memcache) ));
+    }
+
+    public function testWritingStaticCache()
+    {
+        $name = 'I can resist everything except temptation.';
+        $this->twig->render($name);
+
+        $output = $this->memcache->get($this->twig->getStaticCacheKey($name));
+        if ($output === false)
+            $output = '';
+
+        $this->assertRegexp('/I can resist everything except temptation./', $output);
+    }
+}


### PR DESCRIPTION
In order to eliminate the need for compiled templates to be loaded from filesystem each time one is requested I've added "static caching" (maybe a bit unfortunate naming?).

It caches output from compiled template and stores it into cache specified by user (by passing object that implements static cache interface). Included is memcached support.

At the moment it does lack proper definition of ttl for each template cached.
