### PR TITLE
Fixed issue where named arguments in macros does not work with template inheritance

### DIFF
--- a/lib/Twig/ExpressionParser.php
+++ b/lib/Twig/ExpressionParser.php
@@ -358,17 +358,23 @@ class Twig_ExpressionParser
                 throw new Twig_Error_Syntax('Expected name or number', $lineno, $this->parser->getFilename());
             }
 
-            if ($node instanceof Twig_Node_Expression_Name && null !== $this->parser->getImportedSymbol('template', $node->getAttribute('name'))) {
-                if (!$arg instanceof Twig_Node_Expression_Constant) {
-                    throw new Twig_Error_Syntax(sprintf('Dynamic macro names are not supported (called on "%s")', $node->getAttribute('name')), $token->getLine(), $this->parser->getFilename());
-                }
-
+            if (
+                $node instanceof Twig_Node_Expression_Name
+                &&
+                ((null !== $template = $this->parser->getImportedSymbol('template', $node->getAttribute('name'))) || $stream->test(Twig_Token::PUNCTUATION_TYPE, '('))
+            ) {
+                $type = Twig_Template::METHOD_CALL;
                 $arguments = $this->createArrayFromArguments($this->parseArguments(true));
 
-                return new Twig_Node_Expression_MacroCall($node, $arg->getAttribute('value'), $arguments, $lineno);
-            }
+                if (isset($template)) {
+                    return new Twig_Node_Expression_MacroCall($node, $arg->getAttribute('value'), $arguments, $lineno);
+                } elseif ($arguments->hasNamedKey()) {
+                    $name = $node->getAttribute('name');
+                    $template = '_self' === $name ? $node : new Twig_Node_Expression_Constant($name, $lineno);
 
-            if ($stream->test(Twig_Token::PUNCTUATION_TYPE, '(')) {
+                    return new Twig_Node_Expression_MacroCall($template, $arg->getAttribute('value'), $arguments, $lineno);
+                }
+            } elseif ($stream->test(Twig_Token::PUNCTUATION_TYPE, '(')) {
                 $type = Twig_Template::METHOD_CALL;
                 $arguments = $this->createArrayFromArguments($this->parseArguments());
             }

--- a/lib/Twig/Node/Expression/Array.php
+++ b/lib/Twig/Node/Expression/Array.php
@@ -60,6 +60,17 @@ class Twig_Node_Expression_Array extends Twig_Node_Expression
         array_push($this->nodes, $key, $value);
     }
 
