### PR TITLE
[feature] Line whitespace control

### DIFF
--- a/lib/Twig/Lexer.php
+++ b/lib/Twig/Lexer.php
@@ -301,9 +301,19 @@ class Twig_Lexer implements Twig_LexerInterface
         $text = substr($this->code, $this->cursor, $match[0][1] - $this->cursor);
         $this->moveCursor($text.$match[0][0]);
 
-        // if (false !== strpos($match[1][0], $this->options['whitespace_all_trim'])) {
-        //     $text = rtrim($text);
-        // }
+        if (false !== strpos($match[1][0], $this->options['whitespace_all_trim'])) {
+            $text = rtrim($text);
+        }
+
+        if (false !== strpos($match[1][0], $this->options['whitespace_line_trim'])) {
+            if ($pos = strrpos($text, "\n")) {
+                // rtrim only until last line break
+                $text = substr($text, 0, $pos+1).rtrim(substr($text, $pos+1));
+            } else {
+                // rtrim all
+                $text = rtrim($text);
+            }
+        }
 
         $this->pushToken(Twig_Token::TEXT_TYPE, $text);
     }

--- a/lib/Twig/Lexer.php
+++ b/lib/Twig/Lexer.php
@@ -334,11 +334,9 @@ class Twig_Lexer implements Twig_LexerInterface
             $this->pushToken(Twig_Token::INTERPOLATION_START_TYPE);
             $this->moveCursor($match[0]);
             $this->pushState(self::STATE_INTERPOLATION);
