### PR TITLE
Remove broken code

### DIFF
--- a/lib/Twig/Node/Module.php
+++ b/lib/Twig/Node/Module.php
@@ -402,22 +402,7 @@ class Twig_Node_Module extends Twig_Node
                 ->raw(");\n")
             ;
         } else {
-            $compiler
-                ->write(sprintf('%s = ', $var))
-                ->subcompile($node)
-                ->raw(";\n")
-                ->write(sprintf('if (!%s', $var))
-                ->raw(" instanceof Twig_Template) {\n")
-                ->indent()
-                ->write(sprintf('%s = $this->loadTemplate(%s')
-                ->raw(', ')
-                ->repr($compiler->getFilename())
-                ->raw(', ')
-                ->repr($node->getLine())
-                ->raw(");\n", $var, $var))
-                ->outdent()
-                ->write("}\n")
-            ;
+            throw new LogicException('Trait templates can only be constant nodes');
         }
     }
 }


### PR DESCRIPTION
https://github.com/twigphp/Twig/commit/651613c32c315bbeb330b2a6354b34c288e9ea0a#diff-841d1051670799376e88c87114d2caf0 broke the code of ``Twig_Node_Module::compileLoadTemplate`` when passing a non-constant node (it triggers a fatal error)
Trait templates can only be constant expression nodes, so fixing the broken is not actually needed and it can be removed.
Given it is a protected method, I haven't changed the signature to typehint the node as a Twig_Node_Expression_Constant