### PR TITLE
[Docs] Fix example: space missing between concatenated strings

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -558,7 +558,7 @@ even if you're not working with PHP you should feel comfortable with it.
 
     .. code-block:: jinja
 
-        {% set greeting = 'Hello' %}
+        {% set greeting = 'Hello ' %}
         {% set name = 'Fabien' %}
 
         {{ greeting ~ name|lower }}   {# Hello fabien #}


### PR DESCRIPTION
The expression `'Hello'~'Fabien'` produces `'HelloFabien'`, not `'Hello Fabien'`. I've just added a space after `'Hello'`.
