### PR TITLE
Treat object as string when used as array offset

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -340,7 +340,13 @@ abstract class Twig_Template implements Twig_TemplateInterface
     {
         // array
         if (Twig_Template::METHOD_CALL !== $type) {
-            $arrayItem = is_bool($item) || is_float($item) ? (int) $item : $item;
+            if (is_bool($item) || is_float($item)) {
+                $arrayItem = (int) $item;
+            } elseif (is_object($item) && method_exists($object, '__toString')) {
+                $arrayItem = (string) $object;
+            } else {
+                $arrayItem = $item;
+            }
 
             if ((is_array($object) && array_key_exists($arrayItem, $object))
                 || ($object instanceof ArrayAccess && isset($object[$arrayItem]))


### PR DESCRIPTION
Currently if you call `{{ attribute(object, item) }}` where `object` argument is a true array (not an object acting as array) and `item` is an object, an error will be raised: "array_key_exists(): The first argument should be either a string or an integer".

In contrast, if both `object` and `item` are objects, then `item` gets converted to string and everything goes smoothly.

This PR eliminates this incosistency. Now objects that are string-convertible will be converted to strings when passed as `item` argument.