### PR TITLE
Fix two failed unit tests on Windows:

### DIFF
--- a/test/Twig/Tests/Fixtures/tests/in.test
+++ b/test/Twig/Tests/Fixtures/tests/in.test
@@ -50,6 +50,7 @@ TRUE
 {{ [] in [true, ''] ? 'TRUE' : 'FALSE' }}
 {{ [] in [true, []] ? 'TRUE' : 'FALSE' }}
 
+{{ resource ? 'TRUE' : 'FALSE' }}
 {{ resource in 'foo'~resource ? 'TRUE' : 'FALSE' }}
 {{ object in 'stdClass' ? 'TRUE' : 'FALSE' }}
 {{ [] in 'Array' ? 'TRUE' : 'FALSE' }}
@@ -73,7 +74,7 @@ TRUE
 {{ 5.5 in '125.5' ? 'TRUE' : 'FALSE' }}
 {{ '5.5' in 125.5 ? 'TRUE' : 'FALSE' }}
 --DATA--
-return array('bar' => 'bar', 'foo' => array('bar' => 'bar'), 'dir_object' => new SplFileInfo(dirname(__FILE__)), 'object' => new stdClass(), 'resource' => fopen(dirname(__FILE__), 'r'))
+return array('bar' => 'bar', 'foo' => array('bar' => 'bar'), 'dir_object' => new SplFileInfo(dirname(__FILE__)), 'object' => new stdClass(), 'resource' => opendir(dirname(__FILE__)))
 --EXPECT--
 TRUE
 TRUE
@@ -102,6 +103,7 @@ TRUE
 FALSE
 TRUE
 
+TRUE
 FALSE
 FALSE
 FALSE

--- a/test/Twig/Tests/Loader/FilesystemTest.php
+++ b/test/Twig/Tests/Loader/FilesystemTest.php
@@ -78,8 +78,8 @@ class Twig_Tests_Loader_FilesystemTest extends PHPUnit_Framework_TestCase
         ), $loader->getPaths('named'));
 
         $this->assertEquals(
-            $basePath.'/named_quater/named_absolute.html',
-            $loader->getCacheKey('@named/named_absolute.html')
+            realpath($basePath.'/named_quater/named_absolute.html'),
+            realpath($loader->getCacheKey('@named/named_absolute.html'))
         );
         $this->assertEquals("path (final)\n", $loader->getSource('index.html'));
         $this->assertEquals("path (final)\n", $loader->getSource('@__main__/index.html'));


### PR DESCRIPTION
1. fopen() cannot handle directory, replaced by opendir() for getting a testing resource. (also double check a resource is opened)
2. comparing paths by assertEquals() which has mixed '\' and '/' on Windows.