### PR TITLE
Improve the description of the 'same as' test

### DIFF
--- a/doc/tests/sameas.rst
+++ b/doc/tests/sameas.rst
@@ -4,8 +4,8 @@
 .. versionadded:: 1.14.2
     The ``same as`` test was added in Twig 1.14.2 as an alias for ``sameas``.
 
-``same as`` checks if a variable points to the same memory address than
-another variable:
+``same as`` checks if a variable is the same as another variable.
+This is the equivalent to ``===`` in PHP:
 
 .. code-block:: jinja
 


### PR DESCRIPTION
This description of the `same as` test is based on the description in the docblock for `Twig_Node_Expression_Test_Sameas`. It reads better than the one currently used in the docs.