+    public function hasNamedKey()
+    {
+        foreach (array_chunk($this->nodes, 2) as $pair) {
+            if (!is_int($pair[0]->getAttribute('value'))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Compiles the node to PHP.
      *

--- a/lib/Twig/Node/Expression/MacroCall.php
+++ b/lib/Twig/Node/Expression/MacroCall.php
@@ -40,8 +40,9 @@ class Twig_Node_Expression_MacroCall extends Twig_Node_Expression
 
         $compiler
             ->raw('$this->callMacro(')
-            ->subcompile($this->getNode('template'))
+            ->raw('$context')
             ->raw(', ')->repr($this->getAttribute('name'))
+            ->raw(', ')->subcompile($this->getNode('template'))
             ->raw(', ')->subcompile($this->getNode('arguments'))
         ;
 

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -450,12 +450,13 @@ abstract class Twig_Template implements Twig_TemplateInterface
     /**
      * Calls macro in a template.
      *
-     * @param Twig_Template $template        The template
-     * @param string        $macro           The name of macro
-     * @param array         $arguments       The arguments of macro
-     * @param array         $namedNames      An array of names of arguments as keys
-     * @param integer       $namedCount      The count of named arguments
-     * @param integer       $positionalCount The count of positional arguments
+     * @param array                     $context         The context
+     * @param string                    $macro           The name of macro
+     * @param Twig_Template|string|null $template        The template or the variable name
+     * @param array                     $arguments       The arguments of macro
+     * @param array                     $namedNames      An array of names of arguments as keys
+     * @param integer                   $namedCount      The count of named arguments
+     * @param integer                   $positionalCount The count of positional arguments
      *
      * @return string The content of a macro
      *
@@ -463,8 +464,16 @@ abstract class Twig_Template implements Twig_TemplateInterface
      * @throws Twig_Error_Runtime if the argument is defined twice
      * @throws Twig_Error_Runtime if the argument is unknown
      */
-    protected function callMacro(Twig_Template $template, $macro, array $arguments, array $namedNames = array(), $namedCount = 0, $positionalCount = -1)
+    protected function callMacro(array $context, $macro, $template = null, array $arguments, array $namedNames = array(), $namedCount = 0, $positionalCount = -1)
     {
+        if (!$template instanceof Twig_Template) {
+            if (!isset($context[$template]) || !$context[$template] instanceof Twig_Template) {
+                throw new Twig_Error_Runtime(sprintf('Variable "%s" must be a template with definition of macro "%s".', $template, $macro));
+            }
+
+            $template = $context[$template];
+        }
+
         if (!isset($template->macros[$macro]['reflection'])) {
             if (!isset($template->macros[$macro])) {
                 throw new Twig_Error_Runtime(sprintf('Macro "%s" is not defined in the template "%s".', $macro, $template->getTemplateName()));

--- a/test/Twig/Tests/ExpressionParserTest.php
+++ b/test/Twig/Tests/ExpressionParserTest.php
@@ -223,7 +223,22 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
         $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
-        $parser->parse($env->tokenize('{{ foo.bar(name="Foo") }}', 'index'));
+        $parser->parse($env->tokenize('{{ foo.bar.foobar(name="Foo") }}', 'index'));
+    }
+
+    public function testSecondAttributeCallWithNamedArgumentsTransformedToMacroCall()
+    {
+        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $parser = new Twig_Parser($env);
+
+        $expected = new Twig_Node_Expression_MacroCall(
+            new Twig_Node_Expression_Constant('foo', 1),
+            'bar',
+            new Twig_Node_Expression_Array(array(new Twig_Node_Expression_Constant('name', 1), new Twig_Node_Expression_Constant('Foo', 1)), 0),
+            1
+        );
+
+        $this->assertEquals($expected, $parser->parse($env->tokenize('{{ foo.bar(name="Foo") }}'))->getNode('body')->getNode(0)->getNode('expr'));
     }
 
     /**

--- a/test/Twig/Tests/Fixtures/exceptions/unknown_macro_in_invalid_template.test
+++ b/test/Twig/Tests/Fixtures/exceptions/unknown_macro_in_invalid_template.test
@@ -1,0 +1,9 @@
+--TEST--
+Exception for unknown macro in invalid template
+--TEMPLATE--
+{% set macros = "foo" %}
+{{ macros.foo(foo="bar") }}
+--DATA--
+return array()
+--EXCEPTION--
+Twig_Error_Runtime: Variable "macros" must be a template with definition of macro "foo" in "index.twig" at line 3.

--- a/test/Twig/Tests/Fixtures/macros/named_arguments_template_inheritance.test
+++ b/test/Twig/Tests/Fixtures/macros/named_arguments_template_inheritance.test
@@ -1,0 +1,24 @@
+--TEST--
+named arguments with template inheritance
+--TEMPLATE--
+{% extends "parent" %}
+{% block content %}
+    {{- macros.hello(name="John", lang="en") }}
+{% endblock %}
+--TEMPLATE(parent)--
+{% import "macros" as macros %}
+{{ macros.hello(name="Gilles") }}
+{% block content %}{% endblock %}
+--TEMPLATE(macros)--
+{% macro hello(name, age, lang="fr") %}
+  {%- if lang == "en" -%}
+    Hello {{ name }}
+  {%- elseif lang == "fr" -%}
+    Bonjour {{ name }}
+  {%- endif %}
+{% endmacro %}
+--DATA--
+return array();
+--EXPECT--
+Bonjour Gilles
+Hello John

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -371,7 +371,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
     public function testCallUnknownMacro()
     {
         $template = new Twig_TemplateTest($this->getMock('Twig_Environment'));
-        $template->callMacro(new Twig_Tests_TemplateWithMacros('my/template'), 'foo', array());
+        $template->callMacro(array(), 'foo', new Twig_Tests_TemplateWithMacros('my/template'), array());
     }
 
     /**
@@ -381,10 +381,12 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
     public function testCallMacroWhenArgumentIsDefinedTwice()
     {
         $template = new Twig_TemplateTest($this->getMock('Twig_Environment'));
-        $template->callMacro(new Twig_Tests_TemplateWithMacros('my/template', array('date' => array(
+        $templateWithMacros = new Twig_Tests_TemplateWithMacros('my/template', array('date' => array(
             'method' => 'getDate',
             'arguments' => array('format' => null, 'template' => null)
-        ))), 'date', array('d', 'format' => 'H'), array('format' => 1), 1, 1);
+        )));
+
+        $template->callMacro(array(), 'date', $templateWithMacros, array('d', 'format' => 'H'), array('format' => 1), 1, 1);
     }
 
     /**
@@ -394,10 +396,12 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
     public function testCallMacroWithWrongNamedArgumentName()
     {
         $template = new Twig_TemplateTest($this->getMock('Twig_Environment'));
-        $template->callMacro(new Twig_Tests_TemplateWithMacros('my/template', array('date' => array(
+        $templateWithMacros = new Twig_Tests_TemplateWithMacros('my/template', array('date' => array(
             'method' => 'getDate',
             'arguments' => array('foo' => 1, 'bar' => 2)
-        ))), 'date', array('foo' => 2), array('foo' => 1, 'unknown' => 1), 2, 0);
+        )));
+
+        $template->callMacro(array(), 'date', $templateWithMacros, array('foo' => 2), array('foo' => 1, 'unknown' => 1), 2, 0);
     }
 
     /**
@@ -407,10 +411,12 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
     public function testCallMacroWithWrongNamedArgumentNames()
     {
         $template = new Twig_TemplateTest($this->getMock('Twig_Environment'));
-        $template->callMacro(new Twig_Tests_TemplateWithMacros('my/template', array('date' => array(
+        $templateWithMacros = new Twig_Tests_TemplateWithMacros('my/template', array('date' => array(
             'method' => 'getDate',
             'arguments' => array()
-        ))), 'date', array(), array('unknown1' => 1, 'unknown2' => 2), 2, 0);
+        )));
+
+        $template->callMacro(array(), 'date', $templateWithMacros, array(), array('unknown1' => 1, 'unknown2' => 2), 2, 0);
     }
 }
 
@@ -471,9 +477,9 @@ class Twig_TemplateTest extends Twig_Template
         }
     }
 
-    public function callMacro(Twig_Template $template, $macro, array $arguments, array $namedNames = array(), $namedCount = 0, $positionalCount = -1)
+    public function callMacro(array $context, $macro, $template = null, array $arguments, array $namedNames = array(), $namedCount = 0, $positionalCount = -1)
     {
-        return parent::callMacro($template, $macro, $arguments, $namedNames, $namedCount, $positionalCount);
+        return parent::callMacro($context, $macro, $template, $arguments, $namedNames, $namedCount, $positionalCount);
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| New docs? | no |
| Tests pass? | yes |
| Fixed tickets | #1157 |
| License | MIT |
