### PR TITLE
add ignore_missing agrument to source function

### DIFF
--- a/doc/functions/source.rst
+++ b/doc/functions/source.rst
@@ -8,6 +8,13 @@ The ``source`` function returns the content of a template without rendering it:
     {{ source('template.html') }}
     {{ source(some_var) }}
 
+When you set the ``ignore_missing`` flag, Twig will return an empty string if
+the template does not exist:
+
+.. code-block:: jinja
+
+    {{ source('template.html', ignore_missing = true) }}
+
 The function uses the same template loaders as the ones used to include
 templates. So, if you are using the filesystem loader, the templates are looked
 for in the paths defined by it.
@@ -16,3 +23,4 @@ Arguments
 ---------
 
 * ``name``: The name of the template to read
+* ``ignore_missing``: Whether to ignore missing templates or not

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1387,13 +1387,20 @@ function twig_include(Twig_Environment $env, $context, $template, $variables = a
 /**
  * Returns a template content without rendering it.
  *
- * @param string $name The template name
+ * @param string $name           The template name
+ * @param bool   $ignore_missing Whether to ignore missing templates or not
  *
  * @return string The template source
  */
-function twig_source(Twig_Environment $env, $name)
+function twig_source(Twig_Environment $env, $name, $ignoreMissing = false)
 {
-    return $env->getLoader()->getSource($name);
+    try {
+        return $env->getLoader()->getSource($name);
+    } catch (Twig_Error_Loader $e) {
+        if (!$ignoreMissing) {
+            throw $e;
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
This basically works the same way as `ignore_missing` on the `include` function/tag.