### PR TITLE
Add static caching for Twig_Environment::getTemplateClass()

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -44,6 +44,7 @@ class Twig_Environment
     protected $functionCallbacks;
     protected $filterCallbacks;
     protected $staging;
+    protected $templateClasses;
 
     /**
      * Constructor.
@@ -107,6 +108,7 @@ class Twig_Environment
         $this->setCache($options['cache']);
         $this->functionCallbacks = array();
         $this->filterCallbacks = array();
+        $this->templateClasses = array();
 
         $this->addExtension(new Twig_Extension_Core());
         $this->addExtension(new Twig_Extension_Escaper($options['autoescape']));
@@ -262,7 +264,12 @@ class Twig_Environment
      */
     public function getTemplateClass($name, $index = null)
     {
-        return $this->templateClassPrefix.md5($this->getLoader()->getCacheKey($name)).(null === $index ? '' : '_'.$index);
+        $suffix = null === $index ? '' : '_'.$index;
+        $cls = $name.$suffix;
+        if (!isset($this->templateClasses[$cls])) {
+            $this->templateClasses[$cls] = $this->templateClassPrefix.md5($this->getLoader()->getCacheKey($name)).$suffix;
+        }
+        return $this->templateClasses[$cls];
     }
 
     /**


### PR DESCRIPTION
Coming from http://drupal.org/node/1979290.

```
=== baseline-views-field-twig..views-field-twig-static-cache compared (517896dc57c6e..5178989df1d0f):

ct  : 116,895|115,892|-1,003|-0.9%
wt  : 478,367|474,349|-4,018|-0.8%
cpu : 449,530|444,639|-4,891|-1.1%
mu  : 17,447,208|17,453,200|5,992|0.0%
pmu : 17,658,176|17,664,136|5,960|0.0%
```

http://www.lionsad.de/xhprof-kit/xhprof/xhprof_html/?run1=517896dc57c6e&run2=5178989df1d0f&source=drupal-perf-cottser&extra=baseline-views-field-twig..views-field-twig-static-cache

We found that performance could be measurably improved when the same template is rendered multiple times in a request.
