### PR TITLE
Updates slice so that it still accepts a SimpleXMLElement

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -707,7 +707,7 @@ function twig_slice(Twig_Environment $env, $item, $start, $length = null, $prese
             $item = $item->getIterator();
         }
 
-        if ($start >= 0 && $length >= 0) {
+        if ($start >= 0 && $length >= 0 && $item instanceof Iterator) {
             try {
                 return iterator_to_array(new LimitIterator($item, $start, $length === null ? -1 : $length), $preserveKeys);
             } catch (OutOfBoundsException $exception) {

--- a/test/Twig/Tests/Fixtures/filters/slice.test
+++ b/test/Twig/Tests/Fixtures/filters/slice.test
@@ -24,8 +24,9 @@
 
 {{ arr|slice(3)|join('') }}
 {{ arr[2:]|join('') }}
+{{ xml|slice(1)|join('')}}
 --DATA--
-return array('start' => 1, 'length' => 2, 'arr' => new ArrayObject(array(1, 2, 3, 4)))
+return array('start' => 1, 'length' => 2, 'arr' => new ArrayObject(array(1, 2, 3, 4)), 'xml' => new SimpleXMLElement('<items><item>1</item><item>2</item></items>'))
 --EXPECT--
 23
 23
@@ -50,3 +51,4 @@ bc
 
 4
 34
+2


### PR DESCRIPTION
Since #1503 you cannot pass a SimpleXMLElement to slice as you get:

   Catchable fatal error: Argument 1 passed to LimitIterator::__construct() must implement interface Iterator, instance of SimpleXMLElement given

As SimpleXMLElement implements Traversable but not Iterator

This checks that $item is an instance of Iterator before passing to LimitIterator