### PR TITLE
Added support for custom variables in block function

### DIFF
--- a/doc/functions/block.rst
+++ b/doc/functions/block.rst
@@ -1,6 +1,9 @@
 ``block``
 =========
 
+.. versionadded:: 1.28
+    Ability to pass variables to block function was added in Twig 1.28.
+
 When a template uses inheritance and if you want to print a block multiple
 times, use the ``block`` function:
 
@@ -12,4 +15,27 @@ times, use the ``block`` function:
 
     {% block body %}{% endblock %}
 
-.. seealso:: :doc:`extends<../tags/extends>`, :doc:`parent<../functions/parent>`
+The context is passed by default to the block but you can also pass
+additional variables:
+
+.. code-block:: jinja
+
+    {# block title will have access to the variables from the current context and the additional ones provided #}
+    {{ block('title', {foo: 'bar'}) }}
+
+You can disable access to the context by setting ``with_context`` to
+``false``:
+
+.. code-block:: jinja
+
+    {# only the foo variable will be accessible #}
+    {{ block('title', {foo: 'bar'}, with_context = false) }}
+
+Arguments
+---------
+
+* ``name``:           The block to render
+* ``variables``:      The variables to pass to the block
+* ``with_context``:   Whether to pass the current context variables or not
+
+.. seealso:: :doc:`extends<../tags/extends>`, :doc:`parent<../functions/parent>`, :doc:`include<../functions/include>`

--- a/doc/functions/parent.rst
+++ b/doc/functions/parent.rst
@@ -1,6 +1,9 @@
 ``parent``
 ==========
 
+.. versionadded:: 1.28
+    Ability to pass variables to parent function was added in Twig 1.28.
+
 When a template uses inheritance, it's possible to render the contents of the
 parent block when overriding a block by using the ``parent`` function:
 
@@ -16,5 +19,28 @@ parent block when overriding a block by using the ``parent`` function:
 
 The ``parent()`` call will return the content of the ``sidebar`` block as
 defined in the ``base.html`` template.
+
+The context is passed by default to the parent block but you can also pass
+additional variables:
+
+.. code-block:: jinja
+
+    {# parent block will have access to the variables from the current context and the additional ones provided #}
+    {{ parent({foo: 'bar'}) }}
+
+You can disable access to the context by setting ``with_context`` to
+``false``:
+
+.. code-block:: jinja
+
+    {# only the foo variable will be accessible #}
+    {{ parent({foo: 'bar'}, with_context = false) }}
+
+Arguments
+---------
+
+* ``variables``:      The variables to pass to the block
+* ``with_context``:   Whether to pass the current context variables or not
+
 
 .. seealso:: :doc:`extends<../tags/extends>`, :doc:`block<../functions/block>`, :doc:`block<../tags/block>`

--- a/lib/Twig/ExpressionParser.php
+++ b/lib/Twig/ExpressionParser.php
@@ -333,7 +333,7 @@ class Twig_ExpressionParser
     {
         switch ($name) {
             case 'parent':
-                $this->parseArguments();
+                $args = $this->parseArguments(true);
                 if (!count($this->parser->getBlockStack())) {
                     throw new Twig_Error_Syntax('Calling "parent" outside a block is forbidden.', $line, $this->parser->getStream()->getSourceContext()->getName());
                 }
@@ -342,9 +342,11 @@ class Twig_ExpressionParser
                     throw new Twig_Error_Syntax('Calling "parent" on a template that does not extend nor "use" another template is forbidden.', $line, $this->parser->getStream()->getSourceContext()->getName());
                 }
 
-                return new Twig_Node_Expression_Parent($this->parser->peekBlockStack(), $line);
+                return new Twig_Node_Expression_Parent($this->parser->peekBlockStack(), $line, null, $args);
             case 'block':
-                return new Twig_Node_Expression_BlockReference($this->parseArguments()->getNode(0), false, $line);
+                $args = $this->parseArguments(true);
+
+                return new Twig_Node_Expression_BlockReference($args->getNode(0), false, $line, null, $args);
             case 'attribute':
                 $args = $this->parseArguments();
                 if (count($args) < 2) {

--- a/lib/Twig/Node/Expression/BlockReference.php
+++ b/lib/Twig/Node/Expression/BlockReference.php
@@ -14,12 +14,14 @@
  * Represents a block call node.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Martin Hasoň <martin.hason@gmail.com>
  */
-class Twig_Node_Expression_BlockReference extends Twig_Node_Expression
+class Twig_Node_Expression_BlockReference extends Twig_Node_Expression_GeneralCall
 {
-    public function __construct(Twig_NodeInterface $name, $asString = false, $lineno, $tag = null)
+    public function __construct(Twig_NodeInterface $name, $asString = false, $lineno = -1, $tag = null, Twig_Node $arguments = null)
     {
-        parent::__construct(array('name' => $name), array('as_string' => $asString, 'output' => false), $lineno, $tag);
+        $arguments = null === $arguments ? new Twig_Node(array('name' => $name)) : $arguments;
+        parent::__construct(array('name' => $name, 'arguments' => $arguments), array('as_string' => $asString, 'output' => false), $lineno, $tag);
     }
 
     public function compile(Twig_Compiler $compiler)
@@ -28,19 +30,38 @@ class Twig_Node_Expression_BlockReference extends Twig_Node_Expression
             $compiler->raw('(string) ');
         }
 
-        if ($this->getAttribute('output')) {
-            $compiler
-                ->addDebugInfo($this)
-                ->write('$this->displayBlock(')
-                ->subcompile($this->getNode('name'))
-                ->raw(", \$context, \$blocks);\n")
-            ;
+        $output = $this->getAttribute('output');
+        if ($output) {
+            $compiler->addDebugInfo($this)->write('$this->displayBlock(');
         } else {
-            $compiler
-                ->raw('$this->renderBlock(')
-                ->subcompile($this->getNode('name'))
-                ->raw(', $context, $blocks)')
-            ;
+            $compiler->raw('$this->renderBlock(');
         }
+
+        $compiler->subcompile($this->getNode('name'))->raw(', ');
+
+        $arguments = $this->getArgumentsForCallable(array($this, 'blockFunction'), $this->getNode('arguments'), 'function', 'block', false, true);
+
+        if (isset($arguments['variables'])) {
+            $compiler->raw('array_merge(');
+        }
+
+        if (isset($arguments['with_context'])) {
+            $compiler->raw('(')->subcompile($arguments['with_context'])->raw(') ? $context : array()');
+        } else {
+            $compiler->raw('$context');
+        }
+
+        if (isset($arguments['variables'])) {
+            $compiler->raw(', ')->subcompile($arguments['variables'])->raw(')');
+        }
+
+        $compiler->raw($output ? ", \$blocks);\n" : ', $blocks)');
+    }
+
+    /**
+     * This method is used to obtain reflection of arguments.
+     */
+    protected function blockFunction($name, $variables = array(), $withContext = true)
+    {
     }
 }

--- a/lib/Twig/Node/Expression/Call.php
+++ b/lib/Twig/Node/Expression/Call.php
@@ -8,10 +8,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-abstract class Twig_Node_Expression_Call extends Twig_Node_Expression
+abstract class Twig_Node_Expression_Call extends Twig_Node_Expression_GeneralCall
 {
-    private $reflector;
-
     protected function compileCallable(Twig_Compiler $compiler)
     {
         $closingParenthesis = false;
@@ -101,129 +99,17 @@ abstract class Twig_Node_Expression_Call extends Twig_Node_Expression
 
     protected function getArguments($callable, $arguments)
     {
-        $callType = $this->getAttribute('type');
-        $callName = $this->getAttribute('name');
-
-        $parameters = array();
-        $named = false;
-        foreach ($arguments as $name => $node) {
-            if (!is_int($name)) {
-                $named = true;
-                $name = $this->normalizeName($name);
-            } elseif ($named) {
-                throw new Twig_Error_Syntax(sprintf('Positional arguments cannot be used after named arguments for %s "%s".', $callType, $callName));
-            }
-
-            $parameters[$name] = $node;
-        }
-
+        $type = $this->getAttribute('type');
+        $name = $this->getAttribute('name');
         $isVariadic = $this->hasAttribute('is_variadic') && $this->getAttribute('is_variadic');
-        if (!$named && !$isVariadic) {
-            return $parameters;
-        }
 
-        if (!$callable) {
-            if ($named) {
-                $message = sprintf('Named arguments are not supported for %s "%s".', $callType, $callName);
-            } else {
-                $message = sprintf('Arbitrary positional arguments are not supported for %s "%s".', $callType, $callName);
-            }
-
-            throw new LogicException($message);
-        }
-
-        $callableParameters = $this->getCallableParameters($callable, $isVariadic);
-        $arguments = array();
-        $names = array();
-        $missingArguments = array();
-        $optionalArguments = array();
-        $pos = 0;
-        foreach ($callableParameters as $callableParameter) {
-            $names[] = $name = $this->normalizeName($callableParameter->name);
-
-            if (array_key_exists($name, $parameters)) {
-                if (array_key_exists($pos, $parameters)) {
-                    throw new Twig_Error_Syntax(sprintf('Argument "%s" is defined twice for %s "%s".', $name, $callType, $callName));
-                }
-
-                if (!empty($missingArguments)) {
-                    throw new Twig_Error_Syntax(sprintf(
-                        'Argument "%s" could not be assigned for %s "%s(%s)" because it is mapped to an internal PHP function which cannot determine default value for optional argument%s "%s".',
-                        $name, $callType, $callName, implode(', ', $names), count($missingArguments) > 1 ? 's' : '', implode('", "', $missingArguments))
-                    );
-                }
-
-                $arguments = array_merge($arguments, $optionalArguments);
-                $arguments[] = $parameters[$name];
-                unset($parameters[$name]);
-                $optionalArguments = array();
-            } elseif (array_key_exists($pos, $parameters)) {
-                $arguments = array_merge($arguments, $optionalArguments);
-                $arguments[] = $parameters[$pos];
-                unset($parameters[$pos]);
-                $optionalArguments = array();
-                ++$pos;
-            } elseif ($callableParameter->isDefaultValueAvailable()) {
-                $optionalArguments[] = new Twig_Node_Expression_Constant($callableParameter->getDefaultValue(), -1);
-            } elseif ($callableParameter->isOptional()) {
-                if (empty($parameters)) {
-                    break;
-                } else {
-                    $missingArguments[] = $name;
-                }
-            } else {
-                throw new Twig_Error_Syntax(sprintf('Value for argument "%s" is required for %s "%s".', $name, $callType, $callName));
-            }
-        }
-
-        if ($isVariadic) {
-            $arbitraryArguments = new Twig_Node_Expression_Array(array(), -1);
-            foreach ($parameters as $key => $value) {
-                if (is_int($key)) {
-                    $arbitraryArguments->addElement($value);
-                } else {
-                    $arbitraryArguments->addElement($value, new Twig_Node_Expression_Constant($key, -1));
-                }
-                unset($parameters[$key]);
-            }
-
-            if ($arbitraryArguments->count()) {
-                $arguments = array_merge($arguments, $optionalArguments);
-                $arguments[] = $arbitraryArguments;
-            }
-        }
-
-        if (!empty($parameters)) {
-            $unknownParameter = null;
-            foreach ($parameters as $parameter) {
-                if ($parameter instanceof Twig_Node) {
-                    $unknownParameter = $parameter;
-                    break;
-                }
-            }
-
-            throw new Twig_Error_Syntax(sprintf(
-                'Unknown argument%s "%s" for %s "%s(%s)".',
-                count($parameters) > 1 ? 's' : '', implode('", "', array_keys($parameters)), $callType, $callName, implode(', ', $names)
-            ), $unknownParameter ? $unknownParameter->getTemplateLine() : -1);
-        }
-
-        return $arguments;
+        return $this->getArgumentsForCallable($callable, $arguments, $type, $name, $isVariadic);
     }
 
-    protected function normalizeName($name)
+    protected function getParameters(ReflectionFunctionAbstract $reflection)
     {
-        return strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), $name));
-    }
+        $parameters = parent::getParameters($reflection);
 
-    private function getCallableParameters($callable, $isVariadic)
-    {
-        list($r, $_) = $this->reflectCallable($callable);
-        if (null === $r) {
-            return array();
-        }
-
-        $parameters = $r->getParameters();
         if ($this->hasNode('node')) {
             array_shift($parameters);
         }
@@ -238,52 +124,7 @@ abstract class Twig_Node_Expression_Call extends Twig_Node_Expression
                 array_shift($parameters);
             }
         }
-        if ($isVariadic) {
-            $argument = end($parameters);
-            if ($argument && $argument->isArray() && $argument->isDefaultValueAvailable() && array() === $argument->getDefaultValue()) {
-                array_pop($parameters);
-            } else {
-                $callableName = $r->name;
-                if ($r instanceof ReflectionMethod) {
-                    $callableName = $r->getDeclaringClass()->name.'::'.$callableName;
-                }
-
-                throw new LogicException(sprintf('The last parameter of "%s" for %s "%s" must be an array with default value, eg. "array $arg = array()".', $callableName, $this->getAttribute('type'), $this->getAttribute('name')));
-            }
-        }
 
         return $parameters;
-    }
-
-    private function reflectCallable($callable)
-    {
-        if (null !== $this->reflector) {
-            return $this->reflector;
-        }
-
-        if (is_array($callable)) {
-            if (!method_exists($callable[0], $callable[1])) {
-                // __call()
-                return array(null, array());
-            }
-            $r = new ReflectionMethod($callable[0], $callable[1]);
-        } elseif (is_object($callable) && !$callable instanceof Closure) {
-            $r = new ReflectionObject($callable);
-            $r = $r->getMethod('__invoke');
-            $callable = array($callable, '__invoke');
-        } elseif (is_string($callable) && false !== $pos = strpos($callable, '::')) {
-            $class = substr($callable, 0, $pos);
-            $method = substr($callable, $pos + 2);
-            if (!method_exists($class, $method)) {
-                // __staticCall()
-                return array(null, array());
-            }
-            $r = new ReflectionMethod($callable);
-            $callable = array($class, $method);
-        } else {
-            $r = new ReflectionFunction($callable);
-        }
-
-        return $this->reflector = array($r, $callable);
     }
 }

--- a/lib/Twig/Node/Expression/GeneralCall.php
+++ b/lib/Twig/Node/Expression/GeneralCall.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2012 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Represents a general call node.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Martin Hasoň <martin.hason@gmail.com>
+ */
+abstract class Twig_Node_Expression_GeneralCall extends Twig_Node_Expression
+{
+    private $reflector;
+
+    protected function getArgumentsForCallable($callable, $arguments, $callType, $callName, $isVariadic, $assoc = false)
+    {
+        $parameters = array();
+        $named = false;
+        foreach ($arguments as $name => $node) {
+            if (!is_int($name)) {
+                $named = true;
+                $name = $this->normalizeName($name);
+            } elseif ($named) {
+                throw new Twig_Error_Syntax(sprintf('Positional arguments cannot be used after named arguments for %s "%s".', $callType, $callName));
+            }
+
+            $parameters[$name] = $node;
+        }
+
+        if (!$named && !$isVariadic && !$assoc) {
+            return $parameters;
+        }
+
+        if (!$callable) {
+            if ($named) {
+                $message = sprintf('Named arguments are not supported for %s "%s".', $callType, $callName);
+            } else {
+                $message = sprintf('Arbitrary positional arguments are not supported for %s "%s".', $callType, $callName);
+            }
+
+            throw new LogicException($message);
+        }
+
+        $callableParameters = $this->getCallableParameters($callable, $isVariadic);
+        $arguments = array();
+        $names = array();
+        $missingArguments = array();
+        $optionalArguments = array();
+        $pos = 0;
+        foreach ($callableParameters as $callableParameter) {
+            $names[] = $name = $this->normalizeName($callableParameter->name);
+
+            if (array_key_exists($name, $parameters)) {
+                if (array_key_exists($pos, $parameters)) {
+                    throw new Twig_Error_Syntax(sprintf('Argument "%s" is defined twice for %s "%s".', $name, $callType, $callName));
+                }
+
+                if (!empty($missingArguments)) {
+                    throw new Twig_Error_Syntax(sprintf(
+                            'Argument "%s" could not be assigned for %s "%s(%s)" because it is mapped to an internal PHP function which cannot determine default value for optional argument%s "%s".',
+                            $name, $callType, $callName, implode(', ', $names), count($missingArguments) > 1 ? 's' : '', implode('", "', $missingArguments))
+                    );
+                }
+
+                $arguments = array_merge($arguments, $optionalArguments);
+                $arguments[$name] = $parameters[$name];
+                unset($parameters[$name]);
+                $optionalArguments = array();
+            } elseif (array_key_exists($pos, $parameters)) {
+                $arguments = array_merge($arguments, $optionalArguments);
+                $arguments[$name] = $parameters[$pos];
+                unset($parameters[$pos]);
+                $optionalArguments = array();
+                ++$pos;
+            } elseif ($callableParameter->isDefaultValueAvailable()) {
+                $optionalArguments[$name] = new Twig_Node_Expression_Constant($callableParameter->getDefaultValue(), -1);
+            } elseif ($callableParameter->isOptional()) {
+                if (empty($parameters)) {
+                    break;
+                } else {
+                    $missingArguments[] = $name;
+                }
+            } else {
+                throw new Twig_Error_Syntax(sprintf('Value for argument "%s" is required for %s "%s".', $name, $callType, $callName));
+            }
+        }
+
+        if ($isVariadic) {
+            $arbitraryArguments = new Twig_Node_Expression_Array(array(), -1);
+            foreach ($parameters as $key => $value) {
+                if (is_int($key)) {
+                    $arbitraryArguments->addElement($value);
+                } else {
+                    $arbitraryArguments->addElement($value, new Twig_Node_Expression_Constant($key, -1));
+                }
+                unset($parameters[$key]);
+            }
+
+            if ($arbitraryArguments->count()) {
+                $arguments = array_merge($arguments, $optionalArguments);
+                $arguments[] = $arbitraryArguments;
+            }
+        }
+
+        if (!empty($parameters)) {
+            $unknownParameter = null;
+            foreach ($parameters as $parameter) {
+                if ($parameter instanceof Twig_Node) {
+                    $unknownParameter = $parameter;
+                    break;
+                }
+            }
+
+            throw new Twig_Error_Syntax(sprintf(
+                'Unknown argument%s "%s" for %s "%s(%s)".',
+                count($parameters) > 1 ? 's' : '', implode('", "', array_keys($parameters)), $callType, $callName, implode(', ', $names)
+            ), $unknownParameter ? $unknownParameter->getTemplateLine() : -1);
+        }
+
+        return $assoc ? $arguments : array_values($arguments);
+    }
+
+    protected function getParameters(ReflectionFunctionAbstract $reflection)
+    {
+        return $reflection->getParameters();
+    }
+
+    protected function normalizeName($name)
+    {
+        return strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), $name));
+    }
+
+    protected function reflectCallable($callable)
+    {
+        if (null !== $this->reflector) {
+            return $this->reflector;
+        }
+
+        if (is_array($callable)) {
+            if (!method_exists($callable[0], $callable[1])) {
+                // __call()
+                return array(null, array());
+            }
+            $r = new ReflectionMethod($callable[0], $callable[1]);
+        } elseif (is_object($callable) && !$callable instanceof Closure) {
+            $r = new ReflectionObject($callable);
+            $r = $r->getMethod('__invoke');
+            $callable = array($callable, '__invoke');
+        } elseif (is_string($callable) && false !== $pos = strpos($callable, '::')) {
+            $class = substr($callable, 0, $pos);
+            $method = substr($callable, $pos + 2);
+            if (!method_exists($class, $method)) {
+                // __staticCall()
+                return array(null, array());
+            }
+            $r = new ReflectionMethod($callable);
+            $callable = array($class, $method);
+        } else {
+            $r = new ReflectionFunction($callable);
+        }
+
+        return $this->reflector = array($r, $callable);
+    }
+
+    private function getCallableParameters($callable, $isVariadic)
+    {
+        list($r, $_) = $this->reflectCallable($callable);
+        if (null === $r) {
+            return array();
+        }
+
+        $parameters = $this->getParameters($r);
+
+        if ($isVariadic) {
+            $argument = end($parameters);
+            if ($argument && $argument->isArray() && $argument->isDefaultValueAvailable() && array() === $argument->getDefaultValue()) {
+                array_pop($parameters);
+            } else {
+                $callableName = $r->name;
+                if ($r instanceof ReflectionMethod) {
+                    $callableName = $r->getDeclaringClass()->name.'::'.$callableName;
+                }
+
+                throw new LogicException(sprintf('The last parameter of "%s" for %s "%s" must be an array with default value, eg. "array $arg = array()".', $callableName, $this->getAttribute('type'), $this->getAttribute('name')));
+            }
+        }
+
+        return $parameters;
+    }
+}

