### PR TITLE
Bugfix/constructor should not have optional loader

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -81,11 +81,9 @@ class Twig_Environment
      * @param Twig_LoaderInterface $loader  A Twig_LoaderInterface instance
      * @param array                $options An array of options
      */
-    public function __construct(Twig_LoaderInterface $loader = null, $options = array())
+    public function __construct(Twig_LoaderInterface $loader, $options = array())
     {
-        if (null !== $loader) {
-            $this->setLoader($loader);
-        }
+        $this->setLoader($loader);
 
         $options = array_merge(array(
             'debug' => false,

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -603,10 +603,6 @@ class Twig_Environment
      */
     public function getLoader()
     {
-        if (null === $this->loader) {
-            throw new LogicException('You must set a loader first.');
-        }
-
         return $this->loader;
     }
 

--- a/lib/Twig/Test/NodeTestCase.php
+++ b/lib/Twig/Test/NodeTestCase.php
@@ -35,7 +35,7 @@ abstract class Twig_Test_NodeTestCase extends PHPUnit_Framework_TestCase
 
     protected function getEnvironment()
     {
-        return new Twig_Environment();
+        return new Twig_Environment(new Twig_Loader_Array(array()));
     }
 
     protected function getVariableGetter($name, $line = false)

--- a/test/Twig/Tests/CompilerTest.php
+++ b/test/Twig/Tests/CompilerTest.php
@@ -13,7 +13,7 @@ class Twig_Tests_CompilerTest extends PHPUnit_Framework_TestCase
 {
     public function testReprNumericValueWithLocale()
     {
-        $compiler = new Twig_Compiler(new Twig_Environment());
+        $compiler = new Twig_Compiler(new Twig_Environment(new Twig_Loader_Array(array())));
 
         $locale = setlocale(LC_NUMERIC, 0);
         if (false === $locale) {

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -11,16 +11,6 @@
 
 class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
 {
-    /**
-     * @expectedException        LogicException
-     * @expectedExceptionMessage You must set a loader first.
-     */
-    public function testRenderNoLoader()
-    {
-        $env = new Twig_Environment();
-        $env->render('test');
-    }
-
     public function testAutoescapeOption()
     {
         $loader = new Twig_Loader_Array(array(

--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -16,7 +16,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
      */
     public function testRandomFunction($value, $expectedInArray)
     {
-        $env = new Twig_Environment();
+        $env = new Twig_Environment(new Twig_Loader_Array(array()));
 
         for ($i = 0; $i < 100; ++$i) {
             $this->assertTrue(in_array(twig_random($env, $value), $expectedInArray, true)); // assertContains() would not consider the type
@@ -90,7 +90,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped('needs iconv or mbstring');
         }
 
-        $twig = new Twig_Environment();
+        $twig = new Twig_Environment(new Twig_Loader_Array(array()));
         $twig->setCharset('ISO-8859-1');
 
         $text = twig_convert_encoding('Äé', 'ISO-8859-1', 'UTF-8');
@@ -106,7 +106,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped('needs iconv or mbstring');
         }
 
-        $twig = new Twig_Environment();
+        $twig = new Twig_Environment(new Twig_Loader_Array(array()));
         $twig->setCharset('ISO-8859-1');
 
         $input = twig_convert_encoding('Äé', 'ISO-8859-1', 'UTF-8');
@@ -117,7 +117,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
 
     public function testCustomEscaper()
     {
-        $twig = new Twig_Environment();
+        $twig = new Twig_Environment(new Twig_Loader_Array(array()));
         $twig->getExtension('core')->setEscaper('foo', 'foo_escaper_for_test');
 
         $this->assertEquals('fooUTF-8', twig_escape_filter($twig, 'foo', 'foo'));
@@ -133,7 +133,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
 
     public function testTwigFirst()
     {
-        $twig = new Twig_Environment();
+        $twig = new Twig_Environment(new Twig_Loader_Array(array()));
         $this->assertEquals('a', twig_first($twig, 'abc'));
         $this->assertEquals(1, twig_first($twig, array(1, 2, 3)));
         $this->assertSame('', twig_first($twig, null));
@@ -142,7 +142,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
 
     public function testTwigLast()
     {
-        $twig = new Twig_Environment();
+        $twig = new Twig_Environment(new Twig_Loader_Array(array()));
         $this->assertEquals('c', twig_last($twig, 'abc'));
         $this->assertEquals(3, twig_last($twig, array(1, 2, 3)));
         $this->assertSame('', twig_last($twig, null));

--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -61,19 +61,19 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
     {
         $max = mt_getrandmax();
 
-        for ($i = 0; $i < 100; ++$i) {
-            $val = twig_random(new Twig_Environment());
+        for ($i = 0; $i < 100; $i++) {
+            $val = twig_random(new Twig_Environment(new Twig_Loader_Array(array())));
             $this->assertTrue(is_int($val) && $val >= 0 && $val <= $max);
         }
     }
 
     public function testRandomFunctionReturnsAsIs()
     {
-        $this->assertSame('', twig_random(new Twig_Environment(), ''));
-        $this->assertSame('', twig_random(new Twig_Environment(null, array('charset' => null)), ''));
+        $this->assertSame('', twig_random(new Twig_Environment(new Twig_Loader_Array(array())), ''));
+        $this->assertSame('', twig_random(new Twig_Environment(new Twig_Loader_Array(array()), array('charset' => null)), ''));
 
         $instance = new stdClass();
-        $this->assertSame($instance, twig_random(new Twig_Environment(), $instance));
+        $this->assertSame($instance, twig_random(new Twig_Environment(new Twig_Loader_Array(array())), $instance));
     }
 
     /**
@@ -81,7 +81,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
      */
     public function testRandomFunctionOfEmptyArrayThrowsException()
     {
-        twig_random(new Twig_Environment(), array());
+        twig_random(new Twig_Environment(new Twig_Loader_Array(array())), array());
     }
 
     public function testRandomFunctionOnNonUTF8String()
@@ -128,7 +128,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
      */
     public function testUnknownCustomEscaper()
     {
-        twig_escape_filter(new Twig_Environment(), 'foo', 'bar');
+        twig_escape_filter(new Twig_Environment(new Twig_Loader_Array(array())), 'foo', 'bar');
     }
 
     public function testTwigFirst()

--- a/test/Twig/Tests/LexerTest.php
+++ b/test/Twig/Tests/LexerTest.php
@@ -14,7 +14,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{% § %}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
 
         $stream->expect(Twig_Token::BLOCK_START_TYPE);
@@ -25,7 +25,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{{ §() }}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
 
         $stream->expect(Twig_Token::VAR_START_TYPE);
@@ -42,7 +42,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
 
     protected function countToken($template, $type, $value = null)
     {
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
 
         $count = 0;
@@ -67,7 +67,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
             ."baz\n"
             ."}}\n";
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
 
         // foo\nbar\n
@@ -87,7 +87,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
             ."baz\n"
             ."}}\n";
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
 
         // foo\nbar
@@ -102,7 +102,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{# '.str_repeat('*', 100000).' #}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $lexer->tokenize($template);
 
         // should not throw an exception
@@ -112,7 +112,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{% raw %}'.str_repeat('*', 100000).'{% endraw %}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $lexer->tokenize($template);
 
         // should not throw an exception
@@ -122,7 +122,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{{ '.str_repeat('x', 100000).' }}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $lexer->tokenize($template);
 
         // should not throw an exception
@@ -132,7 +132,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{% '.str_repeat('x', 100000).' %}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $lexer->tokenize($template);
 
         // should not throw an exception
@@ -142,7 +142,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{{ 922337203685477580700 }}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
         $stream->next();
         $node = $stream->next();
@@ -155,7 +155,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
             "{{ 'foo \' bar' }}" => 'foo \' bar',
             '{{ "foo \" bar" }}' => 'foo " bar',
         );
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         foreach ($tests as $template => $expected) {
             $stream = $lexer->tokenize($template);
             $stream->expect(Twig_Token::VAR_START_TYPE);
@@ -167,7 +167,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = 'foo {{ "bar #{ baz + 1 }" }}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
         $stream->expect(Twig_Token::TEXT_TYPE, 'foo ');
         $stream->expect(Twig_Token::VAR_START_TYPE);
@@ -184,7 +184,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{{ "bar \#{baz+1}" }}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
         $stream->expect(Twig_Token::VAR_START_TYPE);
         $stream->expect(Twig_Token::STRING_TYPE, 'bar #{baz+1}');
@@ -195,7 +195,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{{ "bar # baz" }}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
         $stream->expect(Twig_Token::VAR_START_TYPE);
         $stream->expect(Twig_Token::STRING_TYPE, 'bar # baz');
@@ -210,7 +210,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{{ "bar #{x" }}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $lexer->tokenize($template);
     }
 
@@ -218,7 +218,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{{ "bar #{ "foo#{bar}" }" }}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
         $stream->expect(Twig_Token::VAR_START_TYPE);
         $stream->expect(Twig_Token::STRING_TYPE, 'bar ');
@@ -235,7 +235,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = '{% foo "bar #{ "foo#{bar}" }" %}';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
         $stream->expect(Twig_Token::BLOCK_START_TYPE);
         $stream->expect(Twig_Token::NAME_TYPE, 'foo');
@@ -253,7 +253,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
     {
         $template = "{{ 1 and\n0}}";
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $stream = $lexer->tokenize($template);
         $stream->expect(Twig_Token::VAR_START_TYPE);
         $stream->expect(Twig_Token::NUMBER_TYPE, 1);
@@ -275,7 +275,7 @@ bar
 
 ';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $lexer->tokenize($template);
     }
 
@@ -294,7 +294,7 @@ bar
 
 ';
 
-        $lexer = new Twig_Lexer(new Twig_Environment());
+        $lexer = new Twig_Lexer(new Twig_Environment(new Twig_Loader_Array(array())));
         $lexer->tokenize($template);
     }
 }

--- a/test/Twig/Tests/Node/Expression/FilterTest.php
+++ b/test/Twig/Tests/Node/Expression/FilterTest.php
@@ -110,7 +110,7 @@ class Twig_Tests_Node_Expression_FilterTest extends Twig_Test_NodeTestCase
 
     protected function getEnvironment()
     {
-        $env = new Twig_Environment();
+        $env = new Twig_Environment(new Twig_Loader_Array(array()));
         $env->addFilter(new Twig_Filter('anonymous', function () {}));
 
         return $env;

--- a/test/Twig/Tests/Node/Expression/FunctionTest.php
+++ b/test/Twig/Tests/Node/Expression/FunctionTest.php
@@ -23,7 +23,7 @@ class Twig_Tests_Node_Expression_FunctionTest extends Twig_Test_NodeTestCase
 
     public function getTests()
     {
-        $environment = new Twig_Environment();
+        $environment = new Twig_Environment(new Twig_Loader_Array(array()));
         $environment->addFunction(new Twig_Function('foo', 'foo', array()));
         $environment->addFunction(new Twig_Function('bar', 'bar', array('needs_environment' => true)));
         $environment->addFunction(new Twig_Function('foofoo', 'foofoo', array('needs_context' => true)));
@@ -76,7 +76,7 @@ class Twig_Tests_Node_Expression_FunctionTest extends Twig_Test_NodeTestCase
 
     protected function getEnvironment()
     {
-        $env = new Twig_Environment();
+        $env = new Twig_Environment(new Twig_Loader_Array(array()));
         $env->addFunction(new Twig_Function('anonymous', function () {}));
 
         return $env;

--- a/test/Twig/Tests/Node/Expression/NameTest.php
+++ b/test/Twig/Tests/Node/Expression/NameTest.php
@@ -24,8 +24,8 @@ class Twig_Tests_Node_Expression_NameTest extends Twig_Test_NodeTestCase
         $self = new Twig_Node_Expression_Name('_self', 1);
         $context = new Twig_Node_Expression_Name('_context', 1);
 
-        $env = new Twig_Environment(null, array('strict_variables' => true));
-        $env1 = new Twig_Environment(null, array('strict_variables' => false));
+        $env = new Twig_Environment(new Twig_Loader_Array(array()), array('strict_variables' => true));
+        $env1 = new Twig_Environment(new Twig_Loader_Array(array()), array('strict_variables' => false));
 
         return array(
             array($node, "// line 1\n".'(isset($context["foo"]) || array_key_exists("foo", $context) ? $context["foo"] : $this->notFound("foo", 1))', $env),

--- a/test/Twig/Tests/Node/Expression/TestTest.php
+++ b/test/Twig/Tests/Node/Expression/TestTest.php
@@ -45,7 +45,7 @@ class Twig_Tests_Node_Expression_TestTest extends Twig_Test_NodeTestCase
 
     protected function getEnvironment()
     {
-        $env = new Twig_Environment();
+        $env = new Twig_Environment(new Twig_Loader_Array(array()));
         $env->addTest(new Twig_Test('anonymous', function () {}));
 
         return $env;

--- a/test/Twig/Tests/ParserTest.php
+++ b/test/Twig/Tests/ParserTest.php
@@ -31,7 +31,7 @@ class Twig_Tests_ParserTest extends PHPUnit_Framework_TestCase
             new Twig_Token(Twig_Token::BLOCK_END_TYPE, '', 1),
             new Twig_Token(Twig_Token::EOF_TYPE, '', 1),
         ));
-        $parser = new Twig_Parser(new Twig_Environment());
+        $parser = new Twig_Parser(new Twig_Environment(new Twig_Loader_Array(array())));
         $parser->parse($stream);
     }
 
@@ -102,7 +102,7 @@ class Twig_Tests_ParserTest extends PHPUnit_Framework_TestCase
 
     public function testParseIsReentrant()
     {
-        $twig = new Twig_Environment(null, array(
+        $twig = new Twig_Environment(new Twig_Loader_Array(array()), array(
             'autoescape' => false,
             'optimizations' => 0,
         ));
@@ -128,7 +128,7 @@ class Twig_Tests_ParserTest extends PHPUnit_Framework_TestCase
     // see https://github.com/symfony/symfony/issues/4218
     public function testGetVarName()
     {
-        $twig = new Twig_Environment(null, array(
+        $twig = new Twig_Environment(new Twig_Loader_Array(array()), array(
             'autoescape' => false,
             'optimizations' => 0,
         ));
@@ -145,7 +145,7 @@ EOF
 
     protected function getParser()
     {
-        $parser = new Twig_Parser(new Twig_Environment());
+        $parser = new Twig_Parser(new Twig_Environment(new Twig_Loader_Array(array())));
         $parser->setParent(new Twig_Node());
         $p = new ReflectionProperty($parser, 'stream');
         $p->setAccessible(true);

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -124,8 +124,8 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
      */
     public function testGetAttributeWithTemplateAsObject($useExt)
     {
-        $template = new Twig_TemplateTest(new Twig_Environment(), $useExt);
-        $template1 = new Twig_TemplateTest(new Twig_Environment(), false);
+        $template = new Twig_TemplateTest(new Twig_Environment(new Twig_Loader_Array(array())), $useExt);
+        $template1 = new Twig_TemplateTest(new Twig_Environment(new Twig_Loader_Array(array())), false);
 
         $this->assertInstanceof('Twig_Markup', $template->getAttribute($template1, 'string'));
         $this->assertEquals('some_string', $template->getAttribute($template1, 'string'));
@@ -159,7 +159,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
     public function testGetAttributeOnArrayWithConfusableKey($useExt = false)
     {
         $template = new Twig_TemplateTest(
-            new Twig_Environment(),
+            new Twig_Environment(new Twig_Loader_Array(array())),
             $useExt
         );
 
@@ -198,7 +198,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
      */
     public function testGetAttribute($defined, $value, $object, $item, $arguments, $type, $useExt = false)
     {
-        $template = new Twig_TemplateTest(new Twig_Environment(), $useExt);
+        $template = new Twig_TemplateTest(new Twig_Environment(new Twig_Loader_Array(array())), $useExt);
 
         $this->assertEquals($value, $template->getAttribute($object, $item, $arguments, $type));
     }
@@ -208,7 +208,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
      */
     public function testGetAttributeStrict($defined, $value, $object, $item, $arguments, $type, $useExt = false, $exceptionMessage = null)
     {
-        $template = new Twig_TemplateTest(new Twig_Environment(null, array('strict_variables' => true)), $useExt);
+        $template = new Twig_TemplateTest(new Twig_Environment(new Twig_Loader_Array(array()), array('strict_variables' => true)), $useExt);
 
         if ($defined) {
             $this->assertEquals($value, $template->getAttribute($object, $item, $arguments, $type));
@@ -230,7 +230,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
      */
     public function testGetAttributeDefined($defined, $value, $object, $item, $arguments, $type, $useExt = false)
     {
-        $template = new Twig_TemplateTest(new Twig_Environment(), $useExt);
+        $template = new Twig_TemplateTest(new Twig_Environment(new Twig_Loader_Array(array())), $useExt);
 
         $this->assertEquals($defined, $template->getAttribute($object, $item, $arguments, $type, true));
     }
@@ -240,7 +240,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
      */
     public function testGetAttributeDefinedStrict($defined, $value, $object, $item, $arguments, $type, $useExt = false)
     {
-        $template = new Twig_TemplateTest(new Twig_Environment(null, array('strict_variables' => true)), $useExt);
+        $template = new Twig_TemplateTest(new Twig_Environment(new Twig_Loader_Array(array()), array('strict_variables' => true)), $useExt);
 
         $this->assertEquals($defined, $template->getAttribute($object, $item, $arguments, $type, true));
     }
@@ -250,7 +250,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
      */
     public function testGetAttributeCallExceptions($useExt = false)
     {
-        $template = new Twig_TemplateTest(new Twig_Environment(), $useExt);
+        $template = new Twig_TemplateTest(new Twig_Environment(new Twig_Loader_Array(array())), $useExt);
 
         $object = new Twig_TemplateMagicMethodExceptionObject();
 

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -80,7 +80,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
      */
     public function testGetAttributeWithSandbox($object, $item, $allowed, $useExt)
     {
-        $twig = new Twig_Environment();
+        $twig = new Twig_Environment(new Twig_Loader_Array(array()));
         $policy = new Twig_Sandbox_SecurityPolicy(array(), array(), array(/*method*/), array(/*prop*/), array());
         $twig->addExtension(new Twig_Extension_Sandbox($policy, !$allowed));
         $template = new Twig_TemplateTest($twig, $useExt);

--- a/test/Twig/Tests/escapingTest.php
+++ b/test/Twig/Tests/escapingTest.php
@@ -146,7 +146,7 @@ class Twig_Test_EscapingTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->env = new Twig_Environment();
+        $this->env = new Twig_Environment(new Twig_Loader_Array(array()));
     }
 
     public function testHtmlEscapingConvertsSpecialChars()


### PR DESCRIPTION
Following #1693 and the fact that "hasLoader" contains semantical error that loader is optional, this PR removes optionality of loader from Environment.