### PR TITLE
Add missing deprecation triggers

### DIFF
--- a/lib/Twig/Filter.php
+++ b/lib/Twig/Filter.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+@trigger_error('The Twig_Filter class is deprecated since version 1.12 and will be removed in 2.0. Use Twig_SimpleFilter instead.', E_USER_DEPRECATED);
+
 /**
  * Represents a template filter.
  *

--- a/lib/Twig/Function.php
+++ b/lib/Twig/Function.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+@trigger_error('The Twig_Function class is deprecated since version 1.12 and will be removed in 2.0. Use Twig_SimpleFunction instead.', E_USER_DEPRECATED);
+
 /**
  * Represents a template function.
  *

--- a/lib/Twig/Test.php
+++ b/lib/Twig/Test.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+@trigger_error('The Twig_Test class is deprecated since version 1.12 and will be removed in 2.0. Use Twig_SimpleTest instead.', E_USER_DEPRECATED);
+
 /**
  * Represents a template test.
  *


### PR DESCRIPTION
Assetic is extending the ``Twig_Function`` class directly currently, and this was not triggering any deprecation warning