### PR TITLE
Fix random example with an integer argument

### DIFF
--- a/doc/functions/random.rst
+++ b/doc/functions/random.rst
@@ -19,7 +19,7 @@ parameter type:
     {{ random(['apple', 'orange', 'citrus']) }} {# example output: orange #}
     {{ random('ABC') }}                         {# example output: C #}
     {{ random() }}                              {# example output: 15386094 (works as the native PHP mt_rand function) #}
-    {{ random(5) }}                             {# example output: 3 #}
+    {{ random(3) }}                             {# example output: 5 #}
 
 Arguments
 ---------


### PR DESCRIPTION
Given the implementation, it seems that an integer argument is used as the lower bound of `mt_rand`. If so the output could not be lower than the given argument.

Or I'm missing something :)
