### PR TITLE
fixed named args for static methods

### DIFF
--- a/lib/Twig/Node/Expression/Call.php
+++ b/lib/Twig/Node/Expression/Call.php
@@ -120,6 +120,9 @@ abstract class Twig_Node_Expression_Call extends Twig_Node_Expression
         } elseif (is_object($callable) && !$callable instanceof Closure) {
             $r = new ReflectionObject($callable);
             $r = $r->getMethod('__invoke');
+        } elseif (is_string($callable) && false !== strpos($callable, '::')) {
+            $parts = explode('::', $callable, 2);
+            $r = new ReflectionMethod($parts[0], $parts[1]);
         } else {
             $r = new ReflectionFunction($callable);
         }

--- a/test/Twig/Tests/Node/Expression/CallTest.php
+++ b/test/Twig/Tests/Node/Expression/CallTest.php
@@ -78,6 +78,16 @@ class Twig_Tests_Node_Expression_CallTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array('arg1'), $node->getArguments(array($this, 'customFunction'), array('arg1' => 'arg1')));
     }
 
+    public function testGetArgumentsForStaticMethod()
+    {
+        $node = new Twig_Tests_Node_Expression_Call(array(), array('type' => 'function', 'name' => 'custom_static_function'));
+        $this->assertEquals(array('arg1'), $node->getArguments(__CLASS__.'::customStaticFunction', array('arg1' => 'arg1')));
+    }
+
+    public static function customStaticFunction($arg1, $arg2 = 'default', $arg3 = array())
+    {
+    }
+
     public function customFunction($arg1, $arg2 = 'default', $arg3 = array())
     {
     }


### PR DESCRIPTION
This fixes an obscure reflection error that gets thrown if a functioned backed by a static method is called with named arguments.