### PR TITLE
Add ability to load from windows root

### DIFF
--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -185,6 +185,8 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
         foreach ($this->paths[$namespace] as $path) {
             if (is_file($path.'/'.$shortname)) {
                 return $this->cache[$name] = $path.'/'.$shortname;
+            } elseif ($path == '/' && is_file($name)) {
+                return $this->cache[$name] = $name;
             }
         }
 


### PR DESCRIPTION
Currently there is no way, as far as I know, to load a template from a full windows path (ie: D:\projects\myproject\template.twig).
I don't code in windows, but some members on our team do, and we use Zend Framework which returns full paths to the templates needed.  Needless to say, our app doesn't work on a windows machine.  We have an extension in place to work around it, but it's an easy fix so I thought I'd do a pull request.
Credit for code goes to:  http://stackoverflow.com/a/8074029
