### PR TITLE
added an escaping strategy based on the template filename extension

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
-* 1.16.4 (2015-XX-XX)
+* 1.17.0 (2015-XX-XX)
 
- * n/a
+ * added a 'filename' autoescaping strategy, which dynamically chooses the
+   autoescaping strategy for a template based on template file extension.
 
 * 1.16.3 (2014-12-25)
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.16-dev"
+            "dev-master": "1.17-dev"
         }
     }
 }

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -96,11 +96,13 @@ The following options are available:
 
 * ``autoescape``: If set to ``true``, auto-escaping will be enabled by default
   for all templates (default to ``true``). As of Twig 1.8, you can set the
-  escaping strategy to use (``html``, ``js``, ``false`` to disable).
-  As of Twig 1.9, you can set the escaping strategy to use (``css``, ``url``, 
-  ``html_attr``, or a PHP callback that takes the template "filename" and must 
+  escaping strategy to use (``html``, ``js``, ``false`` to disable). As of Twig
+  1.9, you can set the escaping strategy to use (``css``, ``url``,
+  ``html_attr``, or a PHP callback that takes the template "filename" and must
   return the escaping strategy to use -- the callback cannot be a function name
-  to avoid collision with built-in escaping strategies).
+  to avoid collision with built-in escaping strategies). As of Twig 1.17, the
+  ``filename`` escaping strategy determines the escaping strategy to use for a
+  template based on the template filename extension.
 
 * ``optimizations``: A flag that indicates which optimizations to apply
   (default to ``-1`` -- all optimizations are enabled; set it to ``0`` to

--- a/ext/twig/php_twig.h
+++ b/ext/twig/php_twig.h
@@ -15,7 +15,7 @@
 #ifndef PHP_TWIG_H
 #define PHP_TWIG_H
 
-#define PHP_TWIG_VERSION "1.16.4-DEV"
+#define PHP_TWIG_VERSION "1.17.0-DEV"
 
 #include "php.h"
 

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -16,7 +16,7 @@
  */
 class Twig_Environment
 {
-    const VERSION = '1.16.4-DEV';
+    const VERSION = '1.17.0-DEV';
 
     protected $charset;
     protected $loader;
@@ -72,6 +72,7 @@ class Twig_Environment
      *                  * false: disable auto-escaping
      *                  * true: equivalent to html
      *                  * html, js: set the autoescaping to one of the supported strategies
+     *                  * filename: set the autoescaping strategy based on the template filename extension
      *                  * PHP callback: a PHP callback that returns an escaping strategy based on the template "filename"
      *
      *  * optimizations: A flag that indicates which optimizations to apply

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -223,12 +223,12 @@ class Twig_Environment
         return $this->cache;
     }
 
-     /**
-      * Sets the cache directory or false if cache is disabled.
-      *
-      * @param string|false $cache The absolute path to the compiled templates,
-      *                            or false to disable cache
-      */
+    /**
+     * Sets the cache directory or false if cache is disabled.
+     *
+     * @param string|false $cache The absolute path to the compiled templates,
+     *                            or false to disable cache
+     */
     public function setCache($cache)
     {
         $this->cache = $cache ? $cache : false;

--- a/lib/Twig/Extension/Escaper.php
+++ b/lib/Twig/Extension/Escaper.php
@@ -64,6 +64,10 @@ class Twig_Extension_Escaper extends Twig_Extension
             $defaultStrategy = 'html';
         }
 
+        if ('filename' === $defaultStrategy) {
+            $defaultStrategy = array('Twig_FileExtensionEscapingStrategy', 'guess');
+        }
+
         $this->defaultStrategy = $defaultStrategy;
     }
 

--- a/lib/Twig/FileExtensionEscapingStrategy.php
+++ b/lib/Twig/FileExtensionEscapingStrategy.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2015 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Default autoescaping strategy based on file names.
+ *
+ * This strategy sets the HTML as the default autoescaping strategy,
+ * but changes it based on the filename.
+ *
+ * Note that there is no runtime performance impact as the
+ * default autoescaping strategy is set at compilation time.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Twig_FileExtensionEscapingStrategy
+{
+    /**
+     * Guesses the best autoescaping strategy based on the file name.
+     *
+     * @param string $filename The template file name
+     *
+     * @return string The escaping strategy name to use
+     */
+    public static function guess($filename)
+    {
+        if (!preg_match('{\.(js|css|txt)(?:\.[^/\\\\]+)?$}', $filename, $match)) {
+            return 'html';
+        }
+
+        switch ($match[1]) {
+            case 'js':
+                return 'js';
+
+            case 'css':
+                return 'css';
+
+            case 'txt':
+                return false;
+        }
+    }
+}

--- a/test/Twig/Tests/FileCachingTest.php
+++ b/test/Twig/Tests/FileCachingTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 class Twig_Tests_FileCachingTest extends PHPUnit_Framework_TestCase
 {
     protected $fileName;

--- a/test/Twig/Tests/FileExtensionEscapingStrategyTest.php
+++ b/test/Twig/Tests/FileExtensionEscapingStrategyTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Twig_Tests_FileExtensionEscapingStrategyTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getGuessData
+     */
+    public function testGuess($strategy, $filename)
+    {
+        $this->assertEquals($strategy, Twig_FileExtensionEscapingStrategy::guess($filename));
+    }
+
+    public function getGuessData()
+    {
+        return array(
+            // default
+            array('html', 'foo.html'),
+            array('html', 'foo.html.twig'),
+            array('html', 'foo'),
+            array('html', 'foo.bar.twig'),
+            array('html', 'foo.txt/foo'),
+            array('html', 'foo.txt/foo.js/'),
+
+            // css
+            array('css', 'foo.css'),
+            array('css', 'foo.css.twig'),
+            array('css', 'foo.twig.css'),
+
+            // js
+            array('js', 'foo.js'),
+            array('js', 'foo.js.twig'),
+            array('js', 'foo.txt/foo.js'),
+            array('js', 'foo.txt.twig/foo.js'),
+
+            // txt
+            array(false, 'foo.txt'),
+            array(false, 'foo.txt.twig'),
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a new autoescaping strategy based on the template filename extension. This strategy has been extracted from Symfony, where we are using it for quite a long time now.
