### PR TITLE
Added use statement for embed tag

### DIFF
--- a/lib/Twig/Node/Module.php
+++ b/lib/Twig/Node/Module.php
@@ -38,10 +38,12 @@ class Twig_Node_Module extends Twig_Node
         if ($this->hasAttribute('embedding_module')) {
             $embeddingModule = $this->getAttribute('embedding_module');
             $useBlocks = $this->getAttribute('embed_use_blocks');
-            
+
             $foundBlocks = array();
             foreach ($embeddingModule->getNode('blocks') as $name => $node) {
-                if (in_array($name, $useBlocks)) $foundBlocks[$name] = $node;
+                if (in_array($name, $useBlocks)) {
+                    $foundBlocks[$name] = $node;
+                }
             }
 
             $notFoundBlocks = array_diff($useBlocks, array_keys($foundBlocks));

--- a/lib/Twig/Node/Module.php
+++ b/lib/Twig/Node/Module.php
@@ -35,9 +35,33 @@ class Twig_Node_Module extends Twig_Node
      */
     public function compile(Twig_Compiler $compiler)
     {
+        if ($this->hasAttribute('embedding_module')) {
+            $embeddingModule = $this->getAttribute('embedding_module');
+            $useBlocks = $this->getAttribute('embed_use_blocks');
+            
+            $foundBlocks = array();
+            foreach ($embeddingModule->getNode('blocks') as $name => $node) {
+                if (in_array($name, $useBlocks)) $foundBlocks[$name] = $node;
+            }
+
+            $notFoundBlocks = array_diff($useBlocks, array_keys($foundBlocks));
+
+            if (count($notFoundBlocks)) {
+                $compiler
+                    ->write("throw new Twig_Error_Runtime('The following blocks are not defined: ")
+                    ->raw(implode(', ', $notFoundBlocks))
+                    ->raw("');");
+            }
+
+            foreach ($foundBlocks as $name => $node) {
+                $this->getNode('blocks')->setNode($name, $node);
+            }
+        }
+
         $this->compileTemplate($compiler);
 
         foreach ($this->getAttribute('embedded_templates') as $template) {
+            $template->setAttribute('embedding_module', $this);
             $compiler->subcompile($template);
         }
     }

--- a/lib/Twig/TokenParser/Embed.php
+++ b/lib/Twig/TokenParser/Embed.php
@@ -62,7 +62,7 @@ class Twig_TokenParser_Embed extends Twig_TokenParser_Include
 
         $blocks = array();
         if ($stream->nextIf(Twig_Token::NAME_TYPE, 'use')) {
-            while(true) {
+            while (true) {
                 $blocks[] = $stream->expect(Twig_Token::NAME_TYPE)->getValue();
                 if (!$stream->nextIf(Twig_Token::PUNCTUATION_TYPE, ',')) {
                     break;

--- a/lib/Twig/TokenParser/Embed.php
+++ b/lib/Twig/TokenParser/Embed.php
@@ -27,6 +27,7 @@ class Twig_TokenParser_Embed extends Twig_TokenParser_Include
 
         $parent = $this->parser->getExpressionParser()->parseExpression();
 
+        $useBlocks = $this->parseUseBlocks();
         list($variables, $only, $ignoreMissing) = $this->parseArguments();
 
         // inject a fake parent to make the parent() function work
@@ -41,6 +42,7 @@ class Twig_TokenParser_Embed extends Twig_TokenParser_Include
 
         // override the parent with the correct one
         $module->setNode('parent', $parent);
+        $module->setAttribute('embed_use_blocks', $useBlocks);
 
         $this->parser->embedTemplate($module);
 
@@ -52,6 +54,23 @@ class Twig_TokenParser_Embed extends Twig_TokenParser_Include
     public function decideBlockEnd(Twig_Token $token)
     {
         return $token->test('endembed');
+    }
+
+    protected function parseUseBlocks()
+    {
+        $stream = $this->parser->getStream();
+
+        $blocks = array();
+        if ($stream->nextIf(Twig_Token::NAME_TYPE, 'use')) {
+            while(true) {
+                $blocks[] = $stream->expect(Twig_Token::NAME_TYPE)->getValue();
+                if (!$stream->nextIf(Twig_Token::PUNCTUATION_TYPE, ',')) {
+                    break;
+                }
+            }
+        }
+
+        return $blocks;
     }
 
     /**

--- a/test/Twig/Tests/Fixtures/tags/embed/block_reuse.test
+++ b/test/Twig/Tests/Fixtures/tags/embed/block_reuse.test
@@ -1,0 +1,36 @@
+--TEST--
+"embed" tag
+--TEMPLATE--
+{% extends "base.twig" %}
+
+{% block local 'LOCAL_BLOCK' %}
+
+{% block content %}
+    EXTENSION_START
+    {% embed 'embed.twig' use local %}
+        {% block embedded %}
+            {{ block('local') }}
+        {% endblock %}
+    {% endembed %}
+
+    EXTENSION_END
+{% endblock %}
+--TEMPLATE(base.twig)--
+BASE_START
+{% block content '' %}
+BASE_END
+--TEMPLATE(embed.twig)--
+EMBEDDING_START
+{% block embedded '' %}
+EMBEDDING_END
+--DATA--
+return array()
+--EXPECT--
+BASE_START
+    EXTENSION_START
+    
+EMBEDDING_START
+            LOCAL_BLOCK
+        EMBEDDING_END
+    EXTENSION_END
+BASE_END


### PR DESCRIPTION
My proposal for #1560.

It makes it possible to use the `print` block form the main template within the `embed` area in the following example:

    {# layout.html #}
    <h1>Website</h1>
    {% block content '' %}

    {# panel.html #}
    <div class="panel">{% block content '' %}</div>

    {# index.html #}
    {% extends 'layout.html.twig' %}

    {% block print %}
        {{ x }}
    {% endblock %}

    {% block content %}
        {% embed 'panel.html.twig' use print %}
            {% block content %}
                {% for x in ['a', 'b', 'c'] %} {{ block('print') }} {% endfor %}
            {% endblock %}
        {% endembed %}
    {% endblock %}

What has been added is the `use` keyword for the `embed` tag. Maybe the implementation is not optimal, since I just skimmed over the source to see how stuff is usually done, but I can improve it if you're interested in including this.