### PR TITLE
Change wording of indentation coding standards

### DIFF
--- a/doc/coding_standards.rst
+++ b/doc/coding_standards.rst
@@ -90,7 +90,7 @@ standards:
      {% set foo_bar = 'foo' %}
 
 * Indent your code inside tags (use the same indentation as the one used for
-  the main language of the project):
+  the target language of the rendered template):
 
   .. code-block:: jinja
 


### PR DESCRIPTION
The documentation says to use indentation consistent with the main language of the **File**. But in a Twig template, that language is going to be Twig. This PR changes the wording to indicate that the indentation rules inside tags should be consistent with the main language of the **Project** Twig is being used within.

```
| Q             | A
| ------------- | ---
| Doc fix?      | yes
| New docs?     | no
| Applies to    | all
| Fixed tickets | none
```
