### PR TITLE
Repair may occur under the windows "\ \" file separator

### DIFF
--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -89,6 +89,7 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
         // invalidate the cache
         $this->cache = array();
 
+        $path = str_replace("\\", "/", $path);
         if (!is_dir($path)) {
             throw new Twig_Error_Loader(sprintf('The "%s" directory does not exist.', $path));
         }


### PR DESCRIPTION
#1743  

Encoding has become the standard.