### PR TITLE
Twig_Filter can't be deprecated & preferred for 3.0

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -34,7 +34,6 @@ Filters
 
   * ``Twig_FilterInterface``
   * ``Twig_FilterCallableInterface``
-  * ``Twig_Filter``
   * ``Twig_Filter_Function``
   * ``Twig_Filter_Method``
   * ``Twig_Filter_Node``


### PR DESCRIPTION
*Warning, before :coffee: has kicked in.*

Seems very strange that several classes are deprecated in 1.x and is reintroduced in 3.x with different content. why not just name space the future version instead of having to do this littel strange dance with naming conflicts?

Oh, and edit buttons from doc is broken.