### PR TITLE
deprecated _self

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.20.0 (2015-XX-XX)
 
+ * deprecated the _self variable for usage outside of the from and import tags
  * added Twig_BaseNodeVisitor to ease the compatibility of node visitors 
    between 1.x and 2.x
 

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -121,6 +121,10 @@ Globals
   or the extensions have been initialized is not possible anymore (but
   changing the value of an already registered global is possible).
 
+* As of Twig 1.x, the ``_self`` global variable is deprecated except for usage
+  in the ``from`` and the ``import`` tags. In Twig 2.0, ``_self`` is not
+  exposed anymore but still usable in the ``from`` and the ``import`` tags.
+
 Miscellaneous
 -------------
 

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -124,7 +124,7 @@ Global Variables
 
 The following variables are always available in templates:
 
-* ``_self``: references the current template;
+* ``_self``: references the current template (deprecated since Twig 1.20);
 * ``_context``: references the current context;
 * ``_charset``: references the current charset.
 

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -60,7 +60,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
             array('{{ array.a }}', 'Key "a" for array with keys "foo" does not exist in "%s" at line 1', false),
             array('{{ attribute(array, -10) }}', 'Key "-10" for array with keys "foo" does not exist in "%s" at line 1', false),
             array('{{ array_access.a }}', 'Method "a" for object "Twig_TemplateArrayAccessObject" does not exist in "%s" at line 1', false),
-            array('{% macro foo(obj) %}{{ obj.missing_method() }}{% endmacro %}{{ _self.foo(array_access) }}', 'Method "missing_method" for object "Twig_TemplateArrayAccessObject" does not exist in "%s" at line 1', false),
+            array('{% from _self import foo %}{% macro foo(obj) %}{{ obj.missing_method() }}{% endmacro %}{{ foo(array_access) }}', 'Method "missing_method" for object "Twig_TemplateArrayAccessObject" does not exist in "%s" at line 1', false),
             array('{{ magic_exception.test }}', 'An exception has been thrown during the rendering of a template ("Hey! Don\'t try to isset me!") in "%s" at line 1.', false),
             array('{{ object["a"] }}', 'Impossible to access a key "a" on an object of class "stdClass" that does not implement ArrayAccess interface in "%s" at line 1', false),
         );


### PR DESCRIPTION
It never makes sense to use the `_self` variable in a template except for the special `from` and `import` usage. So, I propose to deprecate it in 2.x and remove the unexcepted possible usages in 3.0.
