### PR TITLE
Fix exception where node isn't callable

### DIFF
--- a/lib/Twig/Node/Expression/Call.php
+++ b/lib/Twig/Node/Expression/Call.php
@@ -12,7 +12,10 @@ abstract class Twig_Node_Expression_Call extends Twig_Node_Expression
 {
     protected function compileCallable(Twig_Compiler $compiler)
     {
-        $callable = $this->getAttribute('callable');
+        $callable = false;
+        try {
+            $callable = $this->getAttribute('callable');
+        } catch (LogicException $e) {}
 
         $closingParenthesis = false;
         if ($callable) {


### PR DESCRIPTION
I've been trying to upgrade my Tinyboard fork's version of Twig to 1.15.1 from a several years old version. Tinyboard uses the Twig I18n extension (I updated the Extensions folder to Twig-extensions v1.0.1), and an extension of its own that just adds some simple filters. I started getting this exception on most pages after updating Twig:

```
Fatal error: Uncaught exception 'LogicException' with message 'Attribute "callable" does not exist for Node "Twig_Node_Expression_Function".' in /home/mlpchan/www/dev/inc/lib/Twig/Node.php:141
Stack trace:
#0 /home/mlpchan/www/dev/inc/lib/Twig/Node/Expression/Call.php(15): Twig_Node->getAttribute('callable')
#1 /home/mlpchan/www/dev/inc/lib/Twig/Node/Expression/Function.php(33): Twig_Node_Expression_Call->compileCallable(Object(Twig_Compiler))
#2 /home/mlpchan/www/dev/inc/lib/Twig/Compiler.php(97): Twig_Node_Expression_Function->compile(Object(Twig_Compiler))
#3 /home/mlpchan/www/dev/inc/lib/Twig/Node/Print.php(35): Twig_Compiler->subcompile(Object(Twig_Node_Expression_Function))
#4 /home/mlpchan/www/dev/inc/lib/Twig/Node.php(105): Twig_Node_Print->compile(Object(Twig_Compiler))
#5 /home/mlpchan/www/dev/inc/lib/Twig/Node.php(105): Twig_Node->compile(Object(Twig_Compiler))
#6 /home/mlpchan/www/dev/inc/lib/Twig/Compiler.php(97): Twig_Node->compile(Object(Twig_Compiler))
#7 /home/mlpchan/www/dev/inc/lib/Twig/Node/For.php(89) in /home/mlpchan/www/dev/inc/lib/Twig/Environment.php on line 564
```

I think this issue in another project is related: https://github.com/kolber/stacey/pull/91

I notice that Twig_Node_Expression_Function only sometimes sets the 'callable' attribute on itself. Call.php appears to have logic for handling the callable attribute not being set, but it forgets to actually catch the exception if it's not set. I added a try-catch block, and things seem to be all working now. I'm not familiar with the Twig codebase, so someone else will have to judge the correctness of this.
