### PR TITLE
Fix twig_first and twig_last filters for UTF8 multibyte strings

### DIFF
--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -130,44 +130,6 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
     {
         twig_escape_filter(new Twig_Environment(), 'foo', 'bar');
     }
-
-    public function testFirstFilterOnString()
-    {
-        $twig = new Twig_Environment();
-        $twig->setCharset('ISO-8859-1');
-        $this->assertEquals('f', twig_first($twig, 'foobar'));
-    }
-
-    public function testFirstFilterOnUT8String()
-    {
-        if (!function_exists('mb_get_info')) {
-            $this->markTestSkipped('needs mbstring');
-        }
-
-        $twig = new Twig_Environment();
-        $twig->setCharset('UTF-8');
-
-        $this->assertEquals('Ä', twig_first($twig, 'Ä€é'));
-    }
-
-    public function testLastFilterOnString()
-    {
-        $twig = new Twig_Environment();
-        $twig->setCharset('ISO-8859-1');
-        $this->assertEquals('r', twig_last($twig, 'foobar'));
-    }
-
-    public function testLastFilterOnUT8String()
-    {
-        if (!function_exists('mb_get_info')) {
-            $this->markTestSkipped('needs mbstring');
-        }
-
-        $twig = new Twig_Environment();
-        $twig->setCharset('UTF-8');
-
-        $this->assertEquals('é', twig_last($twig, 'Ä€é'));
-    }
 }
 
 function foo_escaper_for_test(Twig_Environment $env, $string, $charset)

--- a/test/Twig/Tests/Fixtures/filters/first.test
+++ b/test/Twig/Tests/Fixtures/filters/first.test
@@ -5,6 +5,7 @@
 {{ {a: 1, b: 2, c: 3, d: 4}|first }}
 {{ '1234'|first }}
 {{ arr|first }}
+{{ 'Ä€é'|first }}
 --DATA--
 return array('arr' => new ArrayObject(array(1, 2, 3, 4)))
 --EXPECT--
@@ -12,3 +13,4 @@ return array('arr' => new ArrayObject(array(1, 2, 3, 4)))
 1
 1
 1
+Ä

--- a/test/Twig/Tests/Fixtures/filters/last.test
+++ b/test/Twig/Tests/Fixtures/filters/last.test
@@ -5,6 +5,7 @@
 {{ {a: 1, b: 2, c: 3, d: 4}|last }}
 {{ '1234'|last }}
 {{ arr|last }}
+{{ 'Ä€é'|last }}
 --DATA--
 return array('arr' => new ArrayObject(array(1, 2, 3, 4)))
 --EXPECT--
@@ -12,3 +13,4 @@ return array('arr' => new ArrayObject(array(1, 2, 3, 4)))
 4
 4
 4
+é


### PR DESCRIPTION
After string is sliced we already have the right result with a first/last letter for UTF8 string.
