### PR TITLE
Improved the error message for inherited templates with contents

### DIFF
--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -364,7 +364,7 @@ class Twig_Parser implements Twig_ParserInterface
             (!$node instanceof Twig_Node_Text && !$node instanceof Twig_Node_BlockReference && $node instanceof Twig_NodeOutputInterface)
         ) {
             if (false !== strpos((string) $node, chr(0xEF).chr(0xBB).chr(0xBF))) {
-                throw new Twig_Error_Syntax('A template that extends another one cannot have a body but a byte order mark (BOM) has been detected; it must be removed.', $node->getLine(), $this->getFilename());
+                throw new Twig_Error_Syntax('The file of a template that extends another one cannot have a byte order mark (BOM); it must be removed.', $node->getLine(), $this->getFilename());
             }
 
             throw new Twig_Error_Syntax('A template that extends another one cannot have contents outside its {% block %} tags.', $node->getLine(), $this->getFilename());

--- a/test/Twig/Tests/ParserTest.php
+++ b/test/Twig/Tests/ParserTest.php
@@ -84,7 +84,7 @@ class Twig_Tests_ParserTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Twig_Error_Syntax
-     * @expectedExceptionMessage A template that extends another one cannot have a body but a byte order mark (BOM) has been detected; it must be removed at line 1.
+     * @expectedExceptionMessage The file of a template that extends another one cannot have a byte order mark (BOM); it must be removed at line 1.
      */
     public function testFilterBodyNodesWithBOM()
     {


### PR DESCRIPTION
A very common error for Twig/Symfony newcomers is to put HTML contents outside
the `{% block %}` tags in templates that inherit from other templates.
Currently, the error message in these situations is the following:

```
'A template that extends another one cannot have a body.'
```

The error message itself isn't very clear (_"to have a body"_??) but it's worse
when you think that it's very common to have a `{% block body %}` in your
templates. This commit tries to improve the error message to:

```
'A template that extends another one cannot have contents outside its {% block %} tags.'
```
