### PR TITLE
fixed usage of the html_attr escaping strategy to avoid double-escaping with the html strategy

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.14.0 (2013-XX-XX)
 
+ * fixed usage of the html_attr escaping strategy to avoid double-escaping with the html strategy
  * fixed some compatibility issues with HHVM
  * added a way to add custom escaping strategies
  * fixed the C extension compilation on Windows

--- a/lib/Twig/NodeVisitor/SafeAnalysis.php
+++ b/lib/Twig/NodeVisitor/SafeAnalysis.php
@@ -13,12 +13,20 @@ class Twig_NodeVisitor_SafeAnalysis implements Twig_NodeVisitorInterface
     public function getSafe(Twig_NodeInterface $node)
     {
         $hash = spl_object_hash($node);
-        if (isset($this->data[$hash])) {
-            foreach ($this->data[$hash] as $bucket) {
-                if ($bucket['key'] === $node) {
-                    return $bucket['value'];
-                }
+        if (!isset($this->data[$hash])) {
+            return;
+        }
+
+        foreach ($this->data[$hash] as $bucket) {
+            if ($bucket['key'] !== $node) {
+                continue;
             }
+
+            if (in_array('html_attr', $bucket['value'])) {
+                $bucket['value'][] = 'html';
+            }
+
+            return $bucket['value'];
         }
     }
 

--- a/test/Twig/Tests/Fixtures/filters/escape_html_attr.test
+++ b/test/Twig/Tests/Fixtures/filters/escape_html_attr.test
@@ -1,0 +1,8 @@
+--TEST--
+"escape" filter does not escape with the html strategy when using the html_attr strategy
+--TEMPLATE--
+{{ '<br />'|escape('html_attr') }}
+--DATA--
+return array()
+--EXPECT--
+&lt;br&#x20;&#x2F;&gt;


### PR DESCRIPTION
fixes #896
