### PR TITLE
Fix type hint

### DIFF
--- a/test/Twig/Tests/escapingTest.php
+++ b/test/Twig/Tests/escapingTest.php
@@ -227,7 +227,7 @@ class Twig_Test_EscapingTest extends PHPUnit_Framework_TestCase
     /**
      * Convert a Unicode Codepoint to a literal UTF-8 character.
      *
-     * @param int Unicode codepoint in hex notation
+     * @param int $codepoint Unicode codepoint in hex notation
      * @return string UTF-8 literal string
      */
     protected function codepointToUtf8($codepoint)


### PR DESCRIPTION
PHPStorm wrongly inferred the type 'Unicode'
