### PR TITLE
Fix the For optimizer, "include" function was always optimized

### DIFF
--- a/lib/Twig/NodeVisitor/Optimizer.php
+++ b/lib/Twig/NodeVisitor/Optimizer.php
@@ -205,6 +205,16 @@ class Twig_NodeVisitor_Optimizer implements Twig_NodeVisitorInterface
             $this->addLoopToAll();
         }
 
+        // include function without the with_context=false parameter
+        elseif ($node instanceof Twig_Node_Expression_Function
+            && 'include' === $node->getAttribute('name')
+            && (!$node->getNode('arguments')->hasNode('with_context')
+                 || false !== $node->getNode('arguments')->getNode('with_context')->getAttribute('value')
+               )
+        ) {
+            $this->addLoopToAll();
+        }
+
         // the loop variable is referenced via an attribute
         elseif ($node instanceof Twig_Node_Expression_GetAttr
             && (!$node->getNode('attribute') instanceof Twig_Node_Expression_Constant

--- a/test/Twig/Tests/NodeVisitor/OptimizerTest.php
+++ b/test/Twig/Tests/NodeVisitor/OptimizerTest.php
@@ -89,6 +89,16 @@ class Twig_Tests_NodeVisitor_OptimizerTest extends PHPUnit_Framework_TestCase
             array('{% for i in foo %}{% for j in foo %}{{ foo.parent.loop.index }}{% endfor %}{% endfor %}', array('i' => false, 'j' => false)),
 
             array('{% for i in foo %}{% for j in foo %}{{ loop["parent"].loop.index }}{% endfor %}{% endfor %}', array('i' => true, 'j' => true)),
+
+            array('{% for i in foo %}{{ include("foo") }}{% endfor %}', array('i' => true)),
+
+            array('{% for i in foo %}{{ include("foo", with_context = false) }}{% endfor %}', array('i' => false)),
+
+            array('{% for i in foo %}{{ include("foo", with_context = true) }}{% endfor %}', array('i' => true)),
+
+            array('{% for i in foo %}{{ include("foo", { "foo": "bar" }, with_context = false) }}{% endfor %}', array('i' => false)),
+
+            array('{% for i in foo %}{{ include("foo", { "foo": loop.index }, with_context = false) }}{% endfor %}', array('i' => true)),
         );
     }
 


### PR DESCRIPTION
A `for`with an in `include` function was always optimized, making it impossible to use the `loop` variable inside the include unless it was explicitly passed in the `include` function parameters.
