### PR TITLE
Simplify exists method in Filesystem Loader

### DIFF
--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -143,12 +143,6 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
      */
     public function exists($name)
     {
-        $name = $this->normalizeName($name);
-
-        if (isset($this->cache[$name])) {
-            return true;
-        }
-
         try {
             $this->findTemplate($name);
 


### PR DESCRIPTION
These lines are exactly the same as the first lines in findTemplate(), so why not just use findTemplate to begin with?
