### PR TITLE
Use string instead of large integer

### DIFF
--- a/test/Twig/Tests/LexerTest.php
+++ b/test/Twig/Tests/LexerTest.php
@@ -151,7 +151,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
         $stream = $lexer->tokenize($template);
         $node = $stream->next();
         $node = $stream->next();
-        $this->assertEquals(922337203685477580700, $node->getValue());
+        $this->assertEquals("922337203685477580700", $node->getValue());
     }
 
     public function testStringWithEscapedDelimiter()


### PR DESCRIPTION
HHVM differs from php-src on large integer parsing (php-src converts
them to floats, HHVM truncates them but leaves them as integers). The
point of this test is to make sure Twig parses it correctly, not the
underlying PHP execution engine.
