### PR TITLE
removed @covers annotations

### DIFF
--- a/test/Twig/Tests/Node/AutoEscapeTest.php
+++ b/test/Twig/Tests/Node/AutoEscapeTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_AutoEscapeTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_AutoEscape::__construct
-     */
     public function testConstructor()
     {
         $body = new Twig_Node(array(new Twig_Node_Text('foo', 1)));
@@ -21,15 +18,6 @@ class Twig_Tests_Node_AutoEscapeTest extends Twig_Test_NodeTestCase
 
         $this->assertEquals($body, $node->getNode('body'));
         $this->assertTrue($node->getAttribute('value'));
-    }
-
-    /**
-     * @covers Twig_Node_AutoEscape::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/BlockReferenceTest.php
+++ b/test/Twig/Tests/Node/BlockReferenceTest.php
@@ -11,23 +11,11 @@
 
 class Twig_Tests_Node_BlockReferenceTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_BlockReference::__construct
-     */
     public function testConstructor()
     {
         $node = new Twig_Node_BlockReference('foo', 1);
 
         $this->assertEquals('foo', $node->getAttribute('name'));
-    }
-
-    /**
-     * @covers Twig_Node_BlockReference::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/BlockTest.php
+++ b/test/Twig/Tests/Node/BlockTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_BlockTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Block::__construct
-     */
     public function testConstructor()
     {
         $body = new Twig_Node_Text('foo', 1);
@@ -21,15 +18,6 @@ class Twig_Tests_Node_BlockTest extends Twig_Test_NodeTestCase
 
         $this->assertEquals($body, $node->getNode('body'));
         $this->assertEquals('foo', $node->getAttribute('name'));
-    }
-
-    /**
-     * @covers Twig_Node_Block::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/DoTest.php
+++ b/test/Twig/Tests/Node/DoTest.php
@@ -11,24 +11,12 @@
 
 class Twig_Tests_Node_DoTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Do::__construct
-     */
     public function testConstructor()
     {
         $expr = new Twig_Node_Expression_Constant('foo', 1);
         $node = new Twig_Node_Do($expr, 1);
 
         $this->assertEquals($expr, $node->getNode('expr'));
-    }
-
-    /**
-     * @covers Twig_Node_Do::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/ArrayTest.php
+++ b/test/Twig/Tests/Node/Expression/ArrayTest.php
@@ -11,24 +11,12 @@
 
 class Twig_Tests_Node_Expression_ArrayTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Array::__construct
-     */
     public function testConstructor()
     {
         $elements = array(new Twig_Node_Expression_Constant('foo', 1), $foo = new Twig_Node_Expression_Constant('bar', 1));
         $node = new Twig_Node_Expression_Array($elements, 1);
 
         $this->assertEquals($foo, $node->getNode(1));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Array::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/AssignNameTest.php
+++ b/test/Twig/Tests/Node/Expression/AssignNameTest.php
@@ -11,23 +11,11 @@
 
 class Twig_Tests_Node_Expression_AssignNameTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_AssignName::__construct
-     */
     public function testConstructor()
     {
         $node = new Twig_Node_Expression_AssignName('foo', 1);
 
         $this->assertEquals('foo', $node->getAttribute('name'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_AssignName::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Binary/AddTest.php
+++ b/test/Twig/Tests/Node/Expression/Binary/AddTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_Binary_AddTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Binary_Add::__construct
-     */
     public function testConstructor()
     {
         $left = new Twig_Node_Expression_Constant(1, 1);
@@ -22,16 +19,6 @@ class Twig_Tests_Node_Expression_Binary_AddTest extends Twig_Test_NodeTestCase
 
         $this->assertEquals($left, $node->getNode('left'));
         $this->assertEquals($right, $node->getNode('right'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Binary_Add::compile
-     * @covers Twig_Node_Expression_Binary_Add::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Binary/AndTest.php
+++ b/test/Twig/Tests/Node/Expression/Binary/AndTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_Binary_AndTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Binary_And::__construct
-     */
     public function testConstructor()
     {
         $left = new Twig_Node_Expression_Constant(1, 1);
@@ -22,16 +19,6 @@ class Twig_Tests_Node_Expression_Binary_AndTest extends Twig_Test_NodeTestCase
 
         $this->assertEquals($left, $node->getNode('left'));
         $this->assertEquals($right, $node->getNode('right'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Binary_And::compile
-     * @covers Twig_Node_Expression_Binary_And::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Binary/ConcatTest.php
+++ b/test/Twig/Tests/Node/Expression/Binary/ConcatTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_Binary_ConcatTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Binary_Concat::__construct
-     */
     public function testConstructor()
     {
         $left = new Twig_Node_Expression_Constant(1, 1);
@@ -22,16 +19,6 @@ class Twig_Tests_Node_Expression_Binary_ConcatTest extends Twig_Test_NodeTestCas
 
         $this->assertEquals($left, $node->getNode('left'));
         $this->assertEquals($right, $node->getNode('right'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Binary_Concat::compile
-     * @covers Twig_Node_Expression_Binary_Concat::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Binary/DivTest.php
+++ b/test/Twig/Tests/Node/Expression/Binary/DivTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_Binary_DivTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Binary_Div::__construct
-     */
     public function testConstructor()
     {
         $left = new Twig_Node_Expression_Constant(1, 1);
@@ -22,16 +19,6 @@ class Twig_Tests_Node_Expression_Binary_DivTest extends Twig_Test_NodeTestCase
 
         $this->assertEquals($left, $node->getNode('left'));
         $this->assertEquals($right, $node->getNode('right'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Binary_Div::compile
-     * @covers Twig_Node_Expression_Binary_Div::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Binary/FloorDivTest.php
+++ b/test/Twig/Tests/Node/Expression/Binary/FloorDivTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_Binary_FloorDivTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Binary_FloorDiv::__construct
-     */
     public function testConstructor()
     {
         $left = new Twig_Node_Expression_Constant(1, 1);
@@ -22,16 +19,6 @@ class Twig_Tests_Node_Expression_Binary_FloorDivTest extends Twig_Test_NodeTestC
 
         $this->assertEquals($left, $node->getNode('left'));
         $this->assertEquals($right, $node->getNode('right'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Binary_FloorDiv::compile
-     * @covers Twig_Node_Expression_Binary_FloorDiv::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Binary/ModTest.php
+++ b/test/Twig/Tests/Node/Expression/Binary/ModTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_Binary_ModTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Binary_Mod::__construct
-     */
     public function testConstructor()
     {
         $left = new Twig_Node_Expression_Constant(1, 1);
@@ -22,16 +19,6 @@ class Twig_Tests_Node_Expression_Binary_ModTest extends Twig_Test_NodeTestCase
 
         $this->assertEquals($left, $node->getNode('left'));
         $this->assertEquals($right, $node->getNode('right'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Binary_Mod::compile
-     * @covers Twig_Node_Expression_Binary_Mod::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Binary/MulTest.php
+++ b/test/Twig/Tests/Node/Expression/Binary/MulTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_Binary_MulTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Binary_Mul::__construct
-     */
     public function testConstructor()
     {
         $left = new Twig_Node_Expression_Constant(1, 1);
@@ -22,16 +19,6 @@ class Twig_Tests_Node_Expression_Binary_MulTest extends Twig_Test_NodeTestCase
 
         $this->assertEquals($left, $node->getNode('left'));
         $this->assertEquals($right, $node->getNode('right'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Binary_Mul::compile
-     * @covers Twig_Node_Expression_Binary_Mul::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Binary/OrTest.php
+++ b/test/Twig/Tests/Node/Expression/Binary/OrTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_Binary_OrTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Binary_Or::__construct
-     */
     public function testConstructor()
     {
         $left = new Twig_Node_Expression_Constant(1, 1);
@@ -22,16 +19,6 @@ class Twig_Tests_Node_Expression_Binary_OrTest extends Twig_Test_NodeTestCase
 
         $this->assertEquals($left, $node->getNode('left'));
         $this->assertEquals($right, $node->getNode('right'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Binary_Or::compile
-     * @covers Twig_Node_Expression_Binary_Or::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Binary/SubTest.php
+++ b/test/Twig/Tests/Node/Expression/Binary/SubTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_Binary_SubTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Binary_Sub::__construct
-     */
     public function testConstructor()
     {
         $left = new Twig_Node_Expression_Constant(1, 1);
@@ -22,16 +19,6 @@ class Twig_Tests_Node_Expression_Binary_SubTest extends Twig_Test_NodeTestCase
 
         $this->assertEquals($left, $node->getNode('left'));
         $this->assertEquals($right, $node->getNode('right'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Binary_Sub::compile
-     * @covers Twig_Node_Expression_Binary_Sub::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/ConditionalTest.php
+++ b/test/Twig/Tests/Node/Expression/ConditionalTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_ConditionalTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Conditional::__construct
-     */
     public function testConstructor()
     {
         $expr1 = new Twig_Node_Expression_Constant(1, 1);
@@ -24,15 +21,6 @@ class Twig_Tests_Node_Expression_ConditionalTest extends Twig_Test_NodeTestCase
         $this->assertEquals($expr1, $node->getNode('expr1'));
         $this->assertEquals($expr2, $node->getNode('expr2'));
         $this->assertEquals($expr3, $node->getNode('expr3'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Conditional::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/ConstantTest.php
+++ b/test/Twig/Tests/Node/Expression/ConstantTest.php
@@ -11,23 +11,11 @@
 
 class Twig_Tests_Node_Expression_ConstantTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Constant::__construct
-     */
     public function testConstructor()
     {
         $node = new Twig_Node_Expression_Constant('foo', 1);
 
         $this->assertEquals('foo', $node->getAttribute('value'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Constant::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/FilterTest.php
+++ b/test/Twig/Tests/Node/Expression/FilterTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_FilterTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Filter::__construct
-     */
     public function testConstructor()
     {
         $expr = new Twig_Node_Expression_Constant('foo', 1);
@@ -24,15 +21,6 @@ class Twig_Tests_Node_Expression_FilterTest extends Twig_Test_NodeTestCase
         $this->assertEquals($expr, $node->getNode('node'));
         $this->assertEquals($name, $node->getNode('filter'));
         $this->assertEquals($args, $node->getNode('arguments'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Filter::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/FunctionTest.php
+++ b/test/Twig/Tests/Node/Expression/FunctionTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_FunctionTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Function::__construct
-     */
     public function testConstructor()
     {
         $name = 'function';
@@ -22,15 +19,6 @@ class Twig_Tests_Node_Expression_FunctionTest extends Twig_Test_NodeTestCase
 
         $this->assertEquals($name, $node->getAttribute('name'));
         $this->assertEquals($args, $node->getNode('arguments'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Function::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/GetAttrTest.php
+++ b/test/Twig/Tests/Node/Expression/GetAttrTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_GetAttrTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_GetAttr::__construct
-     */
     public function testConstructor()
     {
         $expr = new Twig_Node_Expression_Name('foo', 1);
@@ -27,15 +24,6 @@ class Twig_Tests_Node_Expression_GetAttrTest extends Twig_Test_NodeTestCase
         $this->assertEquals($attr, $node->getNode('attribute'));
         $this->assertEquals($args, $node->getNode('arguments'));
         $this->assertEquals(Twig_Template::ARRAY_CALL, $node->getAttribute('type'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_GetAttr::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/NameTest.php
+++ b/test/Twig/Tests/Node/Expression/NameTest.php
@@ -11,23 +11,11 @@
 
 class Twig_Tests_Node_Expression_NameTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Name::__construct
-     */
     public function testConstructor()
     {
         $node = new Twig_Node_Expression_Name('foo', 1);
 
         $this->assertEquals('foo', $node->getAttribute('name'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Name::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/ParentTest.php
+++ b/test/Twig/Tests/Node/Expression/ParentTest.php
@@ -11,23 +11,11 @@
 
 class Twig_Tests_Node_Expression_ParentTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Parent::__construct
-     */
     public function testConstructor()
     {
         $node = new Twig_Node_Expression_Parent('foo', 1);
 
         $this->assertEquals('foo', $node->getAttribute('name'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Parent::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/TestTest.php
+++ b/test/Twig/Tests/Node/Expression/TestTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_Expression_TestTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Test::__construct
-     */
     public function testConstructor()
     {
         $expr = new Twig_Node_Expression_Constant('foo', 1);
@@ -24,15 +21,6 @@ class Twig_Tests_Node_Expression_TestTest extends Twig_Test_NodeTestCase
         $this->assertEquals($expr, $node->getNode('node'));
         $this->assertEquals($args, $node->getNode('arguments'));
         $this->assertEquals($name, $node->getAttribute('name'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Test::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Unary/NegTest.php
+++ b/test/Twig/Tests/Node/Expression/Unary/NegTest.php
@@ -11,25 +11,12 @@
 
 class Twig_Tests_Node_Expression_Unary_NegTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Unary_Neg::__construct
-     */
     public function testConstructor()
     {
         $expr = new Twig_Node_Expression_Constant(1, 1);
         $node = new Twig_Node_Expression_Unary_Neg($expr, 1);
 
         $this->assertEquals($expr, $node->getNode('node'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Unary_Neg::compile
-     * @covers Twig_Node_Expression_Unary_Neg::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Unary/NotTest.php
+++ b/test/Twig/Tests/Node/Expression/Unary/NotTest.php
@@ -11,25 +11,12 @@
 
 class Twig_Tests_Node_Expression_Unary_NotTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Unary_Not::__construct
-     */
     public function testConstructor()
     {
         $expr = new Twig_Node_Expression_Constant(1, 1);
         $node = new Twig_Node_Expression_Unary_Not($expr, 1);
 
         $this->assertEquals($expr, $node->getNode('node'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Unary_Not::compile
-     * @covers Twig_Node_Expression_Unary_Not::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/Expression/Unary/PosTest.php
+++ b/test/Twig/Tests/Node/Expression/Unary/PosTest.php
@@ -11,25 +11,12 @@
 
 class Twig_Tests_Node_Expression_Unary_PosTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Expression_Unary_Pos::__construct
-     */
     public function testConstructor()
     {
         $expr = new Twig_Node_Expression_Constant(1, 1);
         $node = new Twig_Node_Expression_Unary_Pos($expr, 1);
 
         $this->assertEquals($expr, $node->getNode('node'));
-    }
-
-    /**
-     * @covers Twig_Node_Expression_Unary_Pos::compile
-     * @covers Twig_Node_Expression_Unary_Pos::operator
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/ForTest.php
+++ b/test/Twig/Tests/Node/ForTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_ForTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_For::__construct
-     */
     public function testConstructor()
     {
         $keyTarget = new Twig_Node_Expression_AssignName('key', 1);
@@ -37,15 +34,6 @@ class Twig_Tests_Node_ForTest extends Twig_Test_NodeTestCase
         $node = new Twig_Node_For($keyTarget, $valueTarget, $seq, $ifexpr, $body, $else, 1);
         $node->setAttribute('with_loop', false);
         $this->assertEquals($else, $node->getNode('else'));
-    }
-
-    /**
-     * @covers Twig_Node_For::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/IfTest.php
+++ b/test/Twig/Tests/Node/IfTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_IfTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_If::__construct
-     */
     public function testConstructor()
     {
         $t = new Twig_Node(array(
@@ -29,15 +26,6 @@ class Twig_Tests_Node_IfTest extends Twig_Test_NodeTestCase
         $else = new Twig_Node_Print(new Twig_Node_Expression_Name('bar', 1), 1);
         $node = new Twig_Node_If($t, $else, 1);
         $this->assertEquals($else, $node->getNode('else'));
-    }
-
-    /**
-     * @covers Twig_Node_If::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/ImportTest.php
+++ b/test/Twig/Tests/Node/ImportTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_ImportTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Import::__construct
-     */
     public function testConstructor()
     {
         $macro = new Twig_Node_Expression_Constant('foo.twig', 1);
@@ -22,15 +19,6 @@ class Twig_Tests_Node_ImportTest extends Twig_Test_NodeTestCase
 
         $this->assertEquals($macro, $node->getNode('expr'));
         $this->assertEquals($var, $node->getNode('var'));
-    }
-
-    /**
-     * @covers Twig_Node_Import::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/IncludeTest.php
+++ b/test/Twig/Tests/Node/IncludeTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_IncludeTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Include::__construct
-     */
     public function testConstructor()
     {
         $expr = new Twig_Node_Expression_Constant('foo.twig', 1);
@@ -27,15 +24,6 @@ class Twig_Tests_Node_IncludeTest extends Twig_Test_NodeTestCase
         $node = new Twig_Node_Include($expr, $vars, true, false, 1);
         $this->assertEquals($vars, $node->getNode('variables'));
         $this->assertTrue($node->getAttribute('only'));
-    }
-
-    /**
-     * @covers Twig_Node_Include::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/MacroTest.php
+++ b/test/Twig/Tests/Node/MacroTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_MacroTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Macro::__construct
-     */
     public function testConstructor()
     {
         $body = new Twig_Node_Text('foo', 1);
@@ -23,15 +20,6 @@ class Twig_Tests_Node_MacroTest extends Twig_Test_NodeTestCase
         $this->assertEquals($body, $node->getNode('body'));
         $this->assertEquals($arguments, $node->getNode('arguments'));
         $this->assertEquals('foo', $node->getAttribute('name'));
-    }
-
-    /**
-     * @covers Twig_Node_Macro::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/ModuleTest.php
+++ b/test/Twig/Tests/Node/ModuleTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_ModuleTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Module::__construct
-     */
     public function testConstructor()
     {
         $body = new Twig_Node_Text('foo', 1);
@@ -29,22 +26,6 @@ class Twig_Tests_Node_ModuleTest extends Twig_Test_NodeTestCase
         $this->assertEquals($macros, $node->getNode('macros'));
         $this->assertEquals($parent, $node->getNode('parent'));
         $this->assertEquals($filename, $node->getAttribute('filename'));
-    }
-
-    /**
-     * @covers Twig_Node_Module::compile
-     * @covers Twig_Node_Module::compileTemplate
-     * @covers Twig_Node_Module::compileMacros
-     * @covers Twig_Node_Module::compileClassHeader
-     * @covers Twig_Node_Module::compileDisplayHeader
-     * @covers Twig_Node_Module::compileDisplayBody
-     * @covers Twig_Node_Module::compileDisplayFooter
-     * @covers Twig_Node_Module::compileClassFooter
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/PrintTest.php
+++ b/test/Twig/Tests/Node/PrintTest.php
@@ -11,24 +11,12 @@
 
 class Twig_Tests_Node_PrintTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Print::__construct
-     */
     public function testConstructor()
     {
         $expr = new Twig_Node_Expression_Constant('foo', 1);
         $node = new Twig_Node_Print($expr, 1);
 
         $this->assertEquals($expr, $node->getNode('expr'));
-    }
-
-    /**
-     * @covers Twig_Node_Print::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/SandboxTest.php
+++ b/test/Twig/Tests/Node/SandboxTest.php
@@ -11,24 +11,12 @@
 
 class Twig_Tests_Node_SandboxTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Sandbox::__construct
-     */
     public function testConstructor()
     {
         $body = new Twig_Node_Text('foo', 1);
         $node = new Twig_Node_Sandbox($body, 1);
 
         $this->assertEquals($body, $node->getNode('body'));
-    }
-
-    /**
-     * @covers Twig_Node_Sandbox::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/SandboxedModuleTest.php
+++ b/test/Twig/Tests/Node/SandboxedModuleTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_SandboxedModuleTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_SandboxedModule::__construct
-     */
     public function testConstructor()
     {
         $body = new Twig_Node_Text('foo', 1);
@@ -30,17 +27,6 @@ class Twig_Tests_Node_SandboxedModuleTest extends Twig_Test_NodeTestCase
         $this->assertEquals($macros, $node->getNode('macros'));
         $this->assertEquals($parent, $node->getNode('parent'));
         $this->assertEquals($filename, $node->getAttribute('filename'));
-    }
-
-    /**
-     * @covers Twig_Node_SandboxedModule::compile
-     * @covers Twig_Node_SandboxedModule::compileDisplayBody
-     * @covers Twig_Node_SandboxedModule::compileDisplayFooter
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/SandboxedPrintTest.php
+++ b/test/Twig/Tests/Node/SandboxedPrintTest.php
@@ -11,23 +11,11 @@
 
 class Twig_Tests_Node_SandboxedPrintTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_SandboxedPrint::__construct
-     */
     public function testConstructor()
     {
         $node = new Twig_Node_SandboxedPrint($expr = new Twig_Node_Expression_Constant('foo', 1), 1);
 
         $this->assertEquals($expr, $node->getNode('expr'));
-    }
-
-    /**
-     * @covers Twig_Node_SandboxedPrint::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/SetTest.php
+++ b/test/Twig/Tests/Node/SetTest.php
@@ -11,9 +11,6 @@
 
 class Twig_Tests_Node_SetTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Set::__construct
-     */
     public function testConstructor()
     {
         $names = new Twig_Node(array(new Twig_Node_Expression_AssignName('foo', 1)), array(), 1);
@@ -23,15 +20,6 @@ class Twig_Tests_Node_SetTest extends Twig_Test_NodeTestCase
         $this->assertEquals($names, $node->getNode('names'));
         $this->assertEquals($values, $node->getNode('values'));
         $this->assertFalse($node->getAttribute('capture'));
-    }
-
-    /**
-     * @covers Twig_Node_Set::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/SpacelessTest.php
+++ b/test/Twig/Tests/Node/SpacelessTest.php
@@ -11,24 +11,12 @@
 
 class Twig_Tests_Node_SpacelessTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Spaceless::__construct
-     */
     public function testConstructor()
     {
         $body = new Twig_Node(array(new Twig_Node_Text('<div>   <div>   foo   </div>   </div>', 1)));
         $node = new Twig_Node_Spaceless($body, 1);
 
         $this->assertEquals($body, $node->getNode('body'));
-    }
-
-    /**
-     * @covers Twig_Node_Spaceless::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()

--- a/test/Twig/Tests/Node/TextTest.php
+++ b/test/Twig/Tests/Node/TextTest.php
@@ -11,23 +11,11 @@
 
 class Twig_Tests_Node_TextTest extends Twig_Test_NodeTestCase
 {
-    /**
-     * @covers Twig_Node_Text::__construct
-     */
     public function testConstructor()
     {
         $node = new Twig_Node_Text('foo', 1);
 
         $this->assertEquals('foo', $node->getAttribute('data'));
-    }
-
-    /**
-     * @covers Twig_Node_Text::compile
-     * @dataProvider getTests
-     */
-    public function testCompile($node, $source, $environment = null)
-    {
-        parent::testCompile($node, $source, $environment);
     }
 
     public function getTests()


### PR DESCRIPTION
I propose to remove the `@covers` annotations for the following main reasons:
- they were only used in a limited number of test cases;
- they limited the code coverage of nodes for no reasons (some other tests are as valid to test the nodes).