-
         } elseif (preg_match(self::REGEX_DQ_STRING_PART, $this->code, $match, null, $this->cursor) && strlen($match[0]) > 0) {
             $this->pushToken(Twig_Token::STRING_TYPE, stripcslashes($match[0]));
             $this->moveCursor($match[0]);
-
         } elseif (preg_match(self::REGEX_DQ_STRING_DELIM, $this->code, $match, null, $this->cursor)) {
             list($expect, $lineno) = array_pop($this->brackets);
             if ($this->code[$this->cursor] != '"') {

--- a/lib/Twig/Lexer.php
+++ b/lib/Twig/Lexer.php
@@ -54,20 +54,20 @@ class Twig_Lexer implements Twig_LexerInterface
             'tag_comment'           => array('{#', '#}'),
             'tag_block'             => array('{%', '%}'),
             'tag_variable'          => array('{{', '}}'),
-            'whitespace_all_trim'   => '-',
+            'whitespace_trim'       => '-',
             'whitespace_line_trim'  => '~',
             'interpolation'         => array('#{', '}'),
         ), $options);
 
         $this->regexes = array(
-            'lex_var'             => '/\s*'.preg_quote($this->options['whitespace_all_trim'].$this->options['tag_variable'][1], '/').'\s*|\s*'.preg_quote($this->options['whitespace_line_trim'].$this->options['tag_variable'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_variable'][1], '/').'/A',
-            'lex_block'           => '/\s*(?:'.preg_quote($this->options['whitespace_all_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')\n?/A',
-            'lex_raw_data'        => '/('.preg_quote($this->options['tag_block'][0].$this->options['whitespace_all_trim'], '/').'|'.preg_quote($this->options['tag_block'][0], '/').')\s*(?:end%s)\s*(?:'.preg_quote($this->options['whitespace_all_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')/s',
+            'lex_var'             => '/\s*'.preg_quote($this->options['whitespace_trim'].$this->options['tag_variable'][1], '/').'\s*|\s*'.preg_quote($this->options['whitespace_line_trim'].$this->options['tag_variable'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_variable'][1], '/').'/A',
+            'lex_block'           => '/\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')\n?/A',
+            'lex_raw_data'        => '/('.preg_quote($this->options['tag_block'][0].$this->options['whitespace_trim'], '/').'|'.preg_quote($this->options['tag_block'][0], '/').')\s*(?:end%s)\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')/s',
             'operator'            => $this->getOperatorRegex(),
-            'lex_comment'         => '/(?:'.preg_quote($this->options['whitespace_all_trim'], '/').preg_quote($this->options['tag_comment'][1], '/').'\s*|'.preg_quote($this->options['whitespace_line_trim'], '/').preg_quote($this->options['tag_comment'][1], '/').'\s*|'.preg_quote($this->options['tag_comment'][1], '/').')\n?/s',
-            'lex_block_raw'       => '/\s*(raw|verbatim)\s*(?:'.preg_quote($this->options['whitespace_all_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')/As',
+            'lex_comment'         => '/(?:'.preg_quote($this->options['whitespace_trim'], '/').preg_quote($this->options['tag_comment'][1], '/').'\s*|'.preg_quote($this->options['whitespace_line_trim'], '/').preg_quote($this->options['tag_comment'][1], '/').'\s*|'.preg_quote($this->options['tag_comment'][1], '/').')\n?/s',
+            'lex_block_raw'       => '/\s*(raw|verbatim)\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')/As',
             'lex_block_line'      => '/\s*line\s+(\d+)\s*'.preg_quote($this->options['tag_block'][1], '/').'/As',
-            'lex_tokens_start'    => '/('.preg_quote($this->options['tag_variable'][0], '/').'|'.preg_quote($this->options['tag_block'][0], '/').'|'.preg_quote($this->options['tag_comment'][0], '/').')('.preg_quote($this->options['whitespace_all_trim'], '/').'|'.preg_quote($this->options['whitespace_line_trim'], '/').')?/s',
+            'lex_tokens_start'    => '/('.preg_quote($this->options['tag_variable'][0], '/').'|'.preg_quote($this->options['tag_block'][0], '/').'|'.preg_quote($this->options['tag_comment'][0], '/').')('.preg_quote($this->options['whitespace_trim'], '/').'|'.preg_quote($this->options['whitespace_line_trim'], '/').')?/s',
             'interpolation_start' => '/'.preg_quote($this->options['interpolation'][0], '/').'\s*/A',
             'interpolation_end'   => '/\s*'.preg_quote($this->options['interpolation'][1], '/').'/A',
         );
@@ -301,7 +301,7 @@ class Twig_Lexer implements Twig_LexerInterface
         $text = substr($this->code, $this->cursor, $match[0][1] - $this->cursor);
         $this->moveCursor($text.$match[0][0]);
 
-        if (false !== strpos($match[1][0], $this->options['whitespace_all_trim'])) {
+        if (false !== strpos($match[1][0], $this->options['whitespace_trim'])) {
             $text = rtrim($text);
         }
 

--- a/test/Twig/Tests/Fixtures/tags/trim_line_block.test
+++ b/test/Twig/Tests/Fixtures/tags/trim_line_block.test
@@ -59,6 +59,7 @@ Trim line on control tag end:
 8  
 9  
 
+
 Trim line on output tag end:
 1  
 2  

--- a/test/Twig/Tests/Fixtures/tags/trim_line_block.test
+++ b/test/Twig/Tests/Fixtures/tags/trim_line_block.test
@@ -5,12 +5,15 @@ Whitespace line trimming on tags.
 {{ '{{~'|length * 5 + '{%~'|length }}
 
 Trim line on control tag end:
-{% for i in range(1, 9) %}{{ i }}
+{% for i in range(1, 9) %}
+{{ i }}
     {%~ endfor %}
+
 
 Trim line on output tag end:
 {% for i in range(1, 9) %}
     {{~ i }}{% endfor %}
+
 
 Trim line comments:
       
@@ -44,41 +47,22 @@ return array('leading' => 'leading space', 'trailing' => 'trailing space', 'both
 18
 
 Trim line on control tag end:
-1
-2
-3
-4
-5
-6
-7
-8
-9
+123456789
 
 Trim line on output tag end:
-1
-2
-3
-4
-5
-6
-7
-8
-9
+123456789
 
-Trim comments:
+Trim line comments:
       
 After the comment.
 
 Trim line leading space:
-
 leading space
-
 leading space
 
 Combined:
 <ul>
 	<li>both</li>
 </ul>
-
 
 end

--- a/test/Twig/Tests/Fixtures/tags/trim_line_block.test
+++ b/test/Twig/Tests/Fixtures/tags/trim_line_block.test
@@ -60,7 +60,9 @@ Trim line leading space:
 leading space
 leading space
 
+
 Combined:
+
 <ul>
 	<li>both</li>
 </ul>

--- a/test/Twig/Tests/Fixtures/tags/trim_line_block.test
+++ b/test/Twig/Tests/Fixtures/tags/trim_line_block.test
@@ -1,0 +1,84 @@
+--TEST--
+Whitespace line trimming on tags.
+--TEMPLATE--
+{{ 5 * '{#~'|length }}
+{{ '{{~'|length * 5 + '{%~'|length }}
+
+Trim line on control tag end:
+{% for i in range(1, 9) %}{{ i }}
+    {%~ endfor %}
+
+Trim line on output tag end:
+{% for i in range(1, 9) %}
+    {{~ i }}{% endfor %}
+
+Trim line comments:
+      
+      {#~ Above visible #}After the comment.
+
+Trim line leading space:
+{% if leading %}
+
+		{{~ leading }}
+{% endif %}
+
+{%~ if leading %}
+	{{~ leading }}
+
+{%~ endif %}
+
+Combined:
+
+{%~ if both ~%}
+<ul>
+	<li>    {{~ both ~}}   </li>
+</ul>
+
+{%~ endif ~%}
+
+end
+--DATA--
+return array('leading' => 'leading space', 'trailing' => 'trailing space', 'both' => 'both')
+--EXPECT--
+15
+18
+
+Trim line on control tag end:
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+Trim line on output tag end:
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+Trim comments:
+      
+After the comment.
+
+Trim line leading space:
+
+leading space
+
+leading space
+
+Combined:
+<ul>
+	<li>both</li>
+</ul>
+
+
+end

--- a/test/Twig/Tests/Fixtures/tags/trim_line_block.test
+++ b/test/Twig/Tests/Fixtures/tags/trim_line_block.test
@@ -6,18 +6,20 @@ Whitespace line trimming on tags.
 
 Trim line on control tag end:
 {% for i in range(1, 9) %}
-{{ i }}
-    {%~ endfor %}
+  {{- i }}  
+{%~ endfor %}
 
 
 Trim line on output tag end:
 {% for i in range(1, 9) %}
-    {{~ i }}{% endfor %}
+  {{~ i }}  
+{% endfor %}
 
 
 Trim line comments:
       
-      {#~ Above visible #}After the comment.
+      {#~ Above visible -#}
+After the comment.
 
 Trim line leading space:
 {% if leading %}
@@ -47,10 +49,10 @@ return array('leading' => 'leading space', 'trailing' => 'trailing space', 'both
 18
 
 Trim line on control tag end:
-123456789
+1  2  3  4  5  6  7  8  9  
 
 Trim line on output tag end:
-123456789
+1  2  3  4  5  6  7  8  9  
 
 Trim line comments:
       

--- a/test/Twig/Tests/Fixtures/tags/trim_line_block.test
+++ b/test/Twig/Tests/Fixtures/tags/trim_line_block.test
@@ -49,10 +49,27 @@ return array('leading' => 'leading space', 'trailing' => 'trailing space', 'both
 18
 
 Trim line on control tag end:
-1  2  3  4  5  6  7  8  9  
+1  
+2  
+3  
+4  
+5  
+6  
+7  
+8  
+9  
 
 Trim line on output tag end:
-1  2  3  4  5  6  7  8  9  
+1  
+2  
+3  
+4  
+5  
+6  
+7  
+8  
+9  
+
 
 Trim line comments:
       

--- a/test/Twig/Tests/LexerTest.php
+++ b/test/Twig/Tests/LexerTest.php
@@ -10,23 +10,6 @@
  */
 class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
 {
-    public function testWhitespaceTrimLine()
-    {
-        $template = "";
-        
-        $tests = array(
-            "foo \n    {{~ 'bar' }}" => 'foo \n',
-            "foo \nbar {{~ 'baz' }}" => 'foo \nbar',
-        );
-        $lexer = new Twig_Lexer(new Twig_Environment());
-        foreach ($tests as $template => $expected) {
-            $stream = $lexer->tokenize($template);
-            //$stream->expect(Twig_Token::VAR_START_TYPE);
-            $stream->expect(Twig_Token::TEXT_TYPE, $expected);
-            //$stream->expect(Twig_Token::BLOCK_START_TYPE);
-        }
-    }
-    
     public function testNameLabelForTag()
     {
         $template = '{% § %}';

--- a/test/Twig/Tests/LexerTest.php
+++ b/test/Twig/Tests/LexerTest.php
@@ -10,6 +10,22 @@
  */
 class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
 {
+    public function testWhitespaceTrimLine()
+    {
+        $template = "";
+        
+        $tests = array(
+            "foo \n    {{~ 'bar' }}" => 'foo \nbar',
+            "foo \nbar {{~ 'baz' }}" => 'foo \nbarbaz',
+        );
+        $lexer = new Twig_Lexer(new Twig_Environment());
+        foreach ($tests as $template => $expected) {
+            $stream = $lexer->tokenize($template);
+            $stream->expect(Twig_Token::VAR_START_TYPE);
+            $stream->expect(Twig_Token::STRING_TYPE, $expected);
+        }
+    }
+    
     public function testNameLabelForTag()
     {
         $template = '{% § %}';

--- a/test/Twig/Tests/LexerTest.php
+++ b/test/Twig/Tests/LexerTest.php
@@ -21,9 +21,9 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
         $lexer = new Twig_Lexer(new Twig_Environment());
         foreach ($tests as $template => $expected) {
             $stream = $lexer->tokenize($template);
-            $stream->expect(Twig_Token::VAR_START_TYPE);
+            //$stream->expect(Twig_Token::VAR_START_TYPE);
             $stream->expect(Twig_Token::TEXT_TYPE, $expected);
-            $stream->expect(Twig_Token::BLOCK_START_TYPE);
+            //$stream->expect(Twig_Token::BLOCK_START_TYPE);
         }
     }
     

--- a/test/Twig/Tests/LexerTest.php
+++ b/test/Twig/Tests/LexerTest.php
@@ -15,14 +15,15 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
         $template = "";
         
         $tests = array(
-            "foo \n    {{~ 'bar' }}" => 'foo \nbar',
-            "foo \nbar {{~ 'baz' }}" => 'foo \nbarbaz',
+            "foo \n    {{~ 'bar' }}" => 'foo \n',
+            "foo \nbar {{~ 'baz' }}" => 'foo \nbar',
         );
         $lexer = new Twig_Lexer(new Twig_Environment());
         foreach ($tests as $template => $expected) {
             $stream = $lexer->tokenize($template);
             $stream->expect(Twig_Token::VAR_START_TYPE);
-            $stream->expect(Twig_Token::STRING_TYPE, $expected);
+            $stream->expect(Twig_Token::TEXT_TYPE, $expected);
+            $stream->expect(Twig_Token::BLOCK_START_TYPE);
         }
     }
     


### PR DESCRIPTION
This PR introduces line whitespace control character `~` which can be used the same way standard whitespace control character `-` can be, for example:
- `{{~ "Trim to my left, but only until first line break" }}`
- `{%~ for word in ["Trim to my left, but only until first line break"] %}`

I'm not sure if trimming on the right side is possible. `{% for word in ["Trim to my right, but only until first line break"] ~%}` does not stop at line break - it behaves the same way `-` would.. it seems that the closeing tag is handled by diffrent part of code, but I could not find where.

Fixes issue #1423
