### PR TITLE
Added support for foo.some_thing === foo.someThing

### DIFF
--- a/ext/twig/twig.c
+++ b/ext/twig/twig.c
@@ -695,6 +695,7 @@ static char *TWIG_GET_CLASS_NAME(zval *object TSRMLS_DC)
 
 static int twig_add_method_to_class(void *pDest APPLY_TSRMLS_DC, int num_args, va_list args, zend_hash_key *hash_key)
 {
+	int from;
 	zval *retval;
 	char *method, *lMethod;
 	size_t method_len;
@@ -715,11 +716,13 @@ static int twig_add_method_to_class(void *pDest APPLY_TSRMLS_DC, int num_args, v
 	add_assoc_string(retval, TWIG_DECAMELIZE(method), method, 1);
 
 	if (method_len > 3 && 0 == strncmp("get", lMethod, 3)) {
-		add_assoc_string(retval, estrndup(lMethod+3, method_len-3), method, 1);
-		add_assoc_string(retval, TWIG_DECAMELIZE(estrndup(method+3, method_len-3)), method, 1);
+		from = lMethod[3] == '_' ? 4 : 3;
+		add_assoc_string(retval, estrndup(lMethod+from, method_len-from), method, 1);
+		add_assoc_string(retval, TWIG_DECAMELIZE(estrndup(method+from, method_len-from)), method, 1);
 	} else if (method_len > 2 && 0 == strncmp("is", lMethod, 2)) {
-		add_assoc_string(retval, estrndup(lMethod+2, method_len-2), method, 1);
-		add_assoc_string(retval, TWIG_DECAMELIZE(estrndup(method+2, method_len-2)), method, 1);
+		from = lMethod[2] == '_' ? 3 : 2;
+		add_assoc_string(retval, estrndup(lMethod+from, method_len-from), method, 1);
+		add_assoc_string(retval, TWIG_DECAMELIZE(estrndup(method+from, method_len-from)), method, 1);
 	}
 
 	return 0;

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -504,7 +504,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
         }
 
         $cache = array_combine($methods, $methods);
-        $keys = array_merge(preg_replace('/^(?:get|is)(.++)$/i', '\\1', $methods), $methods);
+        $keys = array_merge(preg_replace('/^(?:get|is)_?(.++)$/i', '\\1', $methods), $methods);
         $keys = array_merge(preg_replace('/((?<=[a-z]|\d)[A-Z]|(?<!^)[A-Z](?=[a-z]))/', '_\\1', $keys), $keys);
 
         return array('methods' => $cache + array_change_key_case(array_combine($keys, array_merge($methods, $methods, $methods, $methods))));

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -504,8 +504,9 @@ abstract class Twig_Template implements Twig_TemplateInterface
         }
 
         $cache = array_combine($methods, $methods);
-        $keys = preg_replace('/^(?:get|is)(.++)$/i', '\\1', $methods);
+        $keys = array_merge(preg_replace('/^(?:get|is)(.++)$/i', '\\1', $methods), $methods);
+        $keys = array_merge(preg_replace('/((?<=[a-z]|\d)[A-Z]|(?<!^)[A-Z](?=[a-z]))/', '_\\1', $keys), $keys);
 
-        return array('methods' => $cache + array_change_key_case($cache + array_combine($keys, $methods)));
+        return array('methods' => $cache + array_change_key_case(array_combine($keys, array_merge($methods, $methods, $methods, $methods))));
     }
 }

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -378,6 +378,22 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
             array(true, 'httpresponsecode', $methodAndPropObject, 'get_http_response_code', array(), $methodType),
 
             array(true, 'http2_response', $methodAndPropObject, 'http2_response', array(), $anyType),
+
+            array(true, 'responseCode', $methodAndPropObject, 'responseCode', array(), $anyType),
+            array(true, 'responseCode', $methodAndPropObject, 'response_code', array(), $anyType),
+        ));
+
+        $magicPropertyObject = new Twig_TemplateMagicPropertyPropertyObject();
+        $arrayAccessPropertyObject = new Twig_TemplatePropertyArrayAccess();
+
+        // additional property tests
+        $tests = array_merge($tests, array(
+            array(true, 'camelCase', $magicPropertyObject, 'camelCase', array(), $anyType),
+            array(true, 'camelCase', $magicPropertyObject, 'camel_case', array(), $anyType),
+            array(true, 'camelCase', $arrayAccessPropertyObject, 'camelCase', array(), $anyType),
+            array(true, 'camelCase', $arrayAccessPropertyObject, 'camelCase', array(), $arrayType),
+            array(true, 'camelCase', $arrayAccessPropertyObject, 'camel_case', array(), $anyType),
+            array(true, 'camelCase', $arrayAccessPropertyObject, 'camel_case', array(), $arrayType),
         ));
 
         // tests when input is not an array or object
@@ -518,6 +534,21 @@ class Twig_TemplateMagicPropertyObject
     }
 }
 
