### PR TITLE
add mb support for split function, better replace support

### DIFF
--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -130,6 +130,79 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
     {
         twig_escape_filter(new Twig_Environment(), 'foo', 'bar');
     }
+
+    public function testSplit()
+    {
+        $twig = new Twig_Environment();
+
+        $input = "one,two,three";
+        $output = twig_split_filter($twig, $input, ',');
+        $this->assertSame(array("one", "two", "three"), $output);
+
+        $input = "one,two,three,four,five";
+        $output = twig_split_filter($twig, $input, ',', 3);
+        $this->assertSame(array("one", "two", "three,four,five"), $output);
+
+        $input = "123";
+
+        $output = twig_split_filter($twig, $input, '');
+        $this->assertSame(array("1", "2", "3"), $output);
+
+        $output = twig_split_filter($twig, $input, '', 1);
+        $this->assertSame(array("1", "2", "3"), $output);
+
+        $input = "aabbcc";
+        $output = twig_split_filter($twig, $input, '', 2);
+        $this->assertSame(array("aa", "bb", "cc"), $output);
+
+        if (!function_exists('mb_get_info')) {
+            $this->markTestSkipped('needs mb_get_info');
+        }
+
+        $twig = new Twig_Environment();
+        $twig->setCharset('UTF-8');
+
+        $input = "é";
+        $output = twig_split_filter($twig, $input, '', 10);
+        $this->assertSame(array("é"), $output);
+
+        $input = "éÄéごÄß";
+        $output = twig_split_filter($twig, $input, '');
+        $this->assertSame(array("é", "Ä", "é", "ご", "Ä", "ß"), $output);
+
+        $input = "éÄoÄ";
+        $output = twig_split_filter($twig, $input, '', 2);
+        $this->assertSame(array("éÄ", "oÄ"), $output);
+
+        $input = "éÄéÄÄ";
+        $output = twig_split_filter($twig, $input, '', 3);
+        $this->assertSame(array("éÄé", "ÄÄ"), $output);
+
+        $input = "é,ÄoÄ";
+        $output = twig_split_filter($twig, $input, ',');
+        $this->assertSame(array("é", "ÄoÄ"), $output);
+
+        $input = "éßÄ,éÄ日,Ä";
+        $output = twig_split_filter($twig, $input, ',');
+        $this->assertSame(array("éßÄ", "éÄ日", "Ä"), $output);
+
+        $input = "éÄ,éÄ,Ä,Ä,Ä,Ä,Ä,Äほ";
+        $output = twig_split_filter($twig, $input, ',', 3);
+        $this->assertSame(array("éÄ", "éÄ", "Ä,Ä,Ä,Ä,Ä,Äほ"), $output);
+    }
+
+    public function testReplaceFilter()
+    {
+        $input = "I like %this% and %that% ß and even %this%";
+        $replace = array('%this%' => "foo", "%that%" => "bar");
+        $output = twig_replace_filter($input, $replace);
+        $this->assertSame($output, "I like foo and bar ß and even foo");
+
+        $replace = '%this%';
+        $with = "fooß";
+        $output = twig_replace_filter($input, $replace, $with);
+        $this->assertSame($output, "I like fooß and %that% ß and even fooß");
+    }
 }
 
 function foo_escaper_for_test(Twig_Environment $env, $string, $charset)


### PR DESCRIPTION
This adds multibyte character support for the spilt function.
For example:
"éÄ,éÄ,Ä,Ä,Ä,Ä,Ä,Äほ"|split(',', 3)
Into:
Array
  0 =>éÄ
  1 =>éÄ
  2 =>Ä,Ä,Ä,Ä,Ä,Äほ

And {% set foo = "éÄéÄÄ"|split('', 3) %}
Into:
Array
  0 =>éÄé
  1 =>ÄÄ

Fix for the replace filter.
When using the current replace filter like this:
{{ "I like %this% and %that%."|replace('%this%', 'foo') }}
The result is:
"I like fooisf and fooaof."

With this fix the result is:
"I like foo and %that%."

And added tests for this.
