### PR TITLE
Fixed the `matches` operator code example

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -693,7 +693,7 @@ string:
 
     .. code-block:: jinja
 
-        {% if phone matches '{^[\d\.]+$}' %}
+        {% if phone matches '/^[\\d\\.]+$/' %}
         {% endif %}
 
 Containment Operator


### PR DESCRIPTION
A customer just pointed out that your `matches` operator code example wasn't working for them, and it ended up being because its backslashes themselves needed to be escaped by additional backslashes. (I've verified this.)

While I was editing it, I also switched to forwardslash delimiters on the regex, since those are much more commonly used than curly brackets. (I hadn't even been aware that curly brackets are allowed.) To back that assertion up, [PHP's official preg_quote() docs](http://php.net/manual/en/function.preg-quote.php) state:

> The `/` is the most commonly used delimiter.
