### PR TITLE
Update installation.rst

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -13,7 +13,7 @@ Install `Composer`_ and run the following command to get the latest version:
 
 .. code-block:: bash
 
-    composer require twig/twig:~1.0
+    composer require twig/twig
 
 Installing from the tarball release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Updated composer installation information.
Composer now auto-resolves the latest version of required packages using `composer require package` so there is no need to provide a version number in  the install instructions. Makes it simpler to reproduce and to keep docs up to date.