### PR TITLE
Add gitattributes w/ export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Ignore un-needed files and directories for export of production releases
+# Keeps lib directory
+#
+# See: http://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Exporting-Your-Repository
+
+doc export-ignore
+ext export-ignore
+test export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
This will allow for a `production` ready version of Twig when archived/exported for release(s) and still allowing a development version within the repository.

The `export-ignore` excludes un-needed files and directories when a branch is archived for release these files are included when the repo is cloned/forked.

This would be very useful because `releases` are intended for `production use` and when users are using a package (via composer or zip), they most likely are not interested in downloading the source code as a whole into production, thus saving disk space and meeting security protocol.

  - e.g. /test folder, or your .travis.yml file, etc.