### PR TITLE
Update convert_encoding.rst: wrong argument order

### DIFF
--- a/doc/filters/convert_encoding.rst
+++ b/doc/filters/convert_encoding.rst
@@ -21,8 +21,8 @@ is the input charset:
 Arguments
 ---------
 
-* ``from``: The input charset
 * ``to``:   The output charset
+* ``from``: The input charset
 
 .. _`iconv`:    http://php.net/iconv
 .. _`mbstring`: http://php.net/mbstring


### PR DESCRIPTION
The arguments are in incorrect order. The first should be `to` and the second should be `from` - just like the text describes it.
