### PR TITLE
Fixed rendering of ``-3``

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -642,7 +642,7 @@ but exists for completeness' sake. The following operators are supported:
   ``4``.
 
 * ``//``: Divides two numbers and returns the floored integer result. ``{{ 20
-  // 7 }}`` is ``2``, ``{{ -20  // 7 }}`` is ``-3``(this is just syntactic
+  // 7 }}`` is ``2``, ``{{ -20  // 7 }}`` is ``-3`` (this is just syntactic
   sugar for the :doc:`round<filters/round>` filter).
 
 * ``*``: Multiplies the left operand with the right one. ``{{ 2 * 2 }}`` would


### PR DESCRIPTION
The missing space between "`-3`" and "(this is just syntactic[...])" led to the `-3` being rendered wrong. The parser must've ignored the closing "``" when it was directly followed by a non-space character.
