### PR TITLE
Adding ignoreStrictCheck option for call_user_func_array, if throwing exception

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -438,7 +438,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
         // to call is not supported. If ignoreStrictCheck is true, we should return null.
         try {
             $ret = call_user_func_array(array($object, $method), $arguments);
-        } catch (Exception $e) {
+        } catch (\BadMethodCallException $e) {
             if ($ignoreStrictCheck || !$this->env->isStrictVariables()) {
                 return null;
             }


### PR DESCRIPTION
I experienced the issue when using FuelPHP's ORM with EAV containers. When I tried to reference a property that was not defined I expected to get null, but instead the whole application stopped because an exception was thrown in the ORM, that no such function is present.

I couldn't find other possible exception that could be thrown when this function is called, so I assumed it's safe to take the ignoreStrictCheck into consideration here.
