### PR TITLE
Added a md5 string filter

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -170,6 +170,7 @@ class Twig_Extension_Core extends Twig_Extension
             new Twig_SimpleFilter('striptags', 'strip_tags'),
             new Twig_SimpleFilter('trim', 'trim'),
             new Twig_SimpleFilter('nl2br', 'nl2br', array('pre_escape' => 'html', 'is_safe' => array('html'))),
+            new Twig_SimpleFilter('md5', 'md5'),
 
             // array helpers
             new Twig_SimpleFilter('join', 'twig_join_filter'),

--- a/test/Twig/Tests/Fixtures/filters/md5.test
+++ b/test/Twig/Tests/Fixtures/filters/md5.test
@@ -1,0 +1,10 @@
+--TEST--
+"md5" filter
+--TEMPLATE--
+{{ "Twig"|md5 }}
+{{ text|md5 }}
+--DATA--
+return array('text' => "Twig")
+--EXPECT--
+f35d70ddf2f0b7fd184929f9e224d8e7
+f35d70ddf2f0b7fd184929f9e224d8e7


### PR DESCRIPTION
I have added a md5 filter which can be handy when generating gravatar uris for example:

```
<img src="http://www.gravatar.com/avatar/{{ 'twig@example.com'|md5 }}">
```
