### PR TITLE
Fixed redundant space

### DIFF
--- a/doc/tests/divisibleby.rst
+++ b/doc/tests/divisibleby.rst
@@ -9,6 +9,6 @@
 
 .. code-block:: jinja
 
-    {% if loop.index is divisible by(3) %}
+    {% if loop.index is divisibleby(3) %}
         ...
     {% endif %}


### PR DESCRIPTION
There was a redundant space in document, caused error if copy-paste from docs.
