### PR TITLE
[Docs] Some minor fixes: Typos, Notations, Formatting

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -211,14 +211,14 @@ Automatic Escaping
 ~~~~~~~~~~~~~~~~~~
 
 If automatic escaping is enabled, the output of the filter may be escaped
-before printing. If your filter acts as an escaper (or explicitly outputs html
+before printing. If your filter acts as an escaper (or explicitly outputs HTML
 or JavaScript code), you will want the raw output to be printed. In such a
 case, set the ``is_safe`` option::
 
     $filter = new Twig_SimpleFilter('nl2br', 'nl2br', array('is_safe' => array('html')));
 
 Some filters may need to work on input that is already escaped or safe, for
-example when adding (safe) html tags to originally unsafe output. In such a
+example when adding (safe) HTML tags to originally unsafe output. In such a
 case, set the ``pre_escape`` option to escape the input data before it is run
 through your filter::
 
@@ -278,7 +278,7 @@ to create an instance of ``Twig_SimpleTest``::
     $twig->addTest($test);
 
 Tests allow you to create custom application specific logic for evaluating
-boolean conditions. As a simple, example let's create a Twig test that checks if
+boolean conditions. As a simple example, let's create a Twig test that checks if
 objects are 'red'::
 
     $twig = new Twig_Environment($loader)

--- a/doc/advanced_legacy.rst
+++ b/doc/advanced_legacy.rst
@@ -244,14 +244,14 @@ Automatic Escaping
 ~~~~~~~~~~~~~~~~~~
 
 If automatic escaping is enabled, the output of the filter may be escaped
-before printing. If your filter acts as an escaper (or explicitly outputs html
-or javascript code), you will want the raw output to be printed. In such a
+before printing. If your filter acts as an escaper (or explicitly outputs HTML
+or JavaScript code), you will want the raw output to be printed. In such a
 case, set the ``is_safe`` option::
 
     $filter = new Twig_Filter_Function('nl2br', array('is_safe' => array('html')));
 
 Some filters may need to work on input that is already escaped or safe, for
-example when adding (safe) html tags to originally unsafe output. In such a
+example when adding (safe) HTML tags to originally unsafe output. In such a
 case, set the ``pre_escape`` option to escape the input data before it is run
 through your filter::
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -417,15 +417,15 @@ The escaping rules are implemented as follows:
         {{ var|upper|raw }} {# won't be escaped #}
 
 * Automatic escaping is not applied if the last filter in the chain is marked
-  safe for the current context (e.g. ``html`` or ``js``). ``escaper`` and
-  ``escaper('html')`` are marked safe for html, ``escaper('js')`` is marked
-  safe for javascript, ``raw`` is marked safe for everything.
+  safe for the current context (e.g. ``html`` or ``js``). ``escape`` and
+  ``escape('html')`` are marked safe for HTML, ``escape('js')`` is marked
+  safe for JavaScript, ``raw`` is marked safe for everything.
 
   .. code-block:: jinja
 
         {% autoescape 'js' %}
-            {{ var|escape('html') }} {# will be escaped for html and javascript #}
-            {{ var }} {# will be escaped for javascript #}
+            {{ var|escape('html') }} {# will be escaped for HTML and JavaScript #}
+            {{ var }} {# will be escaped for JavaScript #}
             {{ var|escape('js') }} {# won't be double-escaped #}
         {% endautoescape %}
 

--- a/doc/filters/format.rst
+++ b/doc/filters/format.rst
@@ -8,7 +8,7 @@ The ``format`` filter formats a given string by replacing the placeholders
 
     {{ "I like %s and %s."|format(foo, "bar") }}
 
-    {# returns I like foo and bar
+    {# outputs I like foo and bar
        if the foo parameter equals to the foo string. #}
 
 .. _`sprintf`: http://www.php.net/sprintf

--- a/doc/filters/join.rst
+++ b/doc/filters/join.rst
@@ -15,7 +15,7 @@ define it with the optional first parameter:
 .. code-block:: jinja
 
     {{ [1, 2, 3]|join('|') }}
-    {# returns 1|2|3 #}
+    {# outputs 1|2|3 #}
 
 Arguments
 ---------

--- a/doc/filters/raw.rst
+++ b/doc/filters/raw.rst
@@ -7,6 +7,6 @@ if ``raw`` is the last filter applied to it:
 
 .. code-block:: jinja
 
-    {% autoescape true %}
+    {% autoescape %}
         {{ var|raw }} {# var won't be escaped #}
     {% endautoescape %}

--- a/doc/filters/replace.rst
+++ b/doc/filters/replace.rst
@@ -8,7 +8,7 @@ The ``replace`` filter formats a given string by replacing the placeholders
 
     {{ "I like %this% and %that%."|replace({'%this%': foo, '%that%': "bar"}) }}
 
-    {# returns I like foo and bar
+    {# outputs I like foo and bar
        if the foo parameter equals to the foo string. #}
 
 Arguments

--- a/doc/functions/random.rst
+++ b/doc/functions/random.rst
@@ -18,7 +18,7 @@ parameter type:
 
     {{ random(['apple', 'orange', 'citrus']) }} {# example output: orange #}
     {{ random('ABC') }}                         {# example output: C #}
-    {{ random() }}                              {# example output: 15386094 (works as native PHP `mt_rand`_ function) #}
+    {{ random() }}                              {# example output: 15386094 (works as the native PHP mt_rand function) #}
     {{ random(5) }}                             {# example output: 3 #}
 
 Arguments

--- a/doc/functions/range.rst
+++ b/doc/functions/range.rst
@@ -9,7 +9,7 @@ Returns a list containing an arithmetic progression of integers:
         {{ i }},
     {% endfor %}
 
-    {# returns 0, 1, 2, 3 #}
+    {# outputs 0, 1, 2, 3, #}
 
 When step is given (as the third parameter), it specifies the increment (or
 decrement):
@@ -20,7 +20,7 @@ decrement):
         {{ i }},
     {% endfor %}
 
-    {# returns 0, 2, 4, 6 #}
+    {# outputs 0, 2, 4, 6, #}
 
 The Twig built-in ``..`` operator is just syntactic sugar for the ``range``
 function (with a step of 1):

--- a/doc/functions/source.rst
+++ b/doc/functions/source.rst
@@ -2,7 +2,7 @@
 ==========
 
 .. versionadded:: 1.15
-    The include function was added in Twig 1.15.
+    The source function was added in Twig 1.15.
 
 The ``source`` function returns the content of a template without rendering it:
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -9,7 +9,7 @@ Installing the Twig PHP package
 Installing via Composer (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Install composer in your project:
+1. Install Composer in your project:
 
 .. code-block:: bash
 
@@ -25,7 +25,7 @@ Installing via Composer (recommended)
         }
     }
 
-3. Install via composer
+3. Install via Composer
 
 .. code-block:: bash
 

--- a/doc/recipes.rst
+++ b/doc/recipes.rst
@@ -335,7 +335,7 @@ you have some dynamic JavaScript files thanks to the ``autoescape`` tag:
 
 But if you have many HTML and JS files, and if your template names follow some
 conventions, you can instead determine the default escaping strategy to use
-based on the template name. Let's say that your template names always ends
+based on the template name. Let's say that your template names always end
 with ``.html`` for HTML files, ``.js`` for JavaScript ones, and ``.css`` for
 stylesheets, here is how you can configure Twig::
 

--- a/doc/tags/use.rst
+++ b/doc/tags/use.rst
@@ -35,7 +35,7 @@ but without the associated complexity:
     {% block content %}{% endblock %}
 
 The ``use`` statement tells Twig to import the blocks defined in
-```blocks.html`` into the current template (it's like macros, but for blocks):
+``blocks.html`` into the current template (it's like macros, but for blocks):
 
 .. code-block:: jinja
 

--- a/doc/tests/sameas.rst
+++ b/doc/tests/sameas.rst
@@ -10,5 +10,5 @@ another variable:
 .. code-block:: jinja
 
     {% if foo.attribute is same as(false) %}
-        the foo attribute really is the ``false`` PHP value
+        the foo attribute really is the 'false' PHP value
     {% endif %}


### PR DESCRIPTION
Fixes for:
- Notations: html > HTML; javascript > JavaScript; composer > Composer
- Typos
- Wrong function names: `escaper` > `escape`; `include` > `source` (in new chapter about `source`)
- Formatting issues, e.g. remove RST from code blocks, it's not evaluated
- Wording where code sample outputs something: returns > outputs
- `true` parameter for `autoescape` - not needed any more
