### PR TITLE
(Minor) Add whitespace to list of optimizations in docs. 

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -500,13 +500,17 @@ Twig supports the following optimizations:
 
 * ``Twig_NodeVisitor_Optimizer::OPTIMIZE_ALL``, enables all optimizations
 (this is the default value).
+
 * ``Twig_NodeVisitor_Optimizer::OPTIMIZE_NONE``, disables all optimizations.
 This reduces the compilation time, but it can increase the execution time
 and the consumed memory.
+
 * ``Twig_NodeVisitor_Optimizer::OPTIMIZE_FOR``, optimizes the ``for`` tag by
 removing the ``loop`` variable creation whenever possible.
+
 * ``Twig_NodeVisitor_Optimizer::OPTIMIZE_RAW_FILTER``, removes the ``raw``
 filter whenever possible.
+
 * ``Twig_NodeVisitor_Optimizer::OPTIMIZE_VAR_ACCESS``, simplifies the creation
 and access of variables in the compiled templates whenever possible.
 


### PR DESCRIPTION
![screen shot 2013-05-26 at 6 30 20 pm](https://f.cloud.github.com/assets/54067/566122/10811e24-c66d-11e2-9f5e-7991bbf6a719.png)

Screenshot shows garbled list. Adding whitespace to the source's list fixes it (after converted to PDF).
