### PR TITLE
Added template information on debug mode

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -53,6 +53,8 @@ class Twig_Environment
      *  * debug: When set to true, it automatically set "auto_reload" to true as
      *           well (default to false).
      *
+     *  * template_info: Whether to enable template information on debugging (default to false).
+     *
      *  * charset: The charset used by the templates (default to UTF-8).
      *
      *  * base_template_class: The base template class to use for generated
@@ -89,6 +91,7 @@ class Twig_Environment
 
         $options = array_merge(array(
             'debug'               => false,
+            'template_info'       => false,
             'charset'             => 'UTF-8',
             'base_template_class' => 'Twig_Template',
             'strict_variables'    => false,
@@ -109,6 +112,9 @@ class Twig_Environment
         $this->filterCallbacks = array();
 
         $this->addExtension(new Twig_Extension_Core());
+        if ($this->debug && $options['template_info']) {
+            $this->addExtension(new Twig_Extension_Debug(array('enable' => true, 'format' => $options['autoescape'])));
+        }
         $this->addExtension(new Twig_Extension_Escaper($options['autoescape']));
         $this->addExtension(new Twig_Extension_Optimizer($options['optimizations']));
         $this->extensionInitialized = false;

--- a/lib/Twig/Extension/Debug.php
+++ b/lib/Twig/Extension/Debug.php
@@ -10,6 +10,48 @@
  */
 class Twig_Extension_Debug extends Twig_Extension
 {
+    private $enableInfo;
+    private $format;
+    private $formats;
+
+    /**
+     * Constructor.
+     *
+     * Available options:
+     *
+     *  * enable_info: Whether to display template information (default to false).
+     *
+     *  * format: Format used for displaying information templates (default: 'html')
+     *
+     *  * formats: Formats available for formating:
+     *               * 'html': '<!-- %1$s -->%3$s%2$s%3$s<!-- // %1$s -->%3$s'
+     *               * 'js': '// %1$s%3$s%2$s%3$s'
+     *               * 'css': '\/\* %1$s \*\/%3$s%2$s%3$s'
+     *
+     * @param array $options
+     */
+    public function __construct(array $options = null)
+    {
+        // BC
+        if (!is_array($options)) {
+            $options = array();
+        }
+
+        $options = array_merge(array(
+            'enable_info'   => false,
+            'format'        => 'html',
+            'formats'       => array(
+                'html'      => '<!-- %1$s -->%3$s%2$s%3$s<!-- // %1$s -->%3$s',
+                'js'        => '// %1$s%3$s%2$s%3$s',
+                'css'       => '/* %1$s */%3$s%2$s%3$s',
+            ),
+        ), $options);
+
+        $this->enableInfo   = $options['enable_info'];
+        $this->format       = $options['format'];
+        $this->formats      = $options['formats'];
+    }
+
     /**
      * Returns a list of global functions to add to the existing list.
      *
@@ -40,6 +82,113 @@ class Twig_Extension_Debug extends Twig_Extension
     public function getName()
     {
         return 'debug';
+    }
+
+    /**
+     * Enables display of information alogn side template rendering
+     */
+    public function enableInfo()
+    {
+        $this->enableInfo = true;
+    }
+
+    /**
+     * Disables display of information alogn side template rendering
+     */
+    public function disableInfo()
+    {
+        $this->enableInfo = false;
+    }
+
+    /**
+     * Returns whether it's enabled to display template information
+     *
+     * @return bool
+     */
+    public function isEnabledInfo()
+    {
+        return $this->enableInfo;
+    }
+
+    /**
+     * Sets the string format used to display information
+     *
+     * @param string|callable $format
+     */
+    public function setFormat($format)
+    {
+        $this->format = $format;
+    }
+
+    /**
+     * Returns the current string format used to display information
+     *
+     * @return string|callable
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
+     * Returns the list of available format strings
+     *
+     * @return array
+     */
+    public function getFormats()
+    {
+        return $this->formats;
+    }
+
+    /**
+     * Sets the list of available format strings
+     *
+     * @param array $formats
+     */
+    public function setFormats(array $formats)
+    {
+        $this->formats = $formats;
+    }
+
+    /**
+     * Adds a format string
+     *
+     * @param $key     Format to use the format string with
+     * @param $format  Format string
+     */
+    public function addFormat($key, $format)
+    {
+        $this->formats[$key] = $format;
+    }
+
+    /**
+     * Removes a given format from the format available list
+     *
+     * @param string $key Format to remove
+     */
+    public function removeFormat($key)
+    {
+        unset($this->formats[$key]);
+    }
+
+    /**
+     * Returns the format string used for this template.
+     *
+     * If no format string is found for the current `format` then the default formating is used.
+     *
+     * @param string $filename  Optional filename when using a callback $format
+     * @param string $fallback  Optional fallback format
+     *
+     * @return string
+     */
+    public function getFormatString($filename = null, $fallback = '%2$s')
+    {
+        $format = $this->format;
+        if (is_callable($this->format)) {
+            $format = call_user_func($this->format, $filename);
+        }
+
+        return isset($this->formats[$format]) ? $this->formats[$format] : $fallback;
     }
 }
 


### PR DESCRIPTION
Searched on issues and PRs but could not find something like this so I gave it a try. I don't have a deep knowledge of twig code base so I don't know is this approach is the best (or correct) but I think the idea is useful.

On debug mode (with `template_info` set to `true`) all included templates are wrapped by the path information for the template.
This is useful for easily moving in a code base which is not very well know to the developer (ie, a legacy code base or a new developer joining a project).

Example output:

    <!-- AcmeDemoBundle:Footer:Default.html.twig -->
    <div class="footer container">
    ...
    </div>

    <!-- // AcmeDemoBundle:Footer:Default.html.twig -->

The default format is (for html):

    <!-- %1$s -->%3$s%2$s%3$s<!-- // %1$s -->%3$s

Given to sprintf with the following arguments:

    $templatePath, $contents, PHP_EOL

Being `$templatePath` the template path (not resolved to file system, but in the format ie, `AcmeDemoBundle:Header:section/template.html.twig`).

`$contents` is the contents itself of the template already handled by doDisplay (ie, rendered).

`PHP_EOL` is only for formatting.

The format is determined by the option 'autoescape' passed in `$options` to `Twig_Environment`; and can be either a string or a callback.
Available format (by default) are 'html', 'js' and 'css'; adding, removing and changing formats is possible through the `Twig_Extension_Debug` extension.

The configuration argument `debug` and `template_info` must be both in true to enable this functionality.

Edit: Update description