### PR TITLE
added a source function to include the content of a template without rendering it

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.15.0 (2013-XX-XX)
 
+ * added a source function to include the content of a template without rendering it
  * fixed the C extension sandbox behavior when get or set is prepend to method name
 
 * 1.14.2 (2013-10-30)

--- a/doc/functions/index.rst
+++ b/doc/functions/index.rst
@@ -14,4 +14,5 @@ Functions
     parent
     random
     range
+    source
     template_from_string

--- a/doc/functions/source.rst
+++ b/doc/functions/source.rst
@@ -1,0 +1,21 @@
+``source``
+==========
+
+.. versionadded:: 1.15
+    The include function was added in Twig 1.15.
+
+The ``source`` function returns the content of a template without rendering it:
+
+.. code-block:: jinja
+
+    {{ source('template.html') }}
+    {{ source(some_var) }}
+
+The function uses the same template loaders as the ones used to include
+templates. So, if you are using the filesystem loader, the templates are looked
+for in the paths defined by it.
+
+Arguments
+---------
+
+* ``name``: The name of the template to read

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -215,6 +215,7 @@ class Twig_Extension_Core extends Twig_Extension
             new Twig_SimpleFunction('random', 'twig_random', array('needs_environment' => true)),
             new Twig_SimpleFunction('date', 'twig_date_converter', array('needs_environment' => true)),
             new Twig_SimpleFunction('include', 'twig_include', array('needs_environment' => true, 'needs_context' => true, 'is_safe' => array('all'))),
+            new Twig_SimpleFunction('source', 'twig_source', array('needs_environment' => true, 'is_safe' => array('all'))),
         );
     }
 
@@ -1368,6 +1369,18 @@ function twig_include(Twig_Environment $env, $context, $template, $variables = a
     if ($isSandboxed && !$alreadySandboxed) {
         $sandbox->disableSandbox();
     }
+}
+
+/**
+ * Returns a template content without rendering it.
+ *
+ * @param string $name The template name
+ *
+ * @return string The template source
+ */
+function twig_source(Twig_Environment $env, $name)
+{
+    return $env->getLoader()->getSource($name);
 }
 
 /**

--- a/test/Twig/Tests/Fixtures/functions/source.test
+++ b/test/Twig/Tests/Fixtures/functions/source.test
@@ -1,0 +1,17 @@
+--TEST--
+"source" function
+--TEMPLATE--
+FOO
+{{ source("foo.twig") }}
+
+BAR
+--TEMPLATE(foo.twig)--
+{{ foo }}<br />
+--DATA--
+return array()
+--EXPECT--
+FOO
+
+{{ foo }}<br />
+
+BAR


### PR DESCRIPTION
Replaces #1230.

There is one question about the implementation: Should the content be considered safe (which is the current implementation)?
