### PR TITLE
Get rid of naming clash

### DIFF
--- a/lib/Twig/Compiler.php
+++ b/lib/Twig/Compiler.php
@@ -181,14 +181,14 @@ class Twig_Compiler implements Twig_CompilerInterface
         } elseif (is_array($value)) {
             $this->raw('array(');
             $first = true;
-            foreach ($value as $key => $value) {
+            foreach ($value as $key => $v) {
                 if (!$first) {
                     $this->raw(', ');
                 }
                 $first = false;
                 $this->repr($key);
                 $this->raw(' => ');
-                $this->repr($value);
+                $this->repr($v);
             }
             $this->raw(')');
         } else {


### PR DESCRIPTION
Static code analysis tool did not like this.
Looks like it was wrong before. Tests unchanged though.
