### PR TITLE
Clean output buffers when an exception occured

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -176,8 +176,17 @@ abstract class Twig_Template implements Twig_TemplateInterface
      */
     public function renderParentBlock($name, array $context, array $blocks = array())
     {
+        $level = ob_get_level();
         ob_start();
-        $this->displayParentBlock($name, $context, $blocks);
+        try {
+            $this->displayParentBlock($name, $context, $blocks);
+        } catch (Exception $e) {
+            while (ob_get_level() > $level) {
+                ob_end_clean();
+            }
+
+            throw $e;
+        }
 
         return ob_get_clean();
     }
@@ -197,8 +206,17 @@ abstract class Twig_Template implements Twig_TemplateInterface
      */
     public function renderBlock($name, array $context, array $blocks = array(), $useBlocks = true)
     {
+        $level = ob_get_level();
         ob_start();
-        $this->displayBlock($name, $context, $blocks, $useBlocks);
+        try {
+            $this->displayBlock($name, $context, $blocks, $useBlocks);
+        } catch (Exception $e) {
+            while (ob_get_level() > $level) {
+                ob_end_clean();
+            }
+
+            throw $e;
+        }
 
         return ob_get_clean();
     }


### PR DESCRIPTION
When I was testing rendering of a specific block (`renderBlock()`) of a faulty Twig template (non-existent variable) in PHPUnit, it stated that particular test was risky.

After some debugging, I found out that when an exception occurs in the `displayBlock()` method, the output buffer that was opened in `renderBlock()` would still be open. PHPUnit complains about that by saying the test was risky.

I fixed this by closing all open output buffers when an exception occurs. The fix is the same as the one that is already in place in `render()`. Next, I also applied it to `renderParentBlock()`, that has the same behaviour as `renderBlock()`.