### PR TITLE
replaced _self by current for macro imports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.20.0 (2015-XX-XX)
 
+ * added support for "from current import" and "import current as" (current replaces _self)
  * deprecated the _self variable for usage outside of the from and import tags
  * added Twig_BaseNodeVisitor to ease the compatibility of node visitors 
    between 1.x and 2.x

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -123,7 +123,8 @@ Globals
 
 * As of Twig 1.x, the ``_self`` global variable is deprecated except for usage
   in the ``from`` and the ``import`` tags. In Twig 2.0, ``_self`` is not
-  exposed anymore but still usable in the ``from`` and the ``import`` tags.
+  exposed anymore. When importing macros from the current template, use ``from
+  current import`` or ``import current as``.
 
 Miscellaneous
 -------------

--- a/doc/tags/import.rst
+++ b/doc/tags/import.rst
@@ -51,7 +51,7 @@ namespace:
 
 .. tip::
 
-    To import macros from the current file, use the special ``_self`` variable
-    for the source.
+    To import macros from the current file, use the special ``current``
+    variable for the source (or ``_self`` for Twig before 1.20).
 
 .. seealso:: :doc:`macro<../tags/macro>`, :doc:`from<../tags/from>`

--- a/doc/tags/macro.rst
+++ b/doc/tags/macro.rst
@@ -50,12 +50,12 @@ The macro can then be called at will:
     <p>{{ forms.input('username') }}</p>
     <p>{{ forms.input('password', null, 'password') }}</p>
 
-If macros are defined and used in the same template, you can use the
-special ``_self`` variable to import them:
+If macros are defined and used in the same template, you can use the special
+``current`` variable to import them (or ``_self`` for Twig before 1.20):
 
 .. code-block:: jinja
 
-    {% import _self as forms %}
+    {% import current as forms %}
 
     <p>{{ forms.input('username') }}</p>
 
@@ -76,7 +76,7 @@ import it locally:
     {% endmacro %}
 
     {% macro wrapped_input(name, value, type, size) %}
-        {% import _self as forms %}
+        {% import current as forms %}
 
         <div class="field">
             {{ forms.input(name, value, type, size) }}

--- a/lib/Twig/Node/Import.php
+++ b/lib/Twig/Node/Import.php
@@ -35,7 +35,7 @@ class Twig_Node_Import extends Twig_Node
             ->raw(' = ')
         ;
 
-        if ($this->getNode('expr') instanceof Twig_Node_Expression_Name && '_self' === $this->getNode('expr')->getAttribute('name')) {
+        if ($this->getNode('expr') instanceof Twig_Node_Expression_Name && ('_self' === $this->getNode('expr')->getAttribute('name') || 'current' === $this->getNode('expr')->getAttribute('name'))) {
             $compiler->raw('$this');
         } else {
             $compiler

--- a/test/Twig/Tests/ExpressionParserTest.php
+++ b/test/Twig/Tests/ExpressionParserTest.php
@@ -234,7 +234,7 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
         $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false));
         $parser = new Twig_Parser($env);
 
-        $parser->parse($env->tokenize('{% from _self import foo %}{% macro foo() %}{% endmacro %}{{ foo(name="Foo") }}', 'index'));
+        $parser->parse($env->tokenize('{% from current import foo %}{% macro foo() %}{% endmacro %}{{ foo(name="Foo") }}', 'index'));
     }
 
     /**

--- a/test/Twig/Tests/Extension/SandboxTest.php
+++ b/test/Twig/Tests/Extension/SandboxTest.php
@@ -164,7 +164,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
     public function testMacrosInASandbox()
     {
         $twig = $this->getEnvironment(true, array('autoescape' => true), array('index' => <<<EOF
-{%- import _self as macros %}
+{%- import current as macros %}
 
 {%- macro test(text) %}<p>{{ text }}</p>{% endmacro %}
 

--- a/test/Twig/Tests/Fixtures/expressions/postfix.test
+++ b/test/Twig/Tests/Fixtures/expressions/postfix.test
@@ -1,7 +1,7 @@
 --TEST--
 Twig parses postfix expressions
 --TEMPLATE--
-{% import _self as macros %}
+{% import current as macros %}
 
 {% macro foo() %}foo{% endmacro %}
 

--- a/test/Twig/Tests/Fixtures/expressions/unary_macro_arguments.test
+++ b/test/Twig/Tests/Fixtures/expressions/unary_macro_arguments.test
@@ -1,7 +1,7 @@
 --TEST--
 Twig manages negative numbers as default parameters
 --TEMPLATE--
-{% import _self as macros %}
+{% import current as macros %}
 {{ macros.negative_number1() }}
 {{ macros.negative_number2() }}
 {{ macros.negative_number3() }}

--- a/test/Twig/Tests/Fixtures/macros/default_values.test
+++ b/test/Twig/Tests/Fixtures/macros/default_values.test
@@ -1,7 +1,7 @@
 --TEST--
 macro
 --TEMPLATE--
-{% from _self import test %}
+{% from current import test %}
 
 {% macro test(a, b = 'bar') -%}
 {{ a }}{{ b }}

--- a/test/Twig/Tests/Fixtures/macros/nested_calls.test
+++ b/test/Twig/Tests/Fixtures/macros/nested_calls.test
@@ -1,7 +1,7 @@
 --TEST--
 macro
 --TEMPLATE--
-{% import _self as macros %}
+{% import current as macros %}
 
 {% macro foo(data) %}
     {{ data }}

--- a/test/Twig/Tests/Fixtures/macros/reserved_variables.test
+++ b/test/Twig/Tests/Fixtures/macros/reserved_variables.test
@@ -1,7 +1,7 @@
 --TEST--
 macro
 --TEMPLATE--
-{% from _self import test %}
+{% from current import test %}
 
 {% macro test(this) -%}
     {{ this }}

--- a/test/Twig/Tests/Fixtures/macros/simple.test
+++ b/test/Twig/Tests/Fixtures/macros/simple.test
@@ -1,8 +1,8 @@
 --TEST--
 macro
 --TEMPLATE--
-{% import _self as test %}
-{% from _self import test %}
+{% import current as test %}
+{% from current import test %}
 
 {% macro test(a, b) -%}
     {{ a|default('a') }}<br />

--- a/test/Twig/Tests/Fixtures/macros/varargs.test
+++ b/test/Twig/Tests/Fixtures/macros/varargs.test
@@ -1,7 +1,7 @@
 --TEST--
 macro with arbitrary arguments
 --TEMPLATE--
-{% from _self import test1, test2 %}
+{% from current import test1, test2 %}
 
 {% macro test1(var) %}
     {{- var }}: {{ varargs|join(", ") }}

--- a/test/Twig/Tests/Fixtures/macros/with_filters.test
+++ b/test/Twig/Tests/Fixtures/macros/with_filters.test
@@ -1,7 +1,7 @@
 --TEST--
 macro with a filter
 --TEMPLATE--
-{% import _self as test %}
+{% import current as test %}
 
 {% macro test() %}
     {% filter escape %}foo<br />{% endfilter %}

--- a/test/Twig/Tests/Fixtures/tags/macro/basic.test
+++ b/test/Twig/Tests/Fixtures/tags/macro/basic.test
@@ -1,7 +1,7 @@
 --TEST--
 "macro" tag
 --TEMPLATE--
-{% import _self as macros %}
+{% import current as macros %}
 
 {{ macros.input('username') }}
 {{ macros.input('password', null, 'password', 1) }}

--- a/test/Twig/Tests/Fixtures/tags/macro/endmacro_name.test
+++ b/test/Twig/Tests/Fixtures/tags/macro/endmacro_name.test
@@ -1,7 +1,7 @@
 --TEST--
 "macro" tag supports name for endmacro
 --TEMPLATE--
-{% import _self as macros %}
+{% import current as macros %}
 
 {{ macros.foo() }}
 {{ macros.bar() }}

--- a/test/Twig/Tests/Fixtures/tags/macro/self_import.test
+++ b/test/Twig/Tests/Fixtures/tags/macro/self_import.test
@@ -1,7 +1,7 @@
 --TEST--
 "macro" tag
 --TEMPLATE--
-{% import _self as forms %}
+{% import current as forms %}
 
 {{ forms.input('username') }}
 {{ forms.input('password', null, 'password', 1) }}

--- a/test/Twig/Tests/Fixtures/tags/macro/special_chars.test
+++ b/test/Twig/Tests/Fixtures/tags/macro/special_chars.test
@@ -1,7 +1,7 @@
 --TEST--
 "§" as a macro name
 --TEMPLATE--
-{% import _self as macros %}
+{% import current as macros %}
 
 {{ macros.§('foo') }}
 

--- a/test/Twig/Tests/Fixtures/tags/macro/super_globals.test
+++ b/test/Twig/Tests/Fixtures/tags/macro/super_globals.test
@@ -1,7 +1,7 @@
 --TEST--
 Super globals as macro arguments
 --TEMPLATE--
-{% import _self as macros %}
+{% import current as macros %}
 
 {{ macros.foo('foo') }}
 

--- a/test/Twig/Tests/ParserTest.php
+++ b/test/Twig/Tests/ParserTest.php
@@ -126,7 +126,7 @@ class Twig_Tests_ParserTest extends PHPUnit_Framework_TestCase
         ));
 
         $twig->parse($twig->tokenize(<<<EOF
-{% from _self import foo %}
+{% from current import foo %}
 
 {% macro foo() %}
     {{ foo }}

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -60,7 +60,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
             array('{{ array.a }}', 'Key "a" for array with keys "foo" does not exist in "%s" at line 1', false),
             array('{{ attribute(array, -10) }}', 'Key "-10" for array with keys "foo" does not exist in "%s" at line 1', false),
             array('{{ array_access.a }}', 'Method "a" for object "Twig_TemplateArrayAccessObject" does not exist in "%s" at line 1', false),
-            array('{% from _self import foo %}{% macro foo(obj) %}{{ obj.missing_method() }}{% endmacro %}{{ foo(array_access) }}', 'Method "missing_method" for object "Twig_TemplateArrayAccessObject" does not exist in "%s" at line 1', false),
+            array('{% from current import foo %}{% macro foo(obj) %}{{ obj.missing_method() }}{% endmacro %}{{ foo(array_access) }}', 'Method "missing_method" for object "Twig_TemplateArrayAccessObject" does not exist in "%s" at line 1', false),
             array('{{ magic_exception.test }}', 'An exception has been thrown during the rendering of a template ("Hey! Don\'t try to isset me!") in "%s" at line 1.', false),
             array('{{ object["a"] }}', 'Impossible to access a key "a" on an object of class "stdClass" that does not implement ArrayAccess interface in "%s" at line 1', false),
         );


### PR DESCRIPTION
A variation of this PR could be to keep `_self` in 2.0 (for BC reasons) and remove it in 3.0.

The reason to rename `_self` to `current` is that the only usage of `_self` is in `from` and `import` tags where it's not really a variable anymore, but just a language construct; and `from current import` or `import current as` seems better as language constructs.

I'm aware of one similar usage in Symfony, with the `form_theme` tag. We can do the same as here, supporting both `current` and `_self`, and remove usage of `_self` whenever we bumped the min version of Twig to 3.0.
