### PR TITLE
Put the return of the split filter in a variable

### DIFF
--- a/doc/filters/split.rst
+++ b/doc/filters/split.rst
@@ -9,8 +9,8 @@ of strings:
 
 .. code-block:: jinja
 
-    {{ "one,two,three"|split(',') }}
-    {# returns ['one', 'two', 'three'] #}
+    {% set foo = "one,two,three"|split(',') %}
+    {# foo returns ['one', 'two', 'three'] #}
 
 You can also pass a ``limit`` argument:
 
@@ -24,19 +24,19 @@ You can also pass a ``limit`` argument:
 
 .. code-block:: jinja
 
-    {{ "one,two,three,four,five"|split(',', 3) }}
-    {# returns ['one', 'two', 'three,four,five'] #}
+    {% set foo = "one,two,three,four,five"|split(',', 3) %}
+    {# foo returns ['one', 'two', 'three,four,five'] #}
 
 If the ``delimiter`` is an empty string, then value will be split by equal
 chunks. Length is set by the ``limit`` argument (one character by default).
 
 .. code-block:: jinja
 
-    {{ "123"|split('') }}
-    {# returns ['1', '2', '3'] #}
+    {% set foo = "123"|split('') %}
+    {# foo returns ['1', '2', '3'] #}
 
-    {{ "aabbcc"|split('', 2) }}
-    {# returns ['aa', 'bb', 'cc'] #}
+    {% set bar = "aabbcc"|split('', 2) %}
+    {# bar returns ['aa', 'bb', 'cc'] #}
 
 .. note::
 


### PR DESCRIPTION
Split filter returns an array. It's not possible to render the result straight.
See #1411.
