### PR TITLE
Optimize the retrieval of reserved macro names

### DIFF
--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -64,7 +64,7 @@ class Twig_Parser implements Twig_ParserInterface
     {
         // push all variables into the stack to keep the current state of the parser
         $vars = get_object_vars($this);
-        unset($vars['stack'], $vars['env'], $vars['handlers'], $vars['visitors'], $vars['expressionParser']);
+        unset($vars['stack'], $vars['env'], $vars['handlers'], $vars['visitors'], $vars['expressionParser'], $vars['reservedMacroNames']);
         $this->stack[] = $vars;
 
         // tag handlers


### PR DESCRIPTION
The list of reserved names does not need to be reset for each template compilation.