### PR TITLE
[Doc] corrects number_format argument namming

### DIFF
--- a/doc/filters/number_format.rst
+++ b/doc/filters/number_format.rst
@@ -40,6 +40,6 @@ Arguments
 
  * ``decimal``:       The number of decimal points to display
  * ``decimal_point``: The character(s) to use for the decimal point
- * ``decimal_sep``:   The character(s) to use for the thousands separator
+ * ``thousand_sep``:   The character(s) to use for the thousands separator
 
 .. _`number_format`: http://php.net/number_format


### PR DESCRIPTION
last argument is for thousand separator not decimal
