### PR TITLE
minor fix in the Core.php Extension

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -400,7 +400,7 @@ function twig_random(Twig_Environment $env, $values = null)
             return '';
         }
         if (null !== $charset = $env->getCharset()) {
-            if ('UTF-8' != $charset) {
+            if ('UTF-8' !== $charset) {
                 $values = twig_convert_encoding($values, 'UTF-8', $charset);
             }
 
@@ -408,7 +408,7 @@ function twig_random(Twig_Environment $env, $values = null)
             // split at all positions, but not after the start and not before the end
             $values = preg_split('/(?<!^)(?!$)/u', $values);
 
-            if ('UTF-8' != $charset) {
+            if ('UTF-8' !== $charset) {
                 foreach ($values as $i => $value) {
                     $values[$i] = twig_convert_encoding($value, $charset, 'UTF-8');
                 }

--- a/lib/Twig/Loader/Array.php
+++ b/lib/Twig/Loader/Array.php
@@ -30,7 +30,7 @@ class Twig_Loader_Array implements Twig_LoaderInterface, Twig_ExistsLoaderInterf
      *
      * @see Twig_Loader
      */
-    public function __construct(array $templates)
+    public function __construct(array $templates = array())
     {
         $this->templates = $templates;
     }

--- a/lib/Twig/Token.php
+++ b/lib/Twig/Token.php
@@ -17,10 +17,6 @@
  */
 class Twig_Token
 {
-    protected $value;
-    protected $type;
-    protected $lineno;
-
     const EOF_TYPE                  = -1;
     const TEXT_TYPE                 = 0;
     const BLOCK_START_TYPE          = 1;
@@ -34,6 +30,10 @@ class Twig_Token
     const PUNCTUATION_TYPE          = 9;
     const INTERPOLATION_START_TYPE  = 10;
     const INTERPOLATION_END_TYPE    = 11;
+    
+    protected $value;
+    protected $type;
+    protected $lineno;
 
     /**
      * Constructor.


### PR DESCRIPTION
A small fix in the "twig_random" function of the "Core" Extension.
We should use "!==" instead of "!=" since it's better and faster in this case.