### PR TITLE
FIX #1596 FileSystem::findTemplate now applies realpath on the absolute ...

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 1.17.1 (2015-XX-XX)
 
- * n/a
+ * added a 'realpath' strategy when returning the template filename, if possible.
 
 * 1.17.0 (2015-01-14)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * 1.17.1 (2015-XX-XX)
 
- * added a 'realpath' strategy when returning the template filename, if possible.
+ * The template filename have realpath applied before returning it. In this way we have the same path between the
+   resolution of Twig and Twing bundle cache warmup, allowing to have one cache key.
 
 * 1.17.0 (2015-01-14)
 

--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -183,8 +183,11 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
         }
 
         foreach ($this->paths[$namespace] as $path) {
+            if (false !== $realpath = realpath($path.'/'.$shortname)) {
+                return $this->cache[$name] = $realpath;
+            }
             if (is_file($path.'/'.$shortname)) {
-                return $this->cache[$name] = realpath($path.'/'.$shortname);
+                return $this->cache[$name] = $path.'/'.$shortname;
             }
         }
 

--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -184,7 +184,7 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
 
         foreach ($this->paths[$namespace] as $path) {
             if (is_file($path.'/'.$shortname)) {
-                return $this->cache[$name] = $path.'/'.$shortname;
+                return $this->cache[$name] = realpath($path.'/'.$shortname);
             }
         }
 

--- a/test/Twig/Tests/Loader/FilesystemTest.php
+++ b/test/Twig/Tests/Loader/FilesystemTest.php
@@ -60,6 +60,7 @@ class Twig_Tests_Loader_FilesystemTest extends PHPUnit_Framework_TestCase
         $loader->addPath($basePath.'/named_ter', 'named');
         $loader->addPath($basePath.'/normal_ter');
         $loader->prependPath($basePath.'/normal_final');
+        $loader->prependPath($basePath.'/named/../named_quater', 'named');
         $loader->prependPath($basePath.'/named_final', 'named');
 
         $this->assertEquals(array(
@@ -70,11 +71,16 @@ class Twig_Tests_Loader_FilesystemTest extends PHPUnit_Framework_TestCase
         ), $loader->getPaths());
         $this->assertEquals(array(
             $basePath.'/named_final',
+            $basePath.'/named/../named_quater',
             $basePath.'/named',
             $basePath.'/named_bis',
             $basePath.'/named_ter',
         ), $loader->getPaths('named'));
 
+        $this->assertEquals(
+            $basePath.'/named_quater/named_absolute.html',
+            $loader->getCacheKey('@named/named_absolute.html')
+        );
         $this->assertEquals("path (final)\n", $loader->getSource('index.html'));
         $this->assertEquals("path (final)\n", $loader->getSource('@__main__/index.html'));
         $this->assertEquals("named path (final)\n", $loader->getSource('@named/index.html'));

--- a/test/Twig/Tests/Loader/Fixtures/named_quater/named_absolute.html
+++ b/test/Twig/Tests/Loader/Fixtures/named_quater/named_absolute.html
@@ -1,0 +1,1 @@
+named path (quater)


### PR DESCRIPTION
...path before returning it.

This is a purposal to fix the issue #1596.
Please make any feedback needed.