### PR TITLE
Fix two failed unit tests on Windows:

### DIFF
--- a/test/Twig/Tests/Fixtures/tests/in.test
+++ b/test/Twig/Tests/Fixtures/tests/in.test
@@ -73,7 +73,7 @@ TRUE
 {{ 5.5 in '125.5' ? 'TRUE' : 'FALSE' }}
 {{ '5.5' in 125.5 ? 'TRUE' : 'FALSE' }}
 --DATA--
-return array('bar' => 'bar', 'foo' => array('bar' => 'bar'), 'dir_object' => new SplFileInfo(dirname(__FILE__)), 'object' => new stdClass(), 'resource' => fopen(dirname(__FILE__), 'r'))
+return array('bar' => 'bar', 'foo' => array('bar' => 'bar'), 'dir_object' => new SplFileInfo(dirname(__FILE__)), 'object' => new stdClass(), 'resource' => tmpfile())
 --EXPECT--
 TRUE
 TRUE

--- a/test/Twig/Tests/Loader/FilesystemTest.php
+++ b/test/Twig/Tests/Loader/FilesystemTest.php
@@ -78,8 +78,8 @@ class Twig_Tests_Loader_FilesystemTest extends PHPUnit_Framework_TestCase
         ), $loader->getPaths('named'));
 
         $this->assertEquals(
-            $basePath.'/named_quater/named_absolute.html',
-            $loader->getCacheKey('@named/named_absolute.html')
+            strtr($basePath.'/named_quater/named_absolute.html', '\\', '/'),
+            strtr($loader->getCacheKey('@named/named_absolute.html'), '\\', '/')
         );
         $this->assertEquals("path (final)\n", $loader->getSource('index.html'));
         $this->assertEquals("path (final)\n", $loader->getSource('@__main__/index.html'));


### PR DESCRIPTION
1. fopen() cannot handle directory, replaced by tmpfile() for getting a testing resource.
2. comparing paths by assertEquals() which has mixed '\' and '/' on Windows.