### PR TITLE
Displaying template name before and after rendered content.

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -280,7 +280,16 @@ abstract class Twig_Template implements Twig_TemplateInterface
             throw $e;
         }
 
-        return ob_get_clean();
+        $content = ob_get_clean();
+
+        if ($this->getEnvironment()->isDebug()) {
+            $content =
+                "<!-- [(".$level.") ".$this->getTemplateName()."]-->\n".
+                $content.
+                "\n<!-- [/(".$level.") ".$this->getTemplateName()."]-->";
+        }
+
+        return $content;
     }
 
     protected function displayWithErrorHandling(array $context, array $blocks = array())


### PR DESCRIPTION
Hi,

I know that this pull request cannot be merged, but sometimes we spent time to search in which template is some html generated, with this this problem doesn't exists. 

But the problem with this code is, that this comment <!-- [ ($level) $templateName ] --> will be displayed in every rendered language (js, css, etc.) so I need some clever way to define which language is currently used, and to display(or not) proper comment. 

For now I've two ideas. 
- In Symfony2 all twig files should be named *.{{format}}.twig (but i'm not sure if it's standard in other frameworks), but SF2 do not make you to use it this way, so this way is wrong.
- Second idea is to trying to detect language, and if it's detected and supported, we will display proper comments. It can be a performance issue, but it will be enabled only in debug mode. (we cannot save it during compilation, as we need content for templates like {{content}}.

What do you think?