### PR TITLE
fixed alphabetic order in lists of filters and tags

### DIFF
--- a/doc/filters/index.rst
+++ b/doc/filters/index.rst
@@ -20,10 +20,9 @@ Filters
     last
     length
     lower
+    merge
     nl2br
     number_format
-    merge
-    upper
     raw
     replace
     reverse
@@ -34,4 +33,5 @@ Filters
     striptags
     title
     trim
+    upper
     url_encode

--- a/doc/tags/index.rst
+++ b/doc/tags/index.rst
@@ -6,10 +6,10 @@ Tags
 
     autoescape
     block
-    filter
     do
     embed
     extends
+    filter
     flush
     for
     from


### PR DESCRIPTION
My eyes needed more time than expected to find the `upper` filter, so this should help. :smirk:
