### PR TITLE
Twig_Template::getContext() removal

### DIFF
--- a/lib/Twig/Node/Expression/Name.php
+++ b/lib/Twig/Node/Expression/Name.php
@@ -43,18 +43,31 @@ class Twig_Node_Expression_Name extends Twig_Node_Expression
                 ->raw(']')
             ;
         } else {
-            $compiler
-                ->raw('(isset($context[')
-                ->string($name)
-                ->raw(']) ? $context[')
-                ->string($name)
-                ->raw('] : ')
-            ;
-
             if ($this->getAttribute('ignore_strict_check') || !$compiler->getEnvironment()->isStrictVariables()) {
-                $compiler->raw('null)');
+                $compiler
+                    ->raw('(isset($context[')
+                    ->string($name)
+                    ->raw(']) ? $context[')
+                    ->string($name)
+                    ->raw('] : null)')
+                ;
             } else {
-                $compiler->raw('$this->getContext($context, ')->string($name)->raw('))');
+                // When Twig will require PHP 7.0, the Template::notFound() method
+                // will be removed and the code inlined like this:
+                // (function () { throw new Exception(...); })();
+                $compiler
+                    ->raw('(isset($context[')
+                    ->string($name)
+                    ->raw(']) || array_key_exists(')
+                    ->string($name)
+                    ->raw(', $context) ? $context[')
+                    ->string($name)
+                    ->raw('] : $this->notFound(')
+                    ->string($name)
+                    ->raw(', ')
+                    ->repr($this->lineno)
+                    ->raw('))')
+                ;
             }
         }
     }

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -347,35 +347,18 @@ abstract class Twig_Template
     abstract protected function doDisplay(array $context, array $blocks = array());
 
     /**
-     * Returns a variable from the context.
+     * Throws an exception for an unknown variable.
      *
      * This method is for internal use only and should never be called
      * directly.
      *
-     * This method should not be overridden in a sub-class as this is an
-     * implementation detail that has been introduced to optimize variable
-     * access for versions of PHP before 5.4. This is not a way to override
-     * the way to get a variable value.
+     * This is an implementation detail due to a PHP limitation before version 7.0.
      *
-     * @param array  $context           The context
-     * @param string $item              The variable to return from the context
-     * @param bool   $ignoreStrictCheck Whether to ignore the strict variable check or not
-     *
-     * @return mixed The content of the context variable
-     *
-     * @throws Twig_Error_Runtime if the variable does not exist and Twig is running in strict mode
+     * @internal
      */
-    final protected function getContext($context, $item, $ignoreStrictCheck = false)
+    final protected function notFound($name, $line)
     {
-        if (!array_key_exists($item, $context)) {
-            if ($ignoreStrictCheck || !$this->env->isStrictVariables()) {
-                return;
-            }
-
-            throw new Twig_Error_Runtime(sprintf('Variable "%s" does not exist', $item), -1, $this->getTemplateName());
-        }
-
-        return $context[$item];
+        throw new Twig_Error_Runtime(sprintf('Variable "%s" does not exist', $name), $line, $this->getTemplateName());
     }
 
     /**

--- a/test/Twig/Tests/Node/Expression/NameTest.php
+++ b/test/Twig/Tests/Node/Expression/NameTest.php
@@ -28,7 +28,7 @@ class Twig_Tests_Node_Expression_NameTest extends Twig_Test_NodeTestCase
         $env1 = new Twig_Environment(null, array('strict_variables' => false));
 
         return array(
-            array($node, "// line 1\n".'(isset($context["foo"]) ? $context["foo"] : $this->getContext($context, "foo"))', $env),
+            array($node, "// line 1\n".'(isset($context["foo"]) || array_key_exists("foo", $context) ? $context["foo"] : $this->notFound("foo", 1))', $env),
             array($node, $this->getVariableGetter('foo', 1), $env1),
             array($self, "// line 1\n\$this"),
             array($context, "// line 1\n\$context"),


### PR DESCRIPTION
`Twig_Template::getContext()` is an implementation detail as it is only used on some PHP versions, for some cases. But even with the big warning in the phpdoc, people want to use it, which is a really bad idea. Removing it in 1.x would be kind of a "BC break", so I propose to remove it in 2.0.

