### PR TITLE
Text node: No add echo if there is nothing to echo

### DIFF
--- a/lib/Twig/Node/Text.php
+++ b/lib/Twig/Node/Text.php
@@ -29,7 +29,9 @@ class Twig_Node_Text extends Twig_Node implements Twig_NodeOutputInterface
      */
     public function compile(Twig_Compiler $compiler)
     {
-        $buffer = trim($this->getAttribute('data'));
+ 		$data = $this->getAttribute('data');
+		
+		$buffer = preg_replace( '/\s+/', ' ', $data);
 		
 		if (!empty($buffer))
 		{


### PR DESCRIPTION
In my Twig PHP cache, I can see lot of echo with only white spaces (echo "     ";). This commit will disable useless echos.
