### PR TITLE
Fixed 'starts with' operator for empty needle

### DIFF
--- a/lib/Twig/Compiler.php
+++ b/lib/Twig/Compiler.php
@@ -267,4 +267,9 @@ class Twig_Compiler implements Twig_CompilerInterface
 
         return $this;
     }
+
+    public function getVarName()
+    {
+        return sprintf('__internal_%s', hash('sha256', uniqid(mt_rand(), true), false));
+    }
 }

--- a/lib/Twig/Node/Expression/Binary/StartsWith.php
+++ b/lib/Twig/Node/Expression/Binary/StartsWith.php
@@ -12,12 +12,13 @@ class Twig_Node_Expression_Binary_StartsWith extends Twig_Node_Expression_Binary
 {
     public function compile(Twig_Compiler $compiler)
     {
+        $varName = $compiler->getVarName();
         $compiler
-            ->raw('(0 === strpos(')
-            ->subcompile($this->getNode('left'))
-            ->raw(', ')
+            ->raw(sprintf("(('' === (\$%s = ", $varName))
             ->subcompile($this->getNode('right'))
-            ->raw('))')
+            ->raw(')) ? true : 0 === strpos(')
+            ->subcompile($this->getNode('left'))
+            ->raw(sprintf(', $%s))', $varName))
         ;
     }
 

--- a/test/Twig/Tests/Fixtures/expressions/starts_with.test
+++ b/test/Twig/Tests/Fixtures/expressions/starts_with.test
@@ -7,6 +7,10 @@ Twig supports the "starts with" operator
 {{ 'foo' starts      with 'f' ? 'OK' : 'KO' }}
 {{ 'foo' starts
 with 'f' ? 'OK' : 'KO' }}
+{{ 'foo' starts with '' ? 'OK' : 'KO' }}
+{{ '1' starts with true ? 'OK' : 'KO' }}
+{{ '' starts with false ? 'OK' : 'KO' }}
+{{ 'a' starts with false ? 'OK' : 'KO' }}
 --DATA--
 return array()
 --EXPECT--
@@ -15,3 +19,7 @@ OK
 OK
 OK
 OK
+OK
+KO
+KO
+KO


### PR DESCRIPTION
Fixes #1432
