### PR TITLE
Missing quotes surrounding "foo"

### DIFF
--- a/doc/filters/replace.rst
+++ b/doc/filters/replace.rst
@@ -6,7 +6,7 @@ The ``replace`` filter formats a given string by replacing the placeholders
 
 .. code-block:: jinja
 
-    {{ "I like %this% and %that%."|replace({'%this%': foo, '%that%': "bar"}) }}
+    {{ "I like %this% and %that%."|replace({'%this%': "foo", '%that%': "bar"}) }}
 
     {# outputs I like foo and bar
        if the foo parameter equals to the foo string. #}


### PR DESCRIPTION
If no quotes, this sample code will only print "I like and bar"