### PR TITLE
Reduce the name of the cache directories to 1 character

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -250,7 +250,7 @@ class Twig_Environment
 
         $class = substr($this->getTemplateClass($name), strlen($this->templateClassPrefix));
 
-        return $this->getCache().'/'.substr($class, 0, 2).'/'.substr($class, 2, 2).'/'.substr($class, 4).'.php';
+        return $this->getCache().'/'.$class[0].'/'.$class[1].'/'.$class.'.php';
     }
 
     /**
@@ -1271,11 +1271,11 @@ class Twig_Environment
             if (false === @mkdir($dir, 0777, true)) {
                 clearstatcache(false, $dir);
                 if (!is_dir($dir)) {
-                    throw new RuntimeException(sprintf("Unable to create the cache directory (%s).", $dir));
+                    throw new RuntimeException(sprintf('Unable to create the cache directory (%s).', $dir));
                 }
             }
         } elseif (!is_writable($dir)) {
-            throw new RuntimeException(sprintf("Unable to write in the cache directory (%s).", $dir));
+            throw new RuntimeException(sprintf('Unable to write in the cache directory (%s).', $dir));
         }
 
         $tmpFile = tempnam($dir, basename($file));


### PR DESCRIPTION
Currently Twig spread the cached template over a directory tree and it's a good practice because it makes the filesystem happier (some filesystems limit the number of file per directory and some filesystems do not index the content of the directories => to access a file in a directory you may have to go through all the files in the directory to find it).

But this technique as also a few drawbacks because it will consume more inodes and in PHP because of the realpath cache which could be saturated by the path of too many directories.

`----`

The current implementation use 2 levels of directory with a 2 chars name, which end-up to `36^4 == 1,679,616` combinations and when you have a lot of templates it can be a real issue.

Per example, with 8,000 templates you will have:
- 8,000 different keys because `8,000 <<< 1,679,616` (a key is the combination of the two directories name, so 4 characters)
- 1,296 directories directly under `twig/`
- **1 file** per directory
- a total of `8,000 + 8,000 + 1,296 =` **17,296 keys** in the realpath cache.

My proposal with this PR is to reduce the name of the directories to only one character which for 8,000 templates end up to:
- 1,296 different keys (a key is the combination of the two directories name, so 2 characters)
- 36 directories directly under `twig/`
- ~**8 files** per directory
- a total of `8,000 + 1,296 + 36 =` **9,332 keys** in the realpath cache.

Note: If you don't have a lot of templates (> 1,000) it will not change anything for you.