### PR TITLE
Add getLastLoadedTemplateName() method to Loaders

### DIFF
--- a/lib/Twig/Loader/Array.php
+++ b/lib/Twig/Loader/Array.php
@@ -24,6 +24,7 @@
 class Twig_Loader_Array implements Twig_LoaderInterface, Twig_ExistsLoaderInterface
 {
     protected $templates = array();
+    private $last_used_template;
 
     /**
      * Constructor.
@@ -58,7 +59,22 @@ class Twig_Loader_Array implements Twig_LoaderInterface, Twig_ExistsLoaderInterf
             throw new Twig_Error_Loader(sprintf('Template "%s" is not defined.', $name));
         }
 
+        $this->last_used_template = $name;
+
         return $this->templates[$name];
+    }
+
+    /**
+     * Returns the name of template that was lastly parsed before
+     * this method was called.
+     * This may be useful when, for instance, you need to know the
+     * name of the template where your custom function was called from.
+     *
+     * @return string The template name
+     */
+    public function getLastLoadedTemplateName()
+    {
+        return $this->last_used_template;
     }
 
     /**
@@ -78,6 +94,8 @@ class Twig_Loader_Array implements Twig_LoaderInterface, Twig_ExistsLoaderInterf
         if (!isset($this->templates[$name])) {
             throw new Twig_Error_Loader(sprintf('Template "%s" is not defined.', $name));
         }
+
+        $this->last_used_template = $name;
 
         return $this->templates[$name];
     }

--- a/lib/Twig/Loader/Chain.php
+++ b/lib/Twig/Loader/Chain.php
@@ -17,6 +17,7 @@
 class Twig_Loader_Chain implements Twig_LoaderInterface, Twig_ExistsLoaderInterface
 {
     private $hasSourceCache = array();
+    private $last_used_loader;
     protected $loaders = array();
 
     /**
@@ -54,13 +55,29 @@ class Twig_Loader_Chain implements Twig_LoaderInterface, Twig_ExistsLoaderInterf
             }
 
             try {
-                return $loader->getSource($name);
+                $source = $loader->getSource($name);
+                $this->last_used_loader = $loader;
+
+                return $source;
             } catch (Twig_Error_Loader $e) {
                 $exceptions[] = $e->getMessage();
             }
         }
 
         throw new Twig_Error_Loader(sprintf('Template "%s" is not defined (%s).', $name, implode(', ', $exceptions)));
+    }
+
+    /**
+     * Returns the name of template that was lastly parsed before
+     * this method was called.
+     * This may be useful when, for instance, you need to know the
+     * name of the template where your custom function was called from.
+     *
+     * @return string The template name
+     */
+    public function getLastLoadedTemplateName()
+    {
+        return $this->last_used_loader->getLastLoadedTemplateName();
     }
 
     /**
@@ -106,7 +123,10 @@ class Twig_Loader_Chain implements Twig_LoaderInterface, Twig_ExistsLoaderInterf
             }
 
             try {
-                return $loader->getCacheKey($name);
+                $cache = $loader->getCacheKey($name);
+                $this->last_used_loader = $loader;
+
+                return $cache;
             } catch (Twig_Error_Loader $e) {
                 $exceptions[] = get_class($loader).': '.$e->getMessage();
             }

--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -139,6 +139,19 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
     }
 
     /**
+     * Returns the name of template that was lastly parsed before
+     * this method was called.
+     * This may be useful when, for instance, you need to know the
+     * name of the template where your custom function was called from.
+     *
+     * @return string The template name
+     */
+    public function getLastLoadedTemplateName()
+    {
+        return key(array_slice($this->cache, -1, 1, true));
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function exists($name)

--- a/test/Twig/Tests/Loader/ArrayTest.php
+++ b/test/Twig/Tests/Loader/ArrayTest.php
@@ -53,6 +53,28 @@ class Twig_Tests_Loader_ArrayTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $loader->getSource('foo'));
     }
 
+    public function testGetLastLoadedTemplateName()
+    {
+        $loader = new Twig_Loader_Array(array(
+            'main.twig' => "{% include 'sub.twig' %}",
+            'sub.twig' => '{{ my_custom_function() }}',
+            'standalone.twig' => '{{ my_custom_function() }}',
+        ));
+
+        $twig = new Twig_Environment($loader);
+        $twig->addFunction(new Twig_SimpleFunction('my_custom_function', function () use ($twig) {
+
+            $caller_template_name = $twig->getLoader()->getLastLoadedTemplateName();
+
+            echo "Called from {$caller_template_name}";
+
+        }));
+
+        $this->assertEquals('Called from sub.twig', $twig->render('main.twig'));
+
+        $this->assertEquals('Called from standalone.twig', $twig->render('standalone.twig'));
+    }
+
     public function testIsFresh()
     {
         $loader = new Twig_Loader_Array(array('foo' => 'bar'));

--- a/test/Twig/Tests/Loader/ChainTest.php
+++ b/test/Twig/Tests/Loader/ChainTest.php
@@ -76,4 +76,35 @@ class Twig_Tests_Loader_ChainTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($loader->exists('foo'));
     }
