### PR TITLE
move property initialization to the declaration when possible

### DIFF
--- a/lib/Twig/Compiler.php
+++ b/lib/Twig/Compiler.php
@@ -21,7 +21,7 @@ class Twig_Compiler
     private $source;
     private $indentation;
     private $env;
-    private $debugInfo;
+    private $debugInfo = [];
     private $sourceOffset;
     private $sourceLine;
     private $filename;
@@ -34,7 +34,6 @@ class Twig_Compiler
     public function __construct(Twig_Environment $env)
     {
         $this->env = $env;
-        $this->debugInfo = array();
     }
 
     public function getFilename()

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -34,15 +34,15 @@ class Twig_Environment
     protected $tests;
     protected $functions;
     protected $globals;
-    protected $runtimeInitialized;
-    protected $extensionInitialized;
+    protected $runtimeInitialized = false;
+    protected $extensionInitialized = false;
     protected $loadedTemplates;
     protected $strictVariables;
     protected $unaryOperators;
     protected $binaryOperators;
     protected $templateClassPrefix = '__TwigTemplate_';
-    protected $functionCallbacks;
-    protected $filterCallbacks;
+    protected $functionCallbacks = [];
+    protected $filterCallbacks = [];
     protected $staging;
 
     /**
@@ -101,15 +101,11 @@ class Twig_Environment
         $this->baseTemplateClass = $options['base_template_class'];
         $this->autoReload = null === $options['auto_reload'] ? $this->debug : (bool) $options['auto_reload'];
         $this->strictVariables = (bool) $options['strict_variables'];
-        $this->runtimeInitialized = false;
         $this->setCache($options['cache']);
-        $this->functionCallbacks = array();
-        $this->filterCallbacks = array();
 
         $this->addExtension(new Twig_Extension_Core());
         $this->addExtension(new Twig_Extension_Escaper($options['autoescape']));
         $this->addExtension(new Twig_Extension_Optimizer($options['optimizations']));
-        $this->extensionInitialized = false;
         $this->staging = new Twig_Extension_Staging();
     }
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -15,10 +15,10 @@ if (!defined('ENT_SUBSTITUTE')) {
  */
 class Twig_Extension_Core extends Twig_Extension
 {
-    private $dateFormats = array('F j, Y H:i', '%d days');
-    private $numberFormat = array(0, '.', ',');
-    private $timezone = null;
-    private $escapers = array();
+    private $dateFormats = ['F j, Y H:i', '%d days'];
+    private $numberFormat = [0, '.', ','];
+    private $timezone;
+    private $escapers = [];
 
     /**
      * Defines a new escaper to be used via the escape filter.

--- a/lib/Twig/Extension/Profiler.php
+++ b/lib/Twig/Extension/Profiler.php
@@ -11,11 +11,11 @@
 
 class Twig_Extension_Profiler extends Twig_Extension
 {
-    private $actives;
+    private $actives = [];
 
     public function __construct(Twig_Profiler_Profile $profile)
     {
-        $this->actives = array($profile);
+        $this->actives[] = $profile;
     }
 
     public function enter(Twig_Profiler_Profile $profile)

--- a/lib/Twig/Extension/Staging.php
+++ b/lib/Twig/Extension/Staging.php
@@ -13,6 +13,7 @@
  * Used by Twig_Environment as a staging area.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
  * @internal
  */
 final class Twig_Extension_Staging extends Twig_Extension

--- a/lib/Twig/Extension/Staging.php
+++ b/lib/Twig/Extension/Staging.php
@@ -17,12 +17,12 @@
  */
 final class Twig_Extension_Staging extends Twig_Extension
 {
-    private $functions = array();
-    private $filters = array();
-    private $visitors = array();
-    private $tokenParsers = array();
-    private $globals = array();
-    private $tests = array();
+    private $functions = [];
+    private $filters = [];
+    private $visitors = [];
+    private $tokenParsers = [];
+    private $globals = [];
+    private $tests = [];
 
     public function addFunction(Twig_Function $function)
     {

--- a/lib/Twig/Filter.php
+++ b/lib/Twig/Filter.php
@@ -19,7 +19,7 @@ class Twig_Filter
     private $name;
     private $callable;
     private $options;
-    private $arguments = array();
+    private $arguments = [];
 
     public function __construct($name, $callable, array $options = array())
     {

--- a/lib/Twig/Function.php
+++ b/lib/Twig/Function.php
@@ -19,7 +19,7 @@ class Twig_Function
     private $name;
     private $callable;
     private $options;
-    private $arguments = array();
+    private $arguments = [];
 
     public function __construct($name, $callable, array $options = array())
     {

--- a/lib/Twig/Loader/Array.php
+++ b/lib/Twig/Loader/Array.php
@@ -23,7 +23,7 @@
  */
 class Twig_Loader_Array implements Twig_LoaderInterface
 {
-    private $templates = array();
+    private $templates = [];
 
     /**
      * Constructor.

--- a/lib/Twig/Loader/Chain.php
+++ b/lib/Twig/Loader/Chain.php
@@ -16,8 +16,8 @@
  */
 class Twig_Loader_Chain implements Twig_LoaderInterface
 {
-    private $hasSourceCache = array();
-    protected $loaders = array();
+    private $hasSourceCache = [];
+    protected $loaders = [];
 
     /**
      * Constructor.

--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -19,9 +19,9 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface
     /** Identifier of the main namespace. */
     const MAIN_NAMESPACE = '__main__';
 
-    protected $paths = array();
-    protected $cache = array();
-    protected $errorCache = array();
+    protected $paths = [];
+    protected $cache = [];
+    protected $errorCache = [];
 
     /**
      * Constructor.

--- a/lib/Twig/Node/Expression/Name.php
+++ b/lib/Twig/Node/Expression/Name.php
@@ -11,10 +11,10 @@
  */
 class Twig_Node_Expression_Name extends Twig_Node_Expression
 {
-    private $specialVars = array(
+    private $specialVars = [
         '_context' => '$context',
         '_charset' => '$this->env->getCharset()',
-    );
+    ];
 
     public function __construct($name, $lineno)
     {

--- a/lib/Twig/NodeTraverser.php
+++ b/lib/Twig/NodeTraverser.php
@@ -19,7 +19,7 @@
 class Twig_NodeTraverser
 {
     private $env;
-    private $visitors;
+    private $visitors = [];
 
     /**
      * Constructor.
@@ -30,7 +30,6 @@ class Twig_NodeTraverser
     public function __construct(Twig_Environment $env, array $visitors = array())
     {
         $this->env = $env;
-        $this->visitors = array();
         foreach ($visitors as $visitor) {
             $this->addVisitor($visitor);
         }

--- a/lib/Twig/NodeVisitor/Escaper.php
+++ b/lib/Twig/NodeVisitor/Escaper.php
@@ -16,12 +16,12 @@
  */
 class Twig_NodeVisitor_Escaper extends Twig_BaseNodeVisitor
 {
-    private $statusStack = array();
-    private $blocks = array();
+    private $statusStack = [];
+    private $blocks = [];
     private $safeAnalysis;
     private $traverser;
     private $defaultStrategy = false;
-    private $safeVars = array();
+    private $safeVars = [];
 
     public function __construct()
     {

--- a/lib/Twig/NodeVisitor/Optimizer.php
+++ b/lib/Twig/NodeVisitor/Optimizer.php
@@ -28,10 +28,9 @@ class Twig_NodeVisitor_Optimizer extends Twig_BaseNodeVisitor
     // obsolete, does not do anything
     const OPTIMIZE_VAR_ACCESS = 8;
 
-    private $loops = array();
-    private $loopsTargets = array();
+    private $loops = [];
+    private $loopsTargets = [];
     private $optimizers;
-    private $prependedNodes = array();
 
     /**
      * Constructor.

--- a/lib/Twig/NodeVisitor/SafeAnalysis.php
+++ b/lib/Twig/NodeVisitor/SafeAnalysis.php
@@ -11,8 +11,8 @@
 
 class Twig_NodeVisitor_SafeAnalysis extends Twig_BaseNodeVisitor
 {
-    private $data = array();
-    private $safeVars = array();
+    private $data = [];
+    private $safeVars = [];
 
     public function setSafeVars($safeVars)
     {

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -17,7 +17,7 @@
  */
 class Twig_Parser
 {
-    private $stack = array();
+    private $stack = [];
     private $stream;
     private $parent;
     private $handlers;
@@ -29,7 +29,7 @@ class Twig_Parser
     private $env;
     private $importedSymbols;
     private $traits;
-    private $embeddedTemplates = array();
+    private $embeddedTemplates = [];
 
     /**
      * Constructor.

--- a/lib/Twig/Profiler/Profile.php
+++ b/lib/Twig/Profiler/Profile.php
@@ -22,9 +22,9 @@ class Twig_Profiler_Profile implements IteratorAggregate, Serializable
     private $template;
     private $name;
     private $type;
-    private $starts = array();
-    private $ends = array();
-    private $profiles = array();
+    private $starts = [];
+    private $ends = [];
+    private $profiles = [];
 
     public function __construct($template = 'main', $type = self::ROOT, $name = 'main')
     {

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -21,13 +21,13 @@ abstract class Twig_Template
     const ARRAY_CALL = 'array';
     const METHOD_CALL = 'method';
 
-    protected static $cache = array();
+    protected static $cache = [];
 
     protected $parent;
-    protected $parents = array();
+    protected $parents = [];
     protected $env;
-    protected $blocks;
-    protected $traits;
+    protected $blocks = [];
+    protected $traits = [];
 
     /**
      * Constructor.
@@ -37,8 +37,6 @@ abstract class Twig_Template
     public function __construct(Twig_Environment $env)
     {
         $this->env = $env;
-        $this->blocks = array();
-        $this->traits = array();
     }
 
     /**

--- a/lib/Twig/TokenStream.php
+++ b/lib/Twig/TokenStream.php
@@ -18,7 +18,7 @@
 class Twig_TokenStream
 {
     private $tokens;
-    private $current;
+    private $current = 0;
     private $filename;
 
     /**
@@ -30,7 +30,6 @@ class Twig_TokenStream
     public function __construct(array $tokens, $filename = null)
     {
         $this->tokens = $tokens;
-        $this->current = 0;
         $this->filename = $filename;
     }
 


### PR DESCRIPTION
This normalization is what I did in symfony in symfony/symfony#9487

I switched to short array syntax only in properties since I was touching that anyway and it's a good first step in case we want to go this route for everything in the future.