### PR TITLE
Capitalize trim string first

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1255,6 +1255,8 @@ if (function_exists('mb_get_info')) {
      */
     function twig_capitalize_string_filter(Twig_Environment $env, $string)
     {
+        $string = trim($string);
+
         if (null !== ($charset = $env->getCharset())) {
             return mb_strtoupper(mb_substr($string, 0, 1, $charset), $charset).
                          mb_strtolower(mb_substr($string, 1, mb_strlen($string, $charset), $charset), $charset);


### PR DESCRIPTION
When using new lines in your template, it won't work with filter tags:

```
{%filter capitalize %}
    this should be capitalized, but the first char is a tab, so it won't be.
{% endfilter %}
```
