### PR TITLE
enforced usage of named arguments after positional ones

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
-* 1.12.4 (2013-XX-XX)
+* 1.13.0 (2013-XX-XX)
 
- * n/a
+ * enforced usage of named arguments after positional ones
 
 * 1.12.3 (2013-04-08)
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.12-dev"
+            "dev-master": "1.13-dev"
         }
     }
 }

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -227,14 +227,12 @@ to change the default value:
     {# or skip the format value by using a named argument for the timezone #}
     {{ "now"|date(timezone="Europe/Paris") }}
 
-You can also use both positional and named arguments in one call, which is not
-recommended as it can be confusing:
+You can also use both positional and named arguments in one call, in which
+case positional arguments must always come before named arguments:
 
 .. code-block:: jinja
 
-    {# both work #}
     {{ "now"|date('d/m/Y H:i', timezone="Europe/Paris") }}
-    {{ "now"|date(timezone="Europe/Paris", 'd/m/Y H:i') }}
 
 .. tip::
 

--- a/ext/twig/php_twig.h
+++ b/ext/twig/php_twig.h
@@ -15,7 +15,7 @@
 #ifndef PHP_TWIG_H
 #define PHP_TWIG_H
 
-#define PHP_TWIG_VERSION "1.12.4-DEV"
+#define PHP_TWIG_VERSION "1.13.0-DEV"
 
 #include "php.h"
 

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -16,7 +16,7 @@
  */
 class Twig_Environment
 {
-    const VERSION = '1.12.4-DEV';
+    const VERSION = '1.13.0-DEV';
 
     protected $charset;
     protected $loader;

--- a/lib/Twig/Node/Expression/Call.php
+++ b/lib/Twig/Node/Expression/Call.php
@@ -98,7 +98,10 @@ abstract class Twig_Node_Expression_Call extends Twig_Node_Expression
             if (!is_int($name)) {
                 $named = true;
                 $name = $this->normalizeName($name);
+            } elseif ($named) {
+                throw new Twig_Error_Syntax(sprintf('Positional arguments cannot be used after named arguments for %s "%s".', $this->getAttribute('type'), $this->getAttribute('name')));
             }
+
             $parameters[$name] = $node;
         }
 
@@ -142,6 +145,10 @@ abstract class Twig_Node_Expression_Call extends Twig_Node_Expression
             $name = $this->normalizeName($param->name);
 
             if (array_key_exists($name, $parameters)) {
+                if (array_key_exists($pos, $parameters)) {
+                    throw new Twig_Error_Syntax(sprintf('Arguments "%s" is defined twice for %s "%s".', $name, $this->getAttribute('type'), $this->getAttribute('name')));
+                }
+
                 $arguments[] = $parameters[$name];
                 unset($parameters[$name]);
             } elseif (array_key_exists($pos, $parameters)) {

--- a/test/Twig/Tests/Fixtures/filters/date_namedargs.test
+++ b/test/Twig/Tests/Fixtures/filters/date_namedargs.test
@@ -3,13 +3,11 @@
 --TEMPLATE--
 {{ date|date(format='d/m/Y H:i:s P', timezone='America/Chicago') }}
 {{ date|date(timezone='America/Chicago', format='d/m/Y H:i:s P') }}
-{{ date|date(timezone='America/Chicago', 'd/m/Y H:i:s P') }}
 {{ date|date('d/m/Y H:i:s P', timezone='America/Chicago') }}
 --DATA--
 date_default_timezone_set('UTC');
 return array('date' => mktime(13, 45, 0, 10, 4, 2010))
 --EXPECT--
-04/10/2010 08:45:00 -05:00
 04/10/2010 08:45:00 -05:00
 04/10/2010 08:45:00 -05:00
 04/10/2010 08:45:00 -05:00

--- a/test/Twig/Tests/Node/Expression/CallTest.php
+++ b/test/Twig/Tests/Node/Expression/CallTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Twig_Tests_Node_Expression_CallTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetArguments()
+    {
+        $node = new Twig_Tests_Node_Expression_Call(array(), array('type' => 'function', 'name' => 'date'));
+        $this->assertEquals(array('U'), $node->getArguments('date', array('format' => 'U')));
+    }
+
+    /**
+     * @expectedException        Twig_Error_Syntax
+     * @expectedExceptionMessage Positional arguments cannot be used after named arguments for function "date".
+     */
+    public function testGetArgumentsWhenPositionalArgumentsAfterNamedArguments()
+    {
+        $node = new Twig_Tests_Node_Expression_Call(array(), array('type' => 'function', 'name' => 'date'));
+        $node->getArguments('date', array('timestamp' => 123456, 'Y-m-d'));
+    }
+
+    /**
+     * @expectedException        Twig_Error_Syntax
+     * @expectedExceptionMessage Arguments "format" is defined twice for function "date".
+     */
+    public function testGetArgumentsWhenArgumentIsDefinedTwice()
+    {
+        $node = new Twig_Tests_Node_Expression_Call(array(), array('type' => 'function', 'name' => 'date'));
+        $node->getArguments('date', array('Y-m-d', 'format' => 'U'));
+    }
+}
+
+class Twig_Tests_Node_Expression_Call extends Twig_Node_Expression_Call
+{
+    public function getArguments($callable, $arguments)
+    {
+        return parent::getArguments($callable, $arguments);
+    }
+}


### PR DESCRIPTION
When we introduced named arguments, the behavior for when both positional and named arguments were used in a call was not clearly defined.

This PR addresses this issue by following Python rules:
- No positional argument after named ones
- No possibility to define an argument with both a positional argument and a named one

This introduces a BC break if people were using positional arguments after named ones, but I would argue that this is never a good idea anyway.

This is an alternative to #995 
