### PR TITLE
[doc] [api.rst] Correct base template name

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -199,7 +199,7 @@ projects where storing all templates in a single PHP file might make sense.
         'base.html' => '{% block content %}{% endblock %}',
     ));
     $loader2 = new Twig_Loader_Array(array(
-        'index.html' => '{% extends "base.twig" %}{% block content %}Hello {{ name }}{% endblock %}',
+        'index.html' => '{% extends "base.html" %}{% block content %}Hello {{ name }}{% endblock %}',
         'base.html'  => 'Will never be loaded',
     ));
 


### PR DESCRIPTION
The base template name used in $loader1 and $loader2 is actually "base.html", not "base.twig".
