### PR TITLE
changed join filter to return a safe string when all arguments are safe

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 1.20.1 (2015-XX-XX)
 
- * n/a
+ * changed join filter to return a safe string when all arguments are safe
 
 * 1.20.0 (2015-08-12)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.20.1 (2015-XX-XX)
 
+ * fixed in test to support Twig_Markup instances
  * changed join filter to return a safe string when all arguments are safe
 
 * 1.20.0 (2015-08-12)

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -935,9 +935,15 @@ function twig_sort_filter($array)
     return $array;
 }
 
-/* used internally */
+/**
+ * @internal
+ */
 function twig_in_filter($value, $compare)
 {
+    if ($value instanceof Twig_Markup) {
+        $value = (string) $value;
+    }
+
     if (is_array($compare)) {
         return in_array($value, $compare, is_object($value) || is_resource($value));
     } elseif (is_string($compare) && (is_string($value) || is_int($value) || is_float($value))) {

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -172,7 +172,7 @@ class Twig_Extension_Core extends Twig_Extension
             new Twig_SimpleFilter('nl2br', 'nl2br', array('pre_escape' => 'html', 'is_safe' => array('html'))),
 
             // array helpers
-            new Twig_SimpleFilter('join', 'twig_join_filter'),
+            new Twig_SimpleFilter('join', 'twig_join_filter', array('needs_environment' => true)),
             new Twig_SimpleFilter('split', 'twig_split_filter', array('needs_environment' => true)),
             new Twig_SimpleFilter('sort', 'twig_sort_filter'),
             new Twig_SimpleFilter('merge', 'twig_array_merge'),
@@ -779,13 +779,16 @@ function twig_last(Twig_Environment $env, $item)
  *
  * @return string The concatenated string
  */
-function twig_join_filter($value, $glue = '')
+function twig_join_filter(Twig_Environment $env, $value, $glue = '')
 {
     if ($value instanceof Traversable) {
         $value = iterator_to_array($value, false);
     }
 
-    return implode($glue, (array) $value);
+    $values = (array) $value;
+    $ret = implode($glue, $values);
+
+    return is_array_safe($values) ? new Twig_Markup($ret, $env->getCharset()) : $ret;
 }
 
 /**
@@ -1513,4 +1516,18 @@ function twig_array_batch($items, $size, $fill = null)
     }
 
     return $result;
+}
+
+/**
+ * @internal
+ */
+function is_array_safe($values)
+{
+    foreach ($values as $value) {
+        if (!$value instanceof Twig_Markup) {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/test/Twig/Tests/Fixtures/filters/join.test
+++ b/test/Twig/Tests/Fixtures/filters/join.test
@@ -4,9 +4,13 @@
 {{ ["foo", "bar"]|join(', ') }}
 {{ foo|join(', ') }}
 {{ bar|join(', ') }}
+{{ ["a", "<br />"]|join(', ') }}
+{{ safe|join(', ') }}
 --DATA--
-return array('foo' => new TwigTestFoo(), 'bar' => new ArrayObject(array(3, 4)))
+return array('foo' => new TwigTestFoo(), 'bar' => new ArrayObject(array(3, 4)), 'safe' => array(new Twig_Markup('a', 'UTF-8'), new Twig_Markup('<br />', 'UTF-8')))
 --EXPECT--
 foo, bar
 1, 2
 3, 4
+a, &lt;br /&gt;
+a, <br />

--- a/test/Twig/Tests/Fixtures/tests/in.test
+++ b/test/Twig/Tests/Fixtures/tests/in.test
@@ -73,8 +73,10 @@ TRUE
 {{ 5.5 in 125.5 ? 'TRUE' : 'FALSE' }}
 {{ 5.5 in '125.5' ? 'TRUE' : 'FALSE' }}
 {{ '5.5' in 125.5 ? 'TRUE' : 'FALSE' }}
+
+{{ safe in ['foo', 'bar'] ? 'TRUE' : 'FALSE' }}
 --DATA--
-return array('bar' => 'bar', 'foo' => array('bar' => 'bar'), 'dir_object' => new SplFileInfo(dirname(__FILE__)), 'object' => new stdClass(), 'resource' => opendir(dirname(__FILE__)))
+return array('bar' => 'bar', 'foo' => array('bar' => 'bar'), 'dir_object' => new SplFileInfo(dirname(__FILE__)), 'object' => new stdClass(), 'resource' => opendir(dirname(__FILE__)), 'safe' => new Twig_Markup('foo', 'UTF-8'))
 --EXPECT--
 TRUE
 TRUE
@@ -126,3 +128,5 @@ TRUE
 FALSE
 TRUE
 FALSE
+
+TRUE


### PR DESCRIPTION
This is WIP to fix #1420 (first commit) and #1512 (second commit.

The first commit change the return value of the `join` filter to a Twig_Markup instance when all joined elements are "safe". That means that the returned value of the filter can now be a string or a Twig_Markup instance which is probably a BC break, especially because Twig_Markup instance cannot be used as a string everywhere in Twig (see #1512 for instance -- second commit).

The second commit makes it possible to use a Twig_Markup instance with the in test transparently to avoid WTF effects as such instances can be created by Twig directly.

Of course, if we decide to go down this road, this PR would need to:
- change some other filters/functions/whatever to make this new behavior consistent;
- try to change filters/functions/whatever to make Twig_Markup instances behave like strings as much as possible.

Is it worth it? Does it belong to 1.x or 2.x?
