### PR TITLE
Delimit comment in template using correct syntax

### DIFF
--- a/doc/tags/use.rst
+++ b/doc/tags/use.rst
@@ -39,7 +39,8 @@ The ``use`` statement tells Twig to import the blocks defined in
 
 .. code-block:: jinja
 
-    # blocks.html
+    {# blocks.html #}
+    
     {% block sidebar %}{% endblock %}
 
 In this example, the ``use`` statement imports the ``sidebar`` block into the


### PR DESCRIPTION
Enclose the comment in '{# #}' instead of beginning line with '#'.
