### PR TITLE
date() documentation correction

### DIFF
--- a/doc/functions/date.rst
+++ b/doc/functions/date.rst
@@ -15,7 +15,7 @@ Converts an argument to a date to allow date comparison:
         {# do something #}
     {% endif %}
 
-The argument must be in a format supported by the `date`_ function.
+The argument must be in one of PHP’s supported `date and time formats`_.
 
 You can pass a timezone as the second argument:
 
@@ -49,4 +49,4 @@ Arguments
 * ``date``:     The date
 * ``timezone``: The timezone
 
-.. _`date`: http://www.php.net/date
+.. _`date and time formats`: http://php.net/manual/en/datetime.formats.php


### PR DESCRIPTION
The date() docs were incorrectly stating that the argument should be in a format supported by PHP’s [date()](http://php.net/manual/en/function.date.php) function. That’s true of the |date filter which is used to _format_ dates, but not the date() function, which is used to _create_ new dates.

I double-checked the code and whatever you pass into date() ultimately will get passed to a [DateTime constructor](http://php.net/manual/en/datetime.construct.php), which accepts an actual date string, formatted in one of PHP’s [date and time format](http://php.net/manual/en/datetime.formats.php), which is a different beast than the actual format definition string you might pass into PHP’s date() function.