+class Twig_TemplateMagicPropertyPropertyObject
+{
+    protected $camelCase = 'camelCase';
+
+    public function __isset($name)
+    {
+        return isset($this->$name);
+    }
+
+    public function __get($name)
+    {
+        return $this->$name;
+    }
+}
+
 class Twig_TemplateMagicPropertyObjectWithException
 {
     public function __isset($key)
@@ -574,6 +605,29 @@ class Twig_TemplatePropertyObjectDefinedWithUndefinedValue
     public function __construct()
     {
         $this->foo = @$notExist;
+    }
+}
+
+class Twig_TemplatePropertyArrayAccess implements ArrayAccess
+{
+    protected $camelCase = 'camelCase';
+
+    public function offsetExists($offset)
+    {
+        return isset($this->$offset);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->$offset;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+    }
+
+    public function offsetUnset($offset)
+    {
     }
 }
 
@@ -654,6 +708,8 @@ class Twig_TemplateMethodAndPropObject
     {
         return 'http2_response';
     }
+
+    public $responseCode = 'responseCode';
 }
 
 class Twig_TemplateMagicMethodObject

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -376,6 +376,8 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
 
             array(true, 'httpresponsecode', $methodAndPropObject, 'http_response_code', array(), $anyType),
             array(true, 'httpresponsecode', $methodAndPropObject, 'get_http_response_code', array(), $methodType),
+
+            array(true, 'http2_response', $methodAndPropObject, 'http2_response', array(), $anyType),
         ));
 
         // tests when input is not an array or object
@@ -646,6 +648,11 @@ class Twig_TemplateMethodAndPropObject
     public function GetHTTPResponseCode()
     {
         return 'httpresponsecode';
+    }
+
+    public function get_http2_response()
+    {
+        return 'http2_response';
     }
 }
 

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -365,6 +365,17 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
             array(false, null, $methodAndPropObject, 'c', array(), $methodType),
             array(false, null, $methodAndPropObject, 'c', array(), $arrayType),
 
+            array(true, 'camelcase', $methodAndPropObject, 'camelcase', array(), $anyType),
+            array(true, 'camelcase', $methodAndPropObject, 'camelcase', array(), $methodType),
+
+            array(true, 'camelcase', $methodAndPropObject, 'camelCase', array(), $anyType),
+            array(true, 'camelcase', $methodAndPropObject, 'camelCase', array(), $methodType),
+
+            array(true, 'camelcase', $methodAndPropObject, 'camel_case', array(), $anyType),
+            array(true, 'camelcase', $methodAndPropObject, 'camel_case', array(), $methodType),
+
+            array(true, 'httpresponsecode', $methodAndPropObject, 'http_response_code', array(), $anyType),
+            array(true, 'httpresponsecode', $methodAndPropObject, 'get_http_response_code', array(), $methodType),
         ));
 
         // tests when input is not an array or object
@@ -624,6 +635,17 @@ class Twig_TemplateMethodAndPropObject
     private function getC()
     {
         return 'c';
+    }
+
+    private $camelCase = 'camelcase_prop';
+    public function getCamelCase()
+    {
+        return 'camelcase';
+    }
+
+    public function GetHTTPResponseCode()
+    {
+        return 'httpresponsecode';
     }
 }
 


### PR DESCRIPTION
Alternative implementation of #934. Works well for methods, properties and array calls of objects with minimal performance impact. Results of twig benchmark ([fabpot/twig-perf](https://github.com/fabpot/twig-perf)):

```
                               |       v1.12.3 |       v1.16.3 | origin/master | origin/methods | 
------------------------------------------------------------------------------------------------
empty                          |     13.5  0.0 |      8.8  0.0 |     14.4  0.0 |     20.5  0.0 | 
empty/B                        |      7.9  0.0 |     14.1  0.0 |     14.6  0.0 |     18.9  0.0 | 
simple_attribute               |     88.2  0.9 |     99.8  0.9 |     99.2  0.8 |     99.3  0.9 | 
simple_array_access            |    180.2  1.3 |    132.8  0.9 |    120.6  0.9 |    127.1  1.0 | 
simple_method_access           |     94.4  2.4 |     92.9  2.7 |    101.7  2.7 |    119.7  2.9 | 
simple_attribute_big_context/B |     90.5  0.9 |    101.3  0.9 |    100.5  1.0 |    116.1  1.3 | 
simple_variable                |    710.0  0.7 |    698.6  0.7 |    711.9  0.8 |    680.2  0.7 | 
simple_variable_big_context/B  |    702.2  1.3 |    668.3  1.3 |    795.9  1.2 |    674.3  1.2 | 
simple_foreach                 |     10.9  0.0 |     21.0  0.0 |     15.2  0.0 |     10.7  0.0 | 
simple_foreach/B               |     10.1  5.7 |     16.3  7.7 |      9.9  5.0 |     14.5  4.7 | 
empty_extends                  |      9.5  0.0 |     17.4  0.0 |     17.6  0.0 |     13.9  0.0 | 
empty_extends/B                |     16.1  0.0 |     17.5  0.0 |     10.2  0.0 |     22.6  0.0 | 
empty_include                  |     10.3  0.0 |     10.0  0.0 |     12.1  0.0 |      9.5  0.0 | 
empty_include/B                |     14.8  0.0 |     14.5  0.0 |     15.4  0.0 |     14.4  0.0 | 
standard                       |     22.1  0.0 |     12.6  0.0 |     12.9  0.0 |     14.0  0.0 | 
escaping                       |    101.8  1.2 |    110.9  1.2 |    107.5  0.8 |     99.2  1.0 |
```
