### PR TITLE
[1.x] Updated exception messages for null vars

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -419,7 +419,13 @@ abstract class Twig_Template implements Twig_TemplateInterface
                         $message = sprintf('Key "%s" for array with keys "%s" does not exist', $arrayItem, implode(', ', array_keys($object)));
                     }
                 } elseif (Twig_Template::ARRAY_CALL === $type) {
-                    $message = sprintf('Impossible to access a key ("%s") on a %s variable ("%s")', $item, gettype($object), $object);
+                    if (null === $object) {
+                        $message = sprintf('Impossible to access a key ("%s") on a null variable', $item);
+                    } else {
+                        $message = sprintf('Impossible to access a key ("%s") on a %s variable ("%s")', $item, gettype($object), $object);
+                    }
+                } elseif (null === $object) {
+                    $message = sprintf('Impossible to access an attribute ("%s") on a null variable', $item);
                 } else {
                     $message = sprintf('Impossible to access an attribute ("%s") on a %s variable ("%s")', $item, gettype($object), $object);
                 }
@@ -437,7 +443,13 @@ abstract class Twig_Template implements Twig_TemplateInterface
                 return;
             }
 
-            throw new Twig_Error_Runtime(sprintf('Impossible to invoke a method ("%s") on a %s variable ("%s")', $item, gettype($object), $object), -1, $this->getTemplateName());
+            if (null === $object) {
+                $message = sprintf('Impossible to invoke a method ("%s") on a null variable', $item);
+            } else {
+                $message = sprintf('Impossible to invoke a method ("%s") on a %s variable ("%s")', $item, gettype($object), $object);
+            }
+
+            throw new Twig_Error_Runtime($message, -1, $this->getTemplateName());
         }
 
         // object property

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -28,6 +28,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
 
         $context = array(
             'string'          => 'foo',
+            'null'            => null,
             'empty_array'     => array(),
             'array'           => array('foo' => 'foo'),
             'array_access'    => new Twig_TemplateArrayAccessObject(),
@@ -47,11 +48,14 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
     {
         $tests = array(
             array('{{ string["a"] }}', 'Impossible to access a key ("a") on a string variable ("foo") in "%s" at line 1', false),
+            array('{{ null["a"] }}', 'Impossible to access a key ("a") on a null variable in "%s" at line 1', false),
             array('{{ empty_array["a"] }}', 'Key "a" does not exist as the array is empty in "%s" at line 1', false),
             array('{{ array["a"] }}', 'Key "a" for array with keys "foo" does not exist in "%s" at line 1', false),
             array('{{ array_access["a"] }}', 'Key "a" in object with ArrayAccess of class "Twig_TemplateArrayAccessObject" does not exist in "%s" at line 1', false),
             array('{{ string.a }}', 'Impossible to access an attribute ("a") on a string variable ("foo") in "%s" at line 1', false),
             array('{{ string.a() }}', 'Impossible to invoke a method ("a") on a string variable ("foo") in "%s" at line 1', false),
+            array('{{ null.a }}', 'Impossible to access an attribute ("a") on a null variable in "%s" at line 1', false),
+            array('{{ null.a() }}', 'Impossible to invoke a method ("a") on a null variable in "%s" at line 1', false),
             array('{{ empty_array.a }}', 'Key "a" does not exist as the array is empty in "%s" at line 1', false),
             array('{{ array.a }}', 'Key "a" for array with keys "foo" does not exist in "%s" at line 1', false),
             array('{{ attribute(array, -10) }}', 'Key "-10" for array with keys "foo" does not exist in "%s" at line 1', false),


### PR DESCRIPTION
Updated exception messages for null vars in ```Twig_Template::getAttribute()```.

Example:
**Before:**
```
Impossible to invoke a method ("myMethod") on a NULL variable ("") in My:template.html.twig at line 1
```

**After:**
```
Impossible to invoke a method ("myMethod") on a null variable in My:template.html.twig at line 1
```
