### PR TITLE
Introduced methods in Module and Import nodes to easy extend loading of templates

### DIFF
--- a/lib/Twig/Node/Import.php
+++ b/lib/Twig/Node/Import.php
@@ -35,6 +35,13 @@ class Twig_Node_Import extends Twig_Node
             ->raw(' = ')
         ;
 
+        $this->addGetTemplate($compiler);
+
+        $compiler->raw(";\n");
+    }
+
+    protected function addGetTemplate(Twig_Compiler $compiler)
+    {
         if ($this->getNode('expr') instanceof Twig_Node_Expression_Name && '_self' === $this->getNode('expr')->getAttribute('name')) {
             $compiler->raw("\$this");
         } else {
@@ -48,7 +55,5 @@ class Twig_Node_Import extends Twig_Node
                 ->raw(")")
             ;
         }
-
-        $compiler->raw(";\n");
     }
 }

--- a/lib/Twig/Node/Module.php
+++ b/lib/Twig/Node/Module.php
@@ -113,15 +113,7 @@ class Twig_Node_Module extends Twig_Node
         if ($parent instanceof Twig_Node_Expression_Constant) {
             $compiler->subcompile($parent);
         } else {
-            $compiler
-                ->raw("\$this->loadTemplate(")
-                ->subcompile($parent)
-                ->raw(', ')
-                ->repr($compiler->getFilename())
-                ->raw(', ')
-                ->repr($this->getNode('parent')->getLine())
-                ->raw(")")
-            ;
+            $this->compileGetTemplate($compiler, $parent);
         }
 
         $compiler
@@ -157,16 +149,8 @@ class Twig_Node_Module extends Twig_Node
         if (null === $parent = $this->getNode('parent')) {
             $compiler->write("\$this->parent = false;\n\n");
         } elseif ($parent instanceof Twig_Node_Expression_Constant) {
-            $compiler
-                ->addDebugInfo($parent)
-                ->write("\$this->parent = \$this->loadTemplate(")
-                ->subcompile($parent)
-                ->raw(', ')
-                ->repr($compiler->getFilename())
-                ->raw(', ')
-                ->repr($this->getNode('parent')->getLine())
-                ->raw(");\n")
-            ;
+            $compiler->addDebugInfo($parent);
+            $this->compileLoadTemplate($compiler, $parent, '$this->parent');
         }
 
         $countTraits = count($this->getNode('traits'));
@@ -391,33 +375,21 @@ class Twig_Node_Module extends Twig_Node
 
     protected function compileLoadTemplate(Twig_Compiler $compiler, $node, $var)
     {
-        if ($node instanceof Twig_Node_Expression_Constant) {
-            $compiler
-                ->write(sprintf("%s = \$this->loadTemplate(", $var))
-                ->subcompile($node)
-                ->raw(', ')
-                ->repr($compiler->getFilename())
-                ->raw(', ')
-                ->repr($node->getLine())
-                ->raw(");\n")
-            ;
-        } else {
-            $compiler
-                ->write(sprintf("%s = ", $var))
-                ->subcompile($node)
-                ->raw(";\n")
-                ->write(sprintf("if (!%s", $var))
-                ->raw(" instanceof Twig_Template) {\n")
-                ->indent()
-                ->write(sprintf("%s = \$this->loadTemplate(%s")
-                ->raw(', ')
-                ->repr($compiler->getFilename())
-                ->raw(', ')
-                ->repr($node->getLine())
-                ->raw(");\n", $var, $var))
-                ->outdent()
-                ->write("}\n")
-            ;
-        }
+        $compiler->write(sprintf('%s = ', $var));
+        $this->compileGetTemplate($compiler, $node);
+        $compiler->raw(";\n");
+    }
+
+    protected function compileGetTemplate(Twig_Compiler $compiler, $node)
+    {
+        $compiler
+            ->raw("\$this->loadTemplate(")
+            ->subcompile($node)
+            ->raw(', ')
+            ->repr($compiler->getFilename())
+            ->raw(', ')
+            ->repr($node->getLine())
+            ->raw(")")
+        ;
     }
 }


### PR DESCRIPTION
In inherited class I want to note that a node requires loading the concrete template. Similar to `Twig_Node_Embed` and `Twig_Node_Include`.