--- a/lib/Twig/Node/Expression/Parent.php
+++ b/lib/Twig/Node/Expression/Parent.php
@@ -14,29 +14,50 @@
  * Represents a parent node.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Martin Hasoň <martin.hason@gmail.com>
  */
-class Twig_Node_Expression_Parent extends Twig_Node_Expression
+class Twig_Node_Expression_Parent extends Twig_Node_Expression_GeneralCall
 {
-    public function __construct($name, $lineno, $tag = null)
+    public function __construct($name, $lineno, $tag = null, Twig_Node $arguments = null)
     {
-        parent::__construct(array(), array('output' => false, 'name' => $name), $lineno, $tag);
+        $arguments = null === $arguments ? new Twig_Node() : $arguments;
+        parent::__construct(array('arguments' => $arguments), array('output' => false, 'name' => $name), $lineno, $tag);
     }
 
     public function compile(Twig_Compiler $compiler)
     {
-        if ($this->getAttribute('output')) {
-            $compiler
-                ->addDebugInfo($this)
-                ->write('$this->displayParentBlock(')
-                ->string($this->getAttribute('name'))
-                ->raw(", \$context, \$blocks);\n")
-            ;
+        $output = $this->getAttribute('output');
+        if ($output) {
+            $compiler->addDebugInfo($this)->write('$this->displayParentBlock(');
         } else {
-            $compiler
-                ->raw('$this->renderParentBlock(')
-                ->string($this->getAttribute('name'))
-                ->raw(', $context, $blocks)')
-            ;
+            $compiler->raw('$this->renderParentBlock(');
         }
+
+        $compiler->string($this->getAttribute('name'))->raw(', ');
+
+        $arguments = $this->getArgumentsForCallable(array($this, 'parentFunction'), $this->getNode('arguments'), 'function', 'parent', false, true);
+
+        if (isset($arguments['variables'])) {
+            $compiler->raw('array_merge(');
+        }
+
+        if (isset($arguments['with_context'])) {
+            $compiler->raw('(')->subcompile($arguments['with_context'])->raw(') ? $context : array()');
+        } else {
+            $compiler->raw('$context');
+        }
+
+        if (isset($arguments['variables'])) {
+            $compiler->raw(', ')->subcompile($arguments['variables'])->raw(')');
+        }
+
+        $compiler->raw($output ? ", \$blocks);\n" : ', $blocks)');
+    }
+
+    /**
+     * This method is used to obtain reflection of arguments.
+     */
+    protected function parentFunction($variables = array(), $withContext = true)
+    {
     }
 }

--- a/test/Twig/Tests/Fixtures/functions/block/assignment.test
+++ b/test/Twig/Tests/Fixtures/functions/block/assignment.test
@@ -1,0 +1,12 @@
+--TEST--
+"block" function
+--TEMPLATE--
+{% block bar %}BAR{% endblock %}
+
+{% set tmp = block('bar') %}
+FOO{{ tmp }}BAR
+--DATA--
+return array()
+--EXPECT--
+BAR
+FOOBARBAR

--- a/test/Twig/Tests/Fixtures/functions/block/autoescaping.test
+++ b/test/Twig/Tests/Fixtures/functions/block/autoescaping.test
@@ -1,0 +1,11 @@
+--TEST--
+"block" function is safe for auto-escaping
+--TEMPLATE--
+{% block html %}<p>Test</p>{% endblock %}
+
+{{ block('html') }}
+--DATA--
+return array()
+--EXPECT--
+<p>Test</p>
+<p>Test</p>

--- a/test/Twig/Tests/Fixtures/functions/block/expression.test
+++ b/test/Twig/Tests/Fixtures/functions/block/expression.test
@@ -1,0 +1,11 @@
+--TEST--
+"block" function allows expressions for the block
+--TEMPLATE--
+{% block foo %}FOO{% endblock %}
+
+{{ block(foo) }}
+--DATA--
+return array('foo' => 'foo')
+--EXPECT--
+FOO
+FOO

--- a/test/Twig/Tests/Fixtures/functions/block/with_context.test
+++ b/test/Twig/Tests/Fixtures/functions/block/with_context.test
@@ -1,0 +1,19 @@
+--TEST--
+"block" function accept variables and with_context
+--TEMPLATE--
+{% block foo %}{{ foo|default('') }},{{ foo1|default('') }}{% endblock %}
+
+{{ block("foo") }}
+{{ block("foo", with_context = false) }}
+{{ block("foo", {'foo1': 'foo'}) }}
+{{ block("foo", {'foo': 'foo'}) }}
+{{ block("foo", {'foo1': 'foo'}, with_context = false) }}
+--DATA--
+return array('foo' => 'bar')
+--EXPECT--
+bar,
+bar,
+,
+bar,foo
+foo,
+,foo

--- a/test/Twig/Tests/Fixtures/functions/block/with_variables.test
+++ b/test/Twig/Tests/Fixtures/functions/block/with_variables.test
@@ -1,0 +1,12 @@
+--TEST--
+"block" function accept variables
+--TEMPLATE--
+{% block foo %}{{ foo|default('') }}{% endblock %}
+{{ block("foo", {'foo': 'bar'}) }}
+{{ block("foo", vars) }}
+--DATA--
+return array('vars' => array('foo' => 'bar'))
+--EXPECT--
+
+bar
+bar

--- a/test/Twig/Tests/Fixtures/functions/parent/with_context.test
+++ b/test/Twig/Tests/Fixtures/functions/parent/with_context.test
@@ -1,0 +1,24 @@
+--TEST--
+"parent" function accept variables and with_context
+--TEMPLATE--
+{% extends "foo.twig" %}
+
+{% block foo %}
+    {{- parent() }}
+    {{- parent(with_context = false) }}
+    {{- parent({'foo1': 'foo'}) }}
+    {{- parent({'foo': 'foo'}) }}
+    {{- parent({'foo1': 'foo'}, with_context = false) }}
+{% endblock %}
+--TEMPLATE(foo.twig)--
+{% block foo %}
+    {{- foo|default('') }},{{ foo1|default('') }}
+{% endblock %}
+--DATA--
+return array('foo' => 'bar')
+--EXPECT--
+bar,
+,
+bar,foo
+foo,
+,foo

--- a/test/Twig/Tests/Fixtures/functions/parent/with_variables.test
+++ b/test/Twig/Tests/Fixtures/functions/parent/with_variables.test
@@ -1,0 +1,19 @@
+--TEST--
+"parent" function accept variables
+--TEMPLATE()--
+{% extends "foo.twig" %}
+{% block foo %}
+    {{- parent() }}
+    {{- parent({'foo': 'foo'}) }}
+    {{- parent(vars) }}
+{% endblock %}
+--TEMPLATE(foo.twig)--
+{% block foo %}
+    {{- foo|default('') }}
+{% endblock %}
+--DATA--
+return array('vars' => array('foo' => 'bar'))
+--EXPECT--
+
+foo
+bar


### PR DESCRIPTION
If you must use this workaround:

``` jinja
{# blocks.twig #}
{% block foo %}
{{ var }}
{% endblock %}

{# page.twig #}
{% use "blocks.twig" %}
{% set oldvar = var %}
{% set var = "newvalue" %}
{{ block("foo") }}
{% set var = oldvar %}
```

After this PR everything will be easier:

``` jinja
{# page.twig #}
{% use "blocks.twig" %}
{{ block("foo", {"var": "newvalue"}) }}
```

Fixes #1302 

TODO:
- [x] Add same functionality for `parent()`
- [x] Documentation