+
+    public function testGetLastLoadedTemplateName()
+    {
+        $loader1 = $this->getMock('Twig_Loader_Array', array('getLastLoadedTemplateName', 'exists', 'getSource'), array(), '', false);
+        $loader1->expects($this->at(0))
+            ->method('exists')
+            ->with($this->equalTo('bar.twig'))
+            ->will($this->returnValue(false));
+        $loader1->expects($this->at(1))
+            ->method('exists')
+            ->with($this->equalTo('foo.twig'))
+            ->will($this->returnValue(true));
+        $loader1->expects($this->once())->method('getSource')->will($this->returnValue('foo'));
+        $loader1->expects($this->once())->method('getLastLoadedTemplateName')->will($this->returnValue('foo.twig'));
+
+        $loader2 = $this->getMock('Twig_Loader_Array', array('getLastLoadedTemplateName', 'exists', 'getSource'), array(), '', false);
+        $loader2->expects($this->at(0))
+            ->method('exists')
+            ->with($this->equalTo('bar.twig'))
+            ->will($this->returnValue(true));
+        $loader2->expects($this->once())->method('getSource')->will($this->returnValue('bar'));
+        $loader2->expects($this->once())->method('getLastLoadedTemplateName')->will($this->returnValue('bar.twig'));
+
+        $loader = new Twig_Loader_Chain(array($loader1, $loader2));
+
+        $loader->getSource('bar.twig');
+        $this->assertEquals('bar.twig', $loader->getLastLoadedTemplateName());
+
+        $loader->getSource('foo.twig');
+        $this->assertEquals('foo.twig', $loader->getLastLoadedTemplateName());
+    }
 }

--- a/test/Twig/Tests/Loader/FilesystemTest.php
+++ b/test/Twig/Tests/Loader/FilesystemTest.php
@@ -140,4 +140,23 @@ class Twig_Tests_Loader_FilesystemTest extends PHPUnit_Framework_TestCase
         $template = $twig->loadTemplate('blocks.html.twig');
         $this->assertSame('block from theme 2', $template->renderBlock('b2', array()));
     }
+
+    public function testGetLastLoadedTemplateName()
+    {
+        $loader = new Twig_Loader_Filesystem(array());
+        $loader->addPath(dirname(__FILE__).'/Fixtures/functions');
+
+        $twig = new Twig_Environment($loader);
+        $twig->addFunction(new Twig_SimpleFunction('my_custom_function', function () use ($twig) {
+
+            $caller_template_name = $twig->getLoader()->getLastLoadedTemplateName();
+
+            echo "Called from {$caller_template_name}";
+
+        }));
+
+        $this->assertEquals("Called from sub.twig\n", $twig->render('main.twig'));
+
+        $this->assertEquals("Called from standalone.twig\n", $twig->render('standalone.twig'));
+    }
 }

--- a/test/Twig/Tests/Loader/Fixtures/functions/main.twig
+++ b/test/Twig/Tests/Loader/Fixtures/functions/main.twig
@@ -1,0 +1,1 @@
+{% include 'sub.twig' %}

--- a/test/Twig/Tests/Loader/Fixtures/functions/standalone.twig
+++ b/test/Twig/Tests/Loader/Fixtures/functions/standalone.twig
@@ -1,0 +1,1 @@
+{{ my_custom_function() }}

--- a/test/Twig/Tests/Loader/Fixtures/functions/sub.twig
+++ b/test/Twig/Tests/Loader/Fixtures/functions/sub.twig
@@ -1,0 +1,1 @@
+{{ my_custom_function() }}


### PR DESCRIPTION
`getLastLoadedTemplateName()` simply returns name of template
that was loaded right before you called this method.

Quick example:

```
$twig->addFunction(new Twig_SimpleFunction('my_custom_function', function() use ($twig) {

  $caller_template_name = $twig->getLoader()->getLastLoadedTemplateName();

  echo "This function was called from {$caller_template_name}";

}));
```

`getLastLoadedTemplateName()` is very useful method in my case where
it allows me keeping track of where custom `translate()` Twig
function is used and making sure translators get a detailed info
about every term's contexts.
