### PR TITLE
Added a more clear example in the cycle() docs

### DIFF
--- a/doc/functions/cycle.rst
+++ b/doc/functions/cycle.rst
@@ -5,8 +5,11 @@ The ``cycle`` function cycles on an array of values:
 
 .. code-block:: jinja
 
-    {% for i in 0..10 %}
-        {{ cycle(['odd', 'even'], i) }}
+    {% set start_year = date() | date('Y') %}
+    {% set end_year = start_year + 5 %}
+
+    {% for year in start_year..end_year %}
+        {{ cycle(['odd', 'even'], loop.index0) }}
     {% endfor %}
 
 The array can contain any number of values:


### PR DESCRIPTION
We've receive a lot of feedback that the examples for the cycle() tag could be better, so I figured I'd contribute one.

The previous example was potentially misleading if you were focussed on the actual numbers (0 is even, not odd! etc.), and 99% of the time you’re going to be passing loop.index0 into cycle, so I felt that should be included in the example.

I realize that this one requires a little additional setup, but I think the fact that it's a real-world example makes it worth it.
