### PR TITLE
Fix time sensitive profiler test (ready)

### DIFF
--- a/test/Twig/Tests/Profiler/Dumper/AbstractTest.php
+++ b/test/Twig/Tests/Profiler/Dumper/AbstractTest.php
@@ -32,13 +32,13 @@ abstract class Twig_Tests_Profiler_Dumper_AbstractTest extends PHPUnit_Framework
 
         $embedded = clone $embedded;
         $index->addProfile($embedded);
-        $a = range(1, 1000);
+        usleep(500);
         $embedded->leave();
-        $profile->leave();
 
-        usleep(5000);
+        usleep(4500);
         $index->leave();
 
+        $profile->leave();
         return $profile;
     }
 }

--- a/test/Twig/Tests/Profiler/Dumper/AbstractTest.php
+++ b/test/Twig/Tests/Profiler/Dumper/AbstractTest.php
@@ -39,6 +39,7 @@ abstract class Twig_Tests_Profiler_Dumper_AbstractTest extends PHPUnit_Framework
         $index->leave();
 
         $profile->leave();
+
         return $profile;
     }
 }

--- a/test/Twig/Tests/Profiler/Dumper/HtmlTest.php
+++ b/test/Twig/Tests/Profiler/Dumper/HtmlTest.php
@@ -15,13 +15,13 @@ class Twig_Tests_Profiler_Dumper_HtmlTest extends Twig_Tests_Profiler_Dumper_Abs
     {
         $dumper = new Twig_Profiler_Dumper_Html();
         $this->assertStringMatchesFormat(<<<EOF
-<pre>main
+<pre>main <span style="color: #d44">%d.%dms/%d%</span>
 └ <span style="background-color: #ffd">index.twig</span> <span style="color: #d44">%d.%dms/%d%</span>
   └ embedded.twig::block(<span style="background-color: #dfd">body</span>)
   └ <span style="background-color: #ffd">embedded.twig</span>
   │ └ <span style="background-color: #ffd">included.twig</span>
   └ index.twig::macro(<span style="background-color: #ddf">foo</span>)
-  └ <span style="background-color: #ffd">embedded.twig</span>
+  └ <span style="background-color: #ffd">embedded.twig</span> <span style="color: #d44">%d.%dms/%d%</span>
     └ <span style="background-color: #ffd">included.twig</span>
 </pre>
 EOF

--- a/test/Twig/Tests/Profiler/Dumper/HtmlTest.php
+++ b/test/Twig/Tests/Profiler/Dumper/HtmlTest.php
@@ -21,7 +21,7 @@ class Twig_Tests_Profiler_Dumper_HtmlTest extends Twig_Tests_Profiler_Dumper_Abs
   └ <span style="background-color: #ffd">embedded.twig</span>
   │ └ <span style="background-color: #ffd">included.twig</span>
   └ index.twig::macro(<span style="background-color: #ddf">foo</span>)
-  └ <span style="background-color: #ffd">embedded.twig</span> <span style="color: #d44">%d.%dms/%d%</span>
+  └ <span style="background-color: #ffd">embedded.twig</span>
     └ <span style="background-color: #ffd">included.twig</span>
 </pre>
 EOF

--- a/test/Twig/Tests/Profiler/Dumper/TextTest.php
+++ b/test/Twig/Tests/Profiler/Dumper/TextTest.php
@@ -15,13 +15,13 @@ class Twig_Tests_Profiler_Dumper_TextTest extends Twig_Tests_Profiler_Dumper_Abs
     {
         $dumper = new Twig_Profiler_Dumper_Text();
         $this->assertStringMatchesFormat(<<<EOF
-main
+main %d.%dms/%d%
 └ index.twig %d.%dms/%d%
   └ embedded.twig::block(body)
   └ embedded.twig
   │ └ included.twig
   └ index.twig::macro(foo)
-  └ embedded.twig
+  └ embedded.twig %d.%dms/%d%
     └ included.twig
 
 EOF

--- a/test/Twig/Tests/Profiler/Dumper/TextTest.php
+++ b/test/Twig/Tests/Profiler/Dumper/TextTest.php
@@ -21,7 +21,7 @@ main %d.%dms/%d%
   └ embedded.twig
   │ └ included.twig
   └ index.twig::macro(foo)
-  └ embedded.twig %d.%dms/%d%
+  └ embedded.twig
     └ included.twig
 
 EOF

--- a/test/Twig/Tests/Profiler/ProfileTest.php
+++ b/test/Twig/Tests/Profiler/ProfileTest.php
@@ -69,9 +69,10 @@ class Twig_Tests_Profiler_ProfileTest extends PHPUnit_Framework_TestCase
     public function testGetDuration()
     {
         $profile = new Twig_Profiler_Profile();
+        usleep(1);
         $profile->leave();
 
-        $this->assertTrue($profile->getDuration() > 0);
+        $this->assertTrue($profile->getDuration() > 0, sprintf('Expected duration > 0, got: %f', $profile->getDuration()));
     }
 
     public function testSerialize()


### PR DESCRIPTION
The profiler tests fail some times because of the performance of the machine these are run on.
These changes should provide stability.