### PR TITLE
Optimize resume after for loops by using + vs array_merge

### DIFF
--- a/lib/Twig/Node/For.php
+++ b/lib/Twig/Node/For.php
@@ -107,6 +107,6 @@ class Twig_Node_For extends Twig_Node
         $compiler->write('unset($context[\'_seq\'], $context[\'_iterated\'], $context[\''.$this->getNode('key_target')->getAttribute('name').'\'], $context[\''.$this->getNode('value_target')->getAttribute('name').'\'], $context[\'_parent\'], $context[\'loop\']);'."\n");
 
         // keep the values set in the inner context for variables defined in the outer context
-        $compiler->write("\$context = array_merge(\$_parent, array_intersect_key(\$context, \$_parent));\n");
+        $compiler->write("\$context = array_intersect_key(\$context, \$_parent) + \$_parent;\n");
     }
 }

--- a/test/Twig/Tests/Node/ForTest.php
+++ b/test/Twig/Tests/Node/ForTest.php
@@ -70,7 +70,7 @@ foreach (\$context['_seq'] as \$context["key"] => \$context["item"]) {
 }
 \$_parent = \$context['_parent'];
 unset(\$context['_seq'], \$context['_iterated'], \$context['key'], \$context['item'], \$context['_parent'], \$context['loop']);
-\$context = array_merge(\$_parent, array_intersect_key(\$context, \$_parent));
+\$context = array_intersect_key(\$context, \$_parent) + \$_parent;
 EOF
         );
 
@@ -113,7 +113,7 @@ foreach (\$context['_seq'] as \$context["k"] => \$context["v"]) {
 }
 \$_parent = \$context['_parent'];
 unset(\$context['_seq'], \$context['_iterated'], \$context['k'], \$context['v'], \$context['_parent'], \$context['loop']);
-\$context = array_merge(\$_parent, array_intersect_key(\$context, \$_parent));
+\$context = array_intersect_key(\$context, \$_parent) + \$_parent;
 EOF
         );
 
@@ -146,7 +146,7 @@ foreach (\$context['_seq'] as \$context["k"] => \$context["v"]) {
 }
 \$_parent = \$context['_parent'];
 unset(\$context['_seq'], \$context['_iterated'], \$context['k'], \$context['v'], \$context['_parent'], \$context['loop']);
-\$context = array_merge(\$_parent, array_intersect_key(\$context, \$_parent));
+\$context = array_intersect_key(\$context, \$_parent) + \$_parent;
 EOF
         );
 
@@ -194,7 +194,7 @@ if (!\$context['_iterated']) {
 }
 \$_parent = \$context['_parent'];
 unset(\$context['_seq'], \$context['_iterated'], \$context['k'], \$context['v'], \$context['_parent'], \$context['loop']);
-\$context = array_merge(\$_parent, array_intersect_key(\$context, \$_parent));
+\$context = array_intersect_key(\$context, \$_parent) + \$_parent;
 EOF
         );
 


### PR DESCRIPTION
The plus operator seems to be almost twice as fast as array_merge, so I think in this case and given it's compiled code not made for humans it's worth it. The only potential problem is if you use ints as keys then it won't have the same behavior as array_merge, but I don't know if twig supports this at all, and especially I doubt it's a good idea.
