### PR TITLE
Add literal block identifier so edge cases render

### DIFF
--- a/doc/tags/if.rst
+++ b/doc/tags/if.rst
@@ -47,6 +47,8 @@ more complex ``expressions`` there too:
     The rules to determine if an expression is ``true`` or ``false`` are the
     same as in PHP; here are the edge cases rules:
 
+::
+
     =======                ====================
      Value                  Boolean evaluation
     =======                ====================


### PR DESCRIPTION
This was missing the literal display block prefix, so the edge cases failed to render.
