### PR TITLE
[WIP] Added renderString method 

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -294,6 +294,24 @@ class Twig_Environment
     }
 
     /**
+     * Renders a string.
+     *
+     * @param string $string  The template
+     * @param array  $context An array of parameters to pass to the template
+     *
+     * @return string The rendered template
+     *
+     * @throws Twig_Error_Syntax  When an error occurred during compilation
+     * @throws Twig_Error_Runtime When an error occurred during rendering
+     */
+    public function renderString($string, array $context = array())
+    {
+        $template = $this->createTemplate($string);
+        
+        return $template->render($context);
+    }
+
+    /**
      * Displays a template.
      *
      * @param string $name    The template name


### PR DESCRIPTION
As the String loader has been deprecated I think it makes sense to offer out of the box a way to render strings with twig as @stof suggested here https://github.com/twigphp/Twig/pull/1641#issuecomment-76732213.

This is a wip to find out if this is generally wanted and if so I would have a closer look at it and would provide also the proper documentation. I think it would be great to have a string renderer by default.

The symfony2 bridge would need to be updated accordingly.