### PR TITLE
added a quoted_html_attr which can be used when the attribute is double-quoted

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.14.0 (2013-XX-XX)
 
+ * added a quoted_html_attr which can be used when the attribute is double-quoted
  * fixed usage of the html_attr escaping strategy to avoid double-escaping with the html strategy
  * fixed some compatibility issues with HHVM
  * added a way to add custom escaping strategies

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -96,11 +96,13 @@ The following options are available:
 
 * ``autoescape``: If set to ``true``, auto-escaping will be enabled by default
   for all templates (default to ``true``). As of Twig 1.8, you can set the
-  escaping strategy to use (``html``, ``js``, ``false`` to disable).
-  As of Twig 1.9, you can set the escaping strategy to use (``css``, ``url``, 
-  ``html_attr``, or a PHP callback that takes the template "filename" and must 
-  return the escaping strategy to use -- the callback cannot be a function name
-  to avoid collision with built-in escaping strategies).
+  escaping strategy to use (``html``, ``js``, ``false`` to disable). As of
+  Twig 1.9, you can set the escaping strategy to use (``css``, ``url``,
+  ``html_attr``, or a PHP callback that takes the template "filename" and must
+  return the escaping strategy to use -- the callback cannot be a function
+  name to avoid collision with built-in escaping strategies). As of Twig 1.14,
+  the ``quoted_html_attr`` strategy is usable for HTML attributes enclosed in
+  double-quotes.
 
 * ``optimizations``: A flag that indicates which optimizations to apply
   (default to ``-1`` -- all optimizations are enabled; set it to ``0`` to

--- a/doc/filters/escape.rst
+++ b/doc/filters/escape.rst
@@ -6,6 +6,9 @@
     1.9.0.
 
 .. versionadded:: 1.14.0
+    The ``quotes_html_attr`` strategy was added in Twig 1.14.0.
+
+.. versionadded:: 1.14.0
     The ability to define custom escapers was added in Twig 1.14.0.
 
 The ``escape`` filter escapes a string for safe insertion into the final
@@ -54,6 +57,10 @@ The ``escape`` filter supports the following escaping strategies:
   not be used to escape an entire URI; only a subcomponent being inserted.
 
 * ``html_attr``: escapes a string for the **HTML attribute** context.
+
+* ``quoted_html_attr``: escapes a string for the **HTML attribute** context if
+  the HTML attribute is double-quoted. Do not use it if you are not sure that
+  the attribute is enclosed in double-quotes.
 
 .. note::
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -888,6 +888,13 @@ function twig_escape_filter(Twig_Environment $env, $string, $strategy = 'html', 
 
     switch ($strategy) {
         case 'html':
+        case 'quoted_html_attr':
+            if ('quoted_html_attr' === $strategy) {
+                $flags = ENT_COMPAT;
+            } elseif ('html' === $strategy) {
+                $flags = ENT_QUOTES;
+            }
+
             // see http://php.net/htmlspecialchars
 
             // Using a static variable to avoid initializing the array
@@ -919,18 +926,18 @@ function twig_escape_filter(Twig_Environment $env, $string, $strategy = 'html', 
             }
 
             if (isset($htmlspecialcharsCharsets[$charset])) {
-                return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
+                return htmlspecialchars($string, $flags | ENT_SUBSTITUTE, $charset);
             }
 
             if (isset($htmlspecialcharsCharsets[strtoupper($charset)])) {
                 // cache the lowercase variant for future iterations
                 $htmlspecialcharsCharsets[$charset] = true;
 
-                return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
+                return htmlspecialchars($string, $flags | ENT_SUBSTITUTE, $charset);
             }
 
             $string = twig_convert_encoding($string, 'UTF-8', $charset);
-            $string = htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $string = htmlspecialchars($string, $flags | ENT_SUBSTITUTE, 'UTF-8');
 
             return twig_convert_encoding($string, $charset, 'UTF-8');
 


### PR DESCRIPTION
This is useful when you know for sure that the HTML attribute is double-quoted. See symfony/symfony#2383 for a use case.

Todo:
- [ ] add a use case in the documentation
- [ ] validate that `quoted_html_attr` is a good name
