### PR TITLE
deprecated the String loader

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.18.1 (2015-XX-XX)
 
+ * deprecated Twig_Loader_String
  * fixed the slice filter when used with a SimpleXMLElement object
  * fixed filesystem loader when trying to load non-files (like directories)
 

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -101,6 +101,12 @@ Interfaces
   those constants Twig_Template::ANY_CALL, Twig_Template::ARRAY_CALL,
   Twig_Template::METHOD_CALL)
 
+Loaders
+-------
+
+* As of Twig 1.x, ``Twig_Loader_String`` is deprecated and will be removed in
+  2.0.
+
 Globals
 -------
 

--- a/lib/Twig/Loader/String.php
+++ b/lib/Twig/Loader/String.php
@@ -19,6 +19,8 @@
  * source code of the template). If you don't want to see your cache grows out of
  * control, you need to take care of clearing the old cache file by yourself.
  *
+ * @deprecated since 1.18.1 (to be removed in 2.0)
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class Twig_Loader_String implements Twig_LoaderInterface, Twig_ExistsLoaderInterface

--- a/test/Twig/Tests/ExpressionParserTest.php
+++ b/test/Twig/Tests/ExpressionParserTest.php
@@ -17,7 +17,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testCanOnlyAssignToNames($template)
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
         $parser->parse($env->tokenize($template, 'index'));
@@ -41,7 +41,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testArrayExpression($template, $expected)
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $stream = $env->tokenize($template, 'index');
         $parser = new Twig_Parser($env);
 
@@ -54,7 +54,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testArraySyntaxError($template)
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
         $parser->parse($env->tokenize($template, 'index'));
@@ -149,7 +149,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testStringExpressionDoesNotConcatenateTwoConsecutiveStrings()
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false, 'optimizations' => 0));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false, 'optimizations' => 0));
         $stream = $env->tokenize('{{ "a" "b" }}', 'index');
         $parser = new Twig_Parser($env);
 
@@ -161,7 +161,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testStringExpression($template, $expected)
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false, 'optimizations' => 0));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false, 'optimizations' => 0));
         $stream = $env->tokenize($template, 'index');
         $parser = new Twig_Parser($env);
 
@@ -220,7 +220,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testAttributeCallDoesNotSupportNamedArguments()
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
         $parser->parse($env->tokenize('{{ foo.bar(name="Foo") }}', 'index'));
@@ -231,7 +231,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testMacroCallDoesNotSupportNamedArguments()
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
         $parser->parse($env->tokenize('{% from _self import foo %}{% macro foo() %}{% endmacro %}{{ foo(name="Foo") }}', 'index'));
@@ -243,7 +243,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testMacroDefinitionDoesNotSupportNonNameVariableName()
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
         $parser->parse($env->tokenize('{% macro foo("a") %}{% endmacro %}', 'index'));
@@ -256,7 +256,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testMacroDefinitionDoesNotSupportNonConstantDefaultValues($template)
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
         $parser->parse($env->tokenize($template, 'index'));
@@ -275,7 +275,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testMacroDefinitionSupportsConstantDefaultValues($template)
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
         $parser->parse($env->tokenize($template, 'index'));
@@ -300,7 +300,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testUnknownFunction()
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
         $parser->parse($env->tokenize('{{ cycl() }}', 'index'));
@@ -312,7 +312,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testUnknownFilter()
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
         $parser->parse($env->tokenize('{{ 1|lowe }}', 'index'));
@@ -324,7 +324,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
      */
     public function testUnknownTest()
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
         $parser->parse($env->tokenize('{{ 1 is nul }}', 'index'));

--- a/test/Twig/Tests/FileCachingTest.php
+++ b/test/Twig/Tests/FileCachingTest.php
@@ -26,7 +26,7 @@ class Twig_Tests_FileCachingTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped(sprintf('Unable to run the tests as "%s" is not writable.', $this->tmpDir));
         }
 
-        $this->env = new Twig_Environment(new Twig_Loader_String(), array('cache' => $this->tmpDir));
+        $this->env = new Twig_Environment(new Twig_Loader_Array(array('index' => 'index', 'index2' => 'index2')), array('cache' => $this->tmpDir));
     }
 
     public function tearDown()
