### PR TITLE
Method displayWithErrorHandling should not wrap all exceptions.

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -276,6 +276,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
 
             throw $e;
         }
+        
     }
 
     /**


### PR DESCRIPTION
Hello,

I'm developing an application using Kohana framework and I've found it impossible to track an exact cause of an exception because Twig is wrapping it inside `Twig_Error_Runtime`.
Basically it prevents Kohana error handler from displaying any useful backtrace information I need to track the issue.

I believe that any exception that is not caused by Twig should **not** be thrown as `Twig_Error_Runtime`.
