### PR TITLE
Function block(name) doesn't work with traits and nested blocks

### DIFF
--- a/test/Twig/Tests/Fixtures/tags/inheritance/use_nested_blocks.test
+++ b/test/Twig/Tests/Fixtures/tags/inheritance/use_nested_blocks.test
@@ -1,0 +1,24 @@
+--TEST--
+"block" function in context of traits
+--TEMPLATE--
+{% extends "parent.twig" %}
+
+{% use "use.twig" %}
+
+{% block in2 %}{{ parent() }} redefined{% endblock %}
+
+--TEMPLATE(parent.twig)--
+{% block out1 %}{% block in1 %}in1{% endblock %}{% endblock %}
+
+{% block out2 %}{% block in2 %}in2{% endblock %}{% endblock %}
+
+--TEMPLATE(use.twig)--
+{% block out1 %}<i>{{ block('in1') }}</i>{% endblock %}
+
+{% block out2 %}<i>{{ block('in2') }}</i>{% endblock %}
+
+--DATA--
+return array()
+--EXPECT--
+<i>in1</i>
+<i>in2 redefined</i>


### PR DESCRIPTION
In a complex Twig project, involving multi-inheritance with traits (`use` tag), I'm stuck on an inconsistent behavior of the `block()` function.

When an block is overrided in a trait, the blocks that where defined inside the parent block are not available in the trait while I can include them in the main template.

This PR adds a failing test case.