@@ -40,7 +40,7 @@ class Twig_Tests_FileCachingTest extends PHPUnit_Framework_TestCase
 
     public function testWritingCacheFiles()
     {
-        $name = 'This is just text.';
+        $name = 'index';
         $this->env->loadTemplate($name);
         $cacheFileName = $this->env->getCacheFilename($name);
 
@@ -50,7 +50,7 @@ class Twig_Tests_FileCachingTest extends PHPUnit_Framework_TestCase
 
     public function testClearingCacheFiles()
     {
-        $name = 'I will be deleted.';
+        $name = 'index2';
         $this->env->loadTemplate($name);
         $cacheFileName = $this->env->getCacheFilename($name);
 

--- a/test/Twig/Tests/NativeExtensionTest.php
+++ b/test/Twig/Tests/NativeExtensionTest.php
@@ -17,7 +17,7 @@ class Twig_Tests_NativeExtensionTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped('Skip under HHVM as the behavior is not the same as plain PHP (which is an edge case anyway)');
         }
 
-        $twig = new Twig_Environment(new Twig_Loader_String(), array(
+        $twig = new Twig_Environment(new Twig_Loader_Array(array('index' => '{{ d1.date }}{{ d2.date }}')), array(
             'debug'      => true,
             'cache'      => false,
             'autoescape' => false,
@@ -25,7 +25,7 @@ class Twig_Tests_NativeExtensionTest extends PHPUnit_Framework_TestCase
 
         $d1 = new DateTime();
         $d2 = new DateTime();
-        $output = $twig->render('{{ d1.date }}{{ d2.date }}', compact('d1', 'd2'));
+        $output = $twig->render('index', compact('d1', 'd2'));
 
         // If it fails, PHP will crash.
         $this->assertEquals($output, $d1->date.$d2->date);

--- a/test/Twig/Tests/Node/ModuleTest.php
+++ b/test/Twig/Tests/Node/ModuleTest.php
@@ -30,7 +30,7 @@ class Twig_Tests_Node_ModuleTest extends Twig_Test_NodeTestCase
 
     public function getTests()
     {
-        $twig = new Twig_Environment(new Twig_Loader_String());
+        $twig = new Twig_Environment($this->getMock('Twig_LoaderInterface'));
 
         $tests = array();
 
@@ -46,7 +46,7 @@ class Twig_Tests_Node_ModuleTest extends Twig_Test_NodeTestCase
 <?php
 
 /* foo.twig */
-class __TwigTemplate_a2bfbf7dd6ab85666684fe9297f69363a3fc2046d90f22a317d380c18638df0d extends Twig_Template
+class __TwigTemplate_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 extends Twig_Template
 {
     public function __construct(Twig_Environment \$env)
     {
@@ -87,7 +87,7 @@ EOF
 <?php
 
 /* foo.twig */
-class __TwigTemplate_a2bfbf7dd6ab85666684fe9297f69363a3fc2046d90f22a317d380c18638df0d extends Twig_Template
+class __TwigTemplate_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 extends Twig_Template
 {
     public function __construct(Twig_Environment \$env)
     {
@@ -144,7 +144,7 @@ EOF
 <?php
 
 /* foo.twig */
-class __TwigTemplate_a2bfbf7dd6ab85666684fe9297f69363a3fc2046d90f22a317d380c18638df0d extends Twig_Template
+class __TwigTemplate_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 extends Twig_Template
 {
     protected function doGetParent(array \$context)
     {

--- a/test/Twig/Tests/NodeVisitor/OptimizerTest.php
+++ b/test/Twig/Tests/NodeVisitor/OptimizerTest.php
@@ -12,7 +12,7 @@ class Twig_Tests_NodeVisitor_OptimizerTest extends PHPUnit_Framework_TestCase
 {
     public function testRenderBlockOptimizer()
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
 
         $stream = $env->parse($env->tokenize('{{ block("foo") }}', 'index'));
 
@@ -24,7 +24,7 @@ class Twig_Tests_NodeVisitor_OptimizerTest extends PHPUnit_Framework_TestCase
 
     public function testRenderParentBlockOptimizer()
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
 
         $stream = $env->parse($env->tokenize('{% extends "foo" %}{% block content %}{{ parent() }}{% endblock %}', 'index'));
 
@@ -40,7 +40,7 @@ class Twig_Tests_NodeVisitor_OptimizerTest extends PHPUnit_Framework_TestCase
             return;
         }
 
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false, 'autoescape' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $stream = $env->parse($env->tokenize('{{ block(name|lower) }}', 'index'));
 
         $node = $stream->getNode('body')->getNode(0)->getNode(1);
@@ -54,7 +54,7 @@ class Twig_Tests_NodeVisitor_OptimizerTest extends PHPUnit_Framework_TestCase
      */
     public function testForOptimizer($template, $expected)
     {
-        $env = new Twig_Environment(new Twig_Loader_String(), array('cache' => false));
+        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false));
 
         $stream = $env->parse($env->tokenize($template, 'index'));
 


### PR DESCRIPTION
Even if the String loader should never be used, people keep trying to use it. It's too confusing to keep and we don't really need it in tests. So, I propose to deprecate it in 1.x and remove it in 2.x