### PR TITLE
The results of is_dir() are cached

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -1232,8 +1232,11 @@ class Twig_Environment
     {
         $dir = dirname($file);
         if (!is_dir($dir)) {
-            if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
-                throw new RuntimeException(sprintf("Unable to create the cache directory (%s).", $dir));
+            if (false === @mkdir($dir, 0777, true)) {
+                clearstatcache(false, $dir);
+                if (!is_dir($dir)) {
+                    throw new RuntimeException(sprintf("Unable to create the cache directory (%s).", $dir));
+                }
             }
         } elseif (!is_writable($dir)) {
             throw new RuntimeException(sprintf("Unable to write in the cache directory (%s).", $dir));


### PR DESCRIPTION
If a production server uses statcache, the results of the first and second call of is_dir() is always the same. 
So before calling is_dir() for the second time, use clearstatcache() to clear the results of the first call of is_dir().
