### PR TITLE
A possible way to add custom logic to process context parameters

### DIFF
--- a/lib/Twig/ContextParameterInterface.php
+++ b/lib/Twig/ContextParameterInterface.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * For implementing when an additional logic is needed before
- * pass the template context parameter to the template.
+ * To be implemented when an additional logic is required before
+ * passing the context parameter to the template.
  *
  * @author Vladimir Balin <krocos@mail.ru>
  */
-interface ContextParameterInterface
+interface Twig_ContextParameterInterface
 {
     /**
      * @return mixed The prepared template context parameter

--- a/lib/Twig/ContextParameterInterface.php
+++ b/lib/Twig/ContextParameterInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * For implementing when an additional logic is needed before
+ * pass the template context parameter to the template
+ *
+ * @author Vladimir Balin <krocos@mail.ru>
+ */
+interface ContextParameterInterface
+{
+    /**
+     * @return mixed The prepared template context parameter
+     */
+    public function prepare();
+}

--- a/lib/Twig/ContextParameterInterface.php
+++ b/lib/Twig/ContextParameterInterface.php
@@ -2,7 +2,7 @@
 
 /**
  * For implementing when an additional logic is needed before
- * pass the template context parameter to the template
+ * pass the template context parameter to the template.
  *
  * @author Vladimir Balin <krocos@mail.ru>
  */

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -311,7 +311,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
      */
     public function display(array $context, array $blocks = array())
     {
-        $this->prepareContextParameters($context);
+        $context = $this->prepareContextParameters($context);
         $this->displayWithErrorHandling($this->env->mergeGlobals($context), array_merge($this->blocks, $blocks));
     }
 
@@ -571,16 +571,19 @@ abstract class Twig_Template implements Twig_TemplateInterface
     }
 
     /**
-     * Prepare template context parameters if need.
+     * Prepare template context parameters if needed.
      *
      * @param array $context
+     * @return array
      */
-    private function prepareContextParameters(&$context)
+    private function prepareContextParameters(array $context)
     {
         foreach ($context as $name => $contextParameter) {
-            if ($contextParameter instanceof ContextParameterInterface) {
+            if ($contextParameter instanceof Twig_ContextParameterInterface) {
                 $context[$name] = $contextParameter->prepare();
             }
         }
+
+        return $context;
     }
 }

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -311,6 +311,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
      */
     public function display(array $context, array $blocks = array())
     {
+        $this->prepareContextParameters($context);
         $this->displayWithErrorHandling($this->env->mergeGlobals($context), array_merge($this->blocks, $blocks));
     }
 
@@ -567,5 +568,19 @@ abstract class Twig_Template implements Twig_TemplateInterface
         }
 
         return $ret;
+    }
+
+    /**
+     * Prepare template context parameters if need
+     *
+     * @param array $context
+     */
+    private function prepareContextParameters(&$context)
+    {
+        foreach ($context as $name => $contextParameter) {
+            if ($contextParameter instanceof ContextParameterInterface) {
+                $context[$name] = $contextParameter->prepare();
+            }
+        }
     }
 }

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -571,7 +571,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
     }
 
     /**
-     * Prepare template context parameters if need
+     * Prepare template context parameters if need.
      *
      * @param array $context
      */

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -574,6 +574,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
      * Prepare template context parameters if needed.
      *
      * @param array $context
+     *
      * @return array
      */
     private function prepareContextParameters(array $context)

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -412,6 +412,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
     {
         $twigEnvironment = $this
             ->getMockBuilder('Twig_Environment')
+            ->disableOriginalConstructor()
             ->setMethods(['mergeGlobals'])
             ->getMock();
         $twigEnvironment

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -413,7 +413,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
         $twigEnvironment = $this
             ->getMockBuilder('Twig_Environment')
             ->disableOriginalConstructor()
-            ->setMethods(['mergeGlobals'])
+            ->setMethods(array('mergeGlobals'))
             ->getMock();
         $twigEnvironment
             ->expects($this->once())
@@ -440,7 +440,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
 
         $context2Parameter2 = $this
             ->getMockBuilder('Twig_ContextParameterInterface')
-            ->setMethods(['prepare'])
+            ->setMethods(array('prepare'))
             ->getMock();
         $context2Parameter2
             ->expects($this->once())
@@ -459,7 +459,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
 
         $context3Parameter1 = $this
             ->getMockBuilder('Twig_ContextParameterInterface')
-            ->setMethods(['prepare'])
+            ->setMethods(array('prepare'))
             ->getMock();
         $context3Parameter1
             ->expects($this->once())
@@ -467,7 +467,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
             ->willReturn('value1');
         $context3Parameter2 = $this
             ->getMockBuilder('Twig_ContextParameterInterface')
-            ->setMethods(['prepare'])
+            ->setMethods(array('prepare'))
             ->getMock();
         $context3Parameter2
             ->expects($this->once())
@@ -475,7 +475,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
             ->willReturn('value2');
         $context3Parameter3 = $this
             ->getMockBuilder('Twig_ContextParameterInterface')
-            ->setMethods(['prepare'])
+            ->setMethods(array('prepare'))
             ->getMock();
         $context3Parameter3
             ->expects($this->once())

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -404,6 +404,99 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
 
         return $tests;
     }
+
+    /**
+     * @dataProvider displayMethodProvider
+     */
+    public function testDisplayMethodPreparesContextParametersBeforeMoveOn($context, $preparedContext)
+    {
+        $twigEnvironment = $this
+            ->getMockBuilder('Twig_Environment')
+            ->setMethods(['mergeGlobals'])
+            ->getMock();
+        $twigEnvironment
+            ->expects($this->once())
+            ->method('mergeGlobals')
+            ->with($this->equalTo($preparedContext))
+            ->willReturn($preparedContext);
+
+        $template = new Twig_TemplateTest($twigEnvironment);
+        $template->display($context);
+    }
+
+    public function displayMethodProvider()
+    {
+        $context1 = array(
+            'param1' => 'value1',
+            'param2' => 'value2',
+            'param3' => 'value3',
+        );
+        $preparedContext1 = array(
+            'param1' => 'value1',
+            'param2' => 'value2',
+            'param3' => 'value3',
+        );
+
+        $context2Parameter2 = $this
+            ->getMockBuilder('Twig_ContextParameterInterface')
+            ->setMethods(['prepare'])
+            ->getMock();
+        $context2Parameter2
+            ->expects($this->once())
+            ->method('prepare')
+            ->willReturn('value2');
+        $context2 = array(
+            'param1' => 'value1',
+            'param2' => $context2Parameter2,
+            'param3' => 'value3',
+        );
+        $preparedContext2 = array(
+            'param1' => 'value1',
+            'param2' => 'value2',
+            'param3' => 'value3',
+        );
+
+        $context3Parameter1 = $this
+            ->getMockBuilder('Twig_ContextParameterInterface')
+            ->setMethods(['prepare'])
+            ->getMock();
+        $context3Parameter1
+            ->expects($this->once())
+            ->method('prepare')
+            ->willReturn('value1');
+        $context3Parameter2 = $this
+            ->getMockBuilder('Twig_ContextParameterInterface')
+            ->setMethods(['prepare'])
+            ->getMock();
+        $context3Parameter2
+            ->expects($this->once())
+            ->method('prepare')
+            ->willReturn('value2');
+        $context3Parameter3 = $this
+            ->getMockBuilder('Twig_ContextParameterInterface')
+            ->setMethods(['prepare'])
+            ->getMock();
+        $context3Parameter3
+            ->expects($this->once())
+            ->method('prepare')
+            ->willReturn('value3');
+        $context3 = array(
+            'param1' => $context3Parameter1,
+            'param2' => $context3Parameter2,
+            'param3' => $context3Parameter3,
+        );
+        $preparedContext3 = array(
+            'param1' => 'value1',
+            'param2' => 'value2',
+            'param3' => 'value3',
+        );
+
+        return array(
+            array($context1, $preparedContext1),
+            array($context2, $preparedContext2),
+            array($context3, $preparedContext3),
+        );
+    }
 }
 
 class Twig_TemplateTest extends Twig_Template

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -419,7 +419,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('mergeGlobals')
             ->with($this->equalTo($preparedContext))
-            ->willReturn($preparedContext);
+            ->will($this->returnValue($preparedContext));
 
         $template = new Twig_TemplateTest($twigEnvironment);
         $template->display($context);
@@ -445,7 +445,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
         $context2Parameter2
             ->expects($this->once())
             ->method('prepare')
-            ->willReturn('value2');
+            ->will($this->returnValue('value2'));
         $context2 = array(
             'param1' => 'value1',
             'param2' => $context2Parameter2,
@@ -464,7 +464,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
         $context3Parameter1
             ->expects($this->once())
             ->method('prepare')
-            ->willReturn('value1');
+            ->will($this->returnValue('value1'));
         $context3Parameter2 = $this
             ->getMockBuilder('Twig_ContextParameterInterface')
             ->setMethods(array('prepare'))
@@ -472,7 +472,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
         $context3Parameter2
             ->expects($this->once())
             ->method('prepare')
-            ->willReturn('value2');
+            ->will($this->returnValue('value2'));
         $context3Parameter3 = $this
             ->getMockBuilder('Twig_ContextParameterInterface')
             ->setMethods(array('prepare'))
@@ -480,7 +480,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
         $context3Parameter3
             ->expects($this->once())
             ->method('prepare')
-            ->willReturn('value3');
+            ->will($this->returnValue('value3'));
         $context3 = array(
             'param1' => $context3Parameter1,
             'param2' => $context3Parameter2,


### PR DESCRIPTION
From my point of view it can be useful to process many similar parameters before they pass to the template for rendering

For example:
```php
class FormContext implements ContextParameterInterface
{
    /**
     * @var FormInteface
     */
    private $form;

    /**
     * @param FormInteface $form
     */
    public function __construct(FormInteface $form)
    {
        $this->form = $form;
    }
    
    /**
     * @return mixed The prepared template context parameter
     */
    public function prepare()
    {
        $form->add('submit', 'submit');
        /* or any other manipulations here */
        
        return $form->createView();
    }
}

class SomeController
{
    public function someAction()
    {
        /** @var FormInteface $form */
        $form = /* create form */;
        
        return $this->render('someTempalte.html.twig', [
            'form' => new FormContext($form), /* or call some service here */
        ]);
    }
}
```