### PR TITLE
moved protected to private

### DIFF
--- a/lib/Twig/Compiler.php
+++ b/lib/Twig/Compiler.php
@@ -17,14 +17,14 @@
  */
 class Twig_Compiler
 {
-    protected $lastLine;
-    protected $source;
-    protected $indentation;
-    protected $env;
-    protected $debugInfo;
-    protected $sourceOffset;
-    protected $sourceLine;
-    protected $filename;
+    private $lastLine;
+    private $source;
+    private $indentation;
+    private $env;
+    private $debugInfo;
+    private $sourceOffset;
+    private $sourceLine;
+    private $filename;
 
     /**
      * Constructor.

--- a/lib/Twig/Error.php
+++ b/lib/Twig/Error.php
@@ -33,9 +33,9 @@
  */
 class Twig_Error extends Exception
 {
-    protected $lineno;
-    protected $filename;
-    protected $rawMessage;
+    private $lineno;
+    private $filename;
+    private $rawMessage;
 
     /**
      * Constructor.
@@ -130,7 +130,7 @@ class Twig_Error extends Exception
         $this->updateRepr();
     }
 
-    protected function updateRepr()
+    private function updateRepr()
     {
         $this->message = $this->rawMessage;
 
@@ -158,7 +158,7 @@ class Twig_Error extends Exception
         }
     }
 
-    protected function guessTemplateInfo()
+    private function guessTemplateInfo()
     {
         $template = null;
         $templateClass = null;

--- a/lib/Twig/ExpressionParser.php
+++ b/lib/Twig/ExpressionParser.php
@@ -25,9 +25,9 @@ class Twig_ExpressionParser
     const OPERATOR_LEFT = 1;
     const OPERATOR_RIGHT = 2;
 
-    protected $parser;
-    protected $unaryOperators;
-    protected $binaryOperators;
+    private $parser;
+    private $unaryOperators;
+    private $binaryOperators;
 
     public function __construct(Twig_Parser $parser, array $unaryOperators, array $binaryOperators)
     {
@@ -592,7 +592,7 @@ class Twig_ExpressionParser
     }
 
     // checks that the node only contains "constant" elements
-    protected function checkConstantExpression(Twig_Node $node)
+    private function checkConstantExpression(Twig_Node $node)
     {
         if (!($node instanceof Twig_Node_Expression_Constant || $node instanceof Twig_Node_Expression_Array
             || $node instanceof Twig_Node_Expression_Unary_Neg || $node instanceof Twig_Node_Expression_Unary_Pos

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -15,10 +15,10 @@ if (!defined('ENT_SUBSTITUTE')) {
  */
 class Twig_Extension_Core extends Twig_Extension
 {
-    protected $dateFormats = array('F j, Y H:i', '%d days');
-    protected $numberFormat = array(0, '.', ',');
-    protected $timezone = null;
-    protected $escapers = array();
+    private $dateFormats = array('F j, Y H:i', '%d days');
+    private $numberFormat = array(0, '.', ',');
+    private $timezone = null;
+    private $escapers = array();
 
     /**
      * Defines a new escaper to be used via the escape filter.
@@ -307,7 +307,7 @@ class Twig_Extension_Core extends Twig_Extension
         return new $class($node, $name, $arguments, $parser->getCurrentToken()->getLine());
     }
 
-    protected function getTestName(Twig_Parser $parser, $line)
+    private function getTestName(Twig_Parser $parser, $line)
     {
         $stream = $parser->getStream();
         $name = $stream->expect(Twig_Token::NAME_TYPE)->getValue();

--- a/lib/Twig/Extension/Escaper.php
+++ b/lib/Twig/Extension/Escaper.php
@@ -10,7 +10,7 @@
  */
 class Twig_Extension_Escaper extends Twig_Extension
 {
-    protected $defaultStrategy;
+    private $defaultStrategy;
 
     public function __construct($defaultStrategy = 'html')
     {

--- a/lib/Twig/Extension/Optimizer.php
+++ b/lib/Twig/Extension/Optimizer.php
@@ -10,7 +10,7 @@
  */
 class Twig_Extension_Optimizer extends Twig_Extension
 {
-    protected $optimizers;
+    private $optimizers;
 
     public function __construct($optimizers = -1)
     {

--- a/lib/Twig/Extension/Sandbox.php
+++ b/lib/Twig/Extension/Sandbox.php
@@ -10,9 +10,9 @@
  */
 class Twig_Extension_Sandbox extends Twig_Extension
 {
-    protected $sandboxedGlobally;
-    protected $sandboxed;
-    protected $policy;
+    private $sandboxedGlobally;
+    private $sandboxed;
+    private $policy;
 
     public function __construct(Twig_Sandbox_SecurityPolicyInterface $policy, $sandboxed = false)
     {

--- a/lib/Twig/Extension/Staging.php
+++ b/lib/Twig/Extension/Staging.php
@@ -18,12 +18,12 @@
  */
 class Twig_Extension_Staging extends Twig_Extension
 {
-    protected $functions = array();
-    protected $filters = array();
-    protected $visitors = array();
-    protected $tokenParsers = array();
-    protected $globals = array();
-    protected $tests = array();
+    private $functions = array();
+    private $filters = array();
+    private $visitors = array();
+    private $tokenParsers = array();
+    private $globals = array();
+    private $tests = array();
 
     public function addFunction(Twig_Function $function)
     {

--- a/lib/Twig/Filter.php
+++ b/lib/Twig/Filter.php
@@ -16,10 +16,10 @@
  */
 class Twig_Filter
 {
-    protected $name;
-    protected $callable;
-    protected $options;
-    protected $arguments = array();
+    private $name;
+    private $callable;
+    private $options;
+    private $arguments = array();
 
     public function __construct($name, $callable, array $options = array())
     {

--- a/lib/Twig/Function.php
+++ b/lib/Twig/Function.php
@@ -18,10 +18,10 @@
  */
 class Twig_Function
 {
-    protected $name;
-    protected $callable;
-    protected $options;
-    protected $arguments = array();
+    private $name;
+    private $callable;
+    private $options;
+    private $arguments = array();
 
     public function __construct($name, $callable, array $options = array())
     {

--- a/lib/Twig/Loader/Array.php
+++ b/lib/Twig/Loader/Array.php
@@ -23,7 +23,7 @@
  */
 class Twig_Loader_Array implements Twig_LoaderInterface
 {
-    protected $templates = array();
+    private $templates = array();
 
     /**
      * Constructor.

--- a/lib/Twig/Markup.php
+++ b/lib/Twig/Markup.php
@@ -16,8 +16,8 @@
  */
 class Twig_Markup implements Countable
 {
-    protected $content;
-    protected $charset;
+    private $content;
+    private $charset;
 
     public function __construct($content, $charset)
     {

--- a/lib/Twig/Node/CheckSecurity.php
+++ b/lib/Twig/Node/CheckSecurity.php
@@ -14,9 +14,9 @@
  */
 class Twig_Node_CheckSecurity extends Twig_Node
 {
-    protected $usedFilters;
-    protected $usedTags;
-    protected $usedFunctions;
+    private $usedFilters;
+    private $usedTags;
+    private $usedFunctions;
 
     public function __construct(array $usedFilters, array $usedTags, array $usedFunctions)
     {

--- a/lib/Twig/Node/Expression/Array.php
+++ b/lib/Twig/Node/Expression/Array.php
@@ -10,7 +10,7 @@
  */
 class Twig_Node_Expression_Array extends Twig_Node_Expression
 {
-    protected $index;
+    private $index;
 
     public function __construct(array $elements, $lineno)
     {

--- a/lib/Twig/Node/Expression/Name.php
+++ b/lib/Twig/Node/Expression/Name.php
@@ -11,7 +11,7 @@
  */
 class Twig_Node_Expression_Name extends Twig_Node_Expression
 {
-    protected $specialVars = array(
+    private $specialVars = array(
         '_self' => '$this',
         '_context' => '$context',
         '_charset' => '$this->env->getCharset()',

--- a/lib/Twig/Node/Expression/Test/Defined.php
+++ b/lib/Twig/Node/Expression/Test/Defined.php
@@ -38,7 +38,7 @@ class Twig_Node_Expression_Test_Defined extends Twig_Node_Expression_Test
         }
     }
 
-    protected function changeIgnoreStrictCheck(Twig_Node_Expression_GetAttr $node)
+    private function changeIgnoreStrictCheck(Twig_Node_Expression_GetAttr $node)
     {
         $node->setAttribute('ignore_strict_check', true);
 

--- a/lib/Twig/Node/For.php
+++ b/lib/Twig/Node/For.php
@@ -17,7 +17,7 @@
  */
 class Twig_Node_For extends Twig_Node
 {
-    protected $loop;
+    private $loop;
 
     public function __construct(Twig_Node_Expression_AssignName $keyTarget, Twig_Node_Expression_AssignName $valueTarget, Twig_Node_Expression $seq, Twig_Node_Expression $ifexpr = null, Twig_Node $body, Twig_Node $else = null, $lineno, $tag = null)
     {

--- a/lib/Twig/Node/SandboxedPrint.php
+++ b/lib/Twig/Node/SandboxedPrint.php
@@ -50,7 +50,7 @@ class Twig_Node_SandboxedPrint extends Twig_Node_Print
      *
      * @return Twig_Node
      */
-    protected function removeNodeFilter($node)
+    private function removeNodeFilter($node)
     {
         if ($node instanceof Twig_Node_Expression_Filter) {
             return $this->removeNodeFilter($node->getNode('node'));

--- a/lib/Twig/NodeTraverser.php
+++ b/lib/Twig/NodeTraverser.php
@@ -18,8 +18,8 @@
  */
 class Twig_NodeTraverser
 {
-    protected $env;
-    protected $visitors;
+    private $env;
+    private $visitors;
 
     /**
      * Constructor.
@@ -69,7 +69,7 @@ class Twig_NodeTraverser
         return $node;
     }
 
-    protected function traverseForVisitor(Twig_NodeVisitorInterface $visitor, Twig_Node $node = null)
+    private function traverseForVisitor(Twig_NodeVisitorInterface $visitor, Twig_Node $node = null)
     {
         if (null === $node) {
             return;

--- a/lib/Twig/NodeVisitor/Escaper.php
+++ b/lib/Twig/NodeVisitor/Escaper.php
@@ -16,12 +16,12 @@
  */
 class Twig_NodeVisitor_Escaper implements Twig_NodeVisitorInterface
 {
-    protected $statusStack = array();
-    protected $blocks = array();
-    protected $safeAnalysis;
-    protected $traverser;
-    protected $defaultStrategy = false;
-    protected $safeVars = array();
+    private $statusStack = array();
+    private $blocks = array();
+    private $safeAnalysis;
+    private $traverser;
+    private $defaultStrategy = false;
+    private $safeVars = array();
 
     public function __construct()
     {
@@ -82,7 +82,7 @@ class Twig_NodeVisitor_Escaper implements Twig_NodeVisitorInterface
         return $node;
     }
 
-    protected function escapePrintNode(Twig_Node_Print $node, Twig_Environment $env, $type)
+    private function escapePrintNode(Twig_Node_Print $node, Twig_Environment $env, $type)
     {
         if (false === $type) {
             return $node;
@@ -102,7 +102,7 @@ class Twig_NodeVisitor_Escaper implements Twig_NodeVisitorInterface
         );
     }
 
-    protected function preEscapeFilterNode(Twig_Node_Expression_Filter $filter, Twig_Environment $env)
+    private function preEscapeFilterNode(Twig_Node_Expression_Filter $filter, Twig_Environment $env)
     {
         $name = $filter->getNode('filter')->getAttribute('value');
 
@@ -121,7 +121,7 @@ class Twig_NodeVisitor_Escaper implements Twig_NodeVisitorInterface
         return $filter;
     }
 
-    protected function isSafeFor($type, Twig_Node $expression, $env)
+    private function isSafeFor($type, Twig_Node $expression, $env)
     {
         $safe = $this->safeAnalysis->getSafe($expression);
 
@@ -139,7 +139,7 @@ class Twig_NodeVisitor_Escaper implements Twig_NodeVisitorInterface
         return in_array($type, $safe) || in_array('all', $safe);
     }
 
-    protected function needEscaping(Twig_Environment $env)
+    private function needEscaping(Twig_Environment $env)
     {
         if (count($this->statusStack)) {
             return $this->statusStack[count($this->statusStack) - 1];
@@ -148,7 +148,7 @@ class Twig_NodeVisitor_Escaper implements Twig_NodeVisitorInterface
         return $this->defaultStrategy ? $this->defaultStrategy : false;
     }
 
-    protected function getEscaperFilter($type, Twig_Node $node)
+    private function getEscaperFilter($type, Twig_Node $node)
     {
         $line = $node->getLine();
         $name = new Twig_Node_Expression_Constant('escape', $line);

--- a/lib/Twig/NodeVisitor/Optimizer.php
+++ b/lib/Twig/NodeVisitor/Optimizer.php
@@ -28,10 +28,10 @@ class Twig_NodeVisitor_Optimizer implements Twig_NodeVisitorInterface
     // obsolete, does not do anything
     const OPTIMIZE_VAR_ACCESS = 8;
 
-    protected $loops = array();
-    protected $loopsTargets = array();
-    protected $optimizers;
-    protected $prependedNodes = array();
+    private $loops = array();
+    private $loopsTargets = array();
+    private $optimizers;
+    private $prependedNodes = array();
 
     /**
      * Constructor.
@@ -89,7 +89,7 @@ class Twig_NodeVisitor_Optimizer implements Twig_NodeVisitorInterface
      *
      * @return Twig_NodeInterface
      */
-    protected function optimizePrintNode(Twig_Node $node, Twig_Environment $env)
+    private function optimizePrintNode(Twig_Node $node, Twig_Environment $env)
     {
         if (!$node instanceof Twig_Node_Print) {
             return $node;
@@ -115,7 +115,7 @@ class Twig_NodeVisitor_Optimizer implements Twig_NodeVisitorInterface
      *
      * @return Twig_Node
      */
-    protected function optimizeRawFilter(Twig_Node $node, Twig_Environment $env)
+    private function optimizeRawFilter(Twig_Node $node, Twig_Environment $env)
     {
         if ($node instanceof Twig_Node_Expression_Filter && 'raw' == $node->getNode('filter')->getAttribute('value')) {
             return $node->getNode('node');
@@ -130,7 +130,7 @@ class Twig_NodeVisitor_Optimizer implements Twig_NodeVisitorInterface
      * @param Twig_Node        $node A Node
      * @param Twig_Environment $env  The current Twig environment
      */
-    protected function enterOptimizeFor(Twig_Node $node, Twig_Environment $env)
+    private function enterOptimizeFor(Twig_Node $node, Twig_Environment $env)
     {
         if ($node instanceof Twig_Node_For) {
             // disable the loop variable by default
@@ -197,7 +197,7 @@ class Twig_NodeVisitor_Optimizer implements Twig_NodeVisitorInterface
      * @param Twig_Node        $node A Node
      * @param Twig_Environment $env  The current Twig environment
      */
-    protected function leaveOptimizeFor(Twig_Node $node, Twig_Environment $env)
+    private function leaveOptimizeFor(Twig_Node $node, Twig_Environment $env)
     {
         if ($node instanceof Twig_Node_For) {
             array_shift($this->loops);
@@ -206,12 +206,12 @@ class Twig_NodeVisitor_Optimizer implements Twig_NodeVisitorInterface
         }
     }
 
-    protected function addLoopToCurrent()
+    private function addLoopToCurrent()
     {
         $this->loops[0]->setAttribute('with_loop', true);
     }
 
-    protected function addLoopToAll()
+    private function addLoopToAll()
     {
         foreach ($this->loops as $loop) {
             $loop->setAttribute('with_loop', true);

--- a/lib/Twig/NodeVisitor/SafeAnalysis.php
+++ b/lib/Twig/NodeVisitor/SafeAnalysis.php
@@ -2,8 +2,8 @@
 
 class Twig_NodeVisitor_SafeAnalysis implements Twig_NodeVisitorInterface
 {
-    protected $data = array();
-    protected $safeVars = array();
+    private $data = array();
+    private $safeVars = array();
 
     public function setSafeVars($safeVars)
     {
@@ -30,7 +30,7 @@ class Twig_NodeVisitor_SafeAnalysis implements Twig_NodeVisitorInterface
         }
     }
 
-    protected function setSafe(Twig_Node $node, array $safe)
+    private function setSafe(Twig_Node $node, array $safe)
     {
         $hash = spl_object_hash($node);
         if (isset($this->data[$hash])) {
@@ -112,7 +112,7 @@ class Twig_NodeVisitor_SafeAnalysis implements Twig_NodeVisitorInterface
         return $node;
     }
 
-    protected function intersectSafe(array $a = null, array $b = null)
+    private function intersectSafe(array $a = null, array $b = null)
     {
         if (null === $a || null === $b) {
             return array();

--- a/lib/Twig/NodeVisitor/Sandbox.php
+++ b/lib/Twig/NodeVisitor/Sandbox.php
@@ -16,10 +16,10 @@
  */
 class Twig_NodeVisitor_Sandbox implements Twig_NodeVisitorInterface
 {
-    protected $inAModule = false;
-    protected $tags;
-    protected $filters;
-    protected $functions;
+    private $inAModule = false;
+    private $tags;
+    private $filters;
+    private $functions;
 
     /**
      * Called before child nodes are visited.

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -17,20 +17,20 @@
  */
 class Twig_Parser
 {
-    protected $stack = array();
-    protected $stream;
-    protected $parent;
-    protected $handlers;
-    protected $visitors;
-    protected $expressionParser;
-    protected $blocks;
-    protected $blockStack;
-    protected $macros;
-    protected $env;
-    protected $reservedMacroNames;
-    protected $importedSymbols;
-    protected $traits;
-    protected $embeddedTemplates = array();
+    private $stack = array();
+    private $stream;
+    private $parent;
+    private $handlers;
+    private $visitors;
+    private $expressionParser;
+    private $blocks;
+    private $blockStack;
+    private $macros;
+    private $env;
+    private $reservedMacroNames;
+    private $importedSymbols;
+    private $traits;
+    private $embeddedTemplates = array();
 
     /**
      * Constructor.
@@ -359,7 +359,7 @@ class Twig_Parser
         return $this->stream->getCurrent();
     }
 
-    protected function filterBodyNodes(Twig_Node $node)
+    private function filterBodyNodes(Twig_Node $node)
     {
         // check that the body does not contain non-empty output nodes
         if (

--- a/lib/Twig/Sandbox/SecurityPolicy.php
+++ b/lib/Twig/Sandbox/SecurityPolicy.php
@@ -16,11 +16,11 @@
  */
 class Twig_Sandbox_SecurityPolicy implements Twig_Sandbox_SecurityPolicyInterface
 {
-    protected $allowedTags;
-    protected $allowedFilters;
-    protected $allowedMethods;
-    protected $allowedProperties;
-    protected $allowedFunctions;
+    private $allowedTags;
+    private $allowedFilters;
+    private $allowedMethods;
+    private $allowedProperties;
+    private $allowedFunctions;
 
     public function __construct(array $allowedTags = array(), array $allowedFilters = array(), array $allowedMethods = array(), array $allowedProperties = array(), array $allowedFunctions = array())
     {

--- a/lib/Twig/Test.php
+++ b/lib/Twig/Test.php
@@ -16,9 +16,9 @@
  */
 class Twig_Test
 {
-    protected $name;
-    protected $callable;
-    protected $options;
+    private $name;
+    private $callable;
+    private $options;
 
     public function __construct($name, $callable, array $options = array())
     {

--- a/lib/Twig/Token.php
+++ b/lib/Twig/Token.php
@@ -17,9 +17,9 @@
  */
 class Twig_Token
 {
-    protected $value;
-    protected $type;
-    protected $lineno;
+    private $value;
+    private $type;
+    private $lineno;
 
     const EOF_TYPE = -1;
     const TEXT_TYPE = 0;

--- a/lib/Twig/TokenParser/For.php
+++ b/lib/Twig/TokenParser/For.php
@@ -83,7 +83,7 @@ class Twig_TokenParser_For extends Twig_TokenParser
     }
 
     // the loop variable cannot be used in the condition
-    protected function checkLoopUsageCondition(Twig_TokenStream $stream, Twig_Node $node)
+    private function checkLoopUsageCondition(Twig_TokenStream $stream, Twig_Node $node)
     {
         if ($node instanceof Twig_Node_Expression_GetAttr && $node->getNode('node') instanceof Twig_Node_Expression_Name && 'loop' == $node->getNode('node')->getAttribute('name')) {
             throw new Twig_Error_Syntax('The "loop" variable cannot be used in a looping condition', $node->getLine(), $stream->getFilename());
@@ -100,7 +100,7 @@ class Twig_TokenParser_For extends Twig_TokenParser
 
     // check usage of non-defined loop-items
     // it does not catch all problems (for instance when a for is included into another or when the variable is used in an include)
-    protected function checkLoopUsageBody(Twig_TokenStream $stream, Twig_Node $node)
+    private function checkLoopUsageBody(Twig_TokenStream $stream, Twig_Node $node)
     {
         if ($node instanceof Twig_Node_Expression_GetAttr && $node->getNode('node') instanceof Twig_Node_Expression_Name && 'loop' == $node->getNode('node')->getAttribute('name')) {
             $attribute = $node->getNode('attribute');

--- a/lib/Twig/TokenStream.php
+++ b/lib/Twig/TokenStream.php
@@ -17,9 +17,9 @@
  */
 class Twig_TokenStream
 {
-    protected $tokens;
-    protected $current;
-    protected $filename;
+    private $tokens;
+    private $current;
+    private $filename;
 
     /**
      * Constructor.


### PR DESCRIPTION
Moved some protected properties/methods from protected to private.

I've changed protected properties/methods mostly on internal classes but not where it could potentially break BC too badly with existing code.

Classes where we could change protected to private but where it could be a problem for existing code:

* Twig_ExpressionParser
* Twig_Environment
* Twig_Lexer
* Twig_Node
* Twig_Parser (done in second commit)
* Twig_Template

closes #1645
