### PR TITLE
Traversable support for 'replace', 'merge' and 'sort'

### DIFF
--- a/doc/filters/merge.rst
+++ b/doc/filters/merge.rst
@@ -42,6 +42,7 @@ overridden.
         
 .. note::
 
-    Internally, Twig uses the PHP `array_merge`_ function.
+    Internally, Twig uses the PHP `array_merge`_ function. It supports
+    Traversable objects by transforming those to arrays.
 
 .. _`array_merge`: http://php.net/array_merge

--- a/doc/filters/sort.rst
+++ b/doc/filters/sort.rst
@@ -12,6 +12,7 @@ The ``sort`` filter sorts an array:
 .. note::
 
     Internally, Twig uses the PHP `asort`_ function to maintain index
-    association.
+    association. It supports Traversable objects by transforming
+    those to arrays.
 
 .. _`asort`: http://php.net/asort

--- a/test/Twig/Tests/Fixtures/filters/merge.test
+++ b/test/Twig/Tests/Fixtures/filters/merge.test
@@ -6,11 +6,13 @@
 {{ {'bar': 'foo'}|merge(items)|join }}
 {{ {'bar': 'foo'}|merge(items)|keys|join }}
 {{ numerics|merge([4, 5, 6])|join }}
+{{ traversable.a|merge(traversable.b)|join }}
 --DATA--
-return array('items' => array('foo' => 'bar'), 'numerics' => array(1, 2, 3))
+return array('items' => array('foo' => 'bar'), 'numerics' => array(1, 2, 3), 'traversable' => array('a' => new ArrayObject(array(0 => 1, 1 => 2, 2 => 3)), 'b' => new ArrayObject(array('a' => 'b'))))
 --EXPECT--
 barfoo
 foobar
 foobar
 barfoo
 123456
+123b

--- a/test/Twig/Tests/Fixtures/filters/replace.test
+++ b/test/Twig/Tests/Fixtures/filters/replace.test
@@ -1,8 +1,12 @@
 --TEST--
 "replace" filter
 --TEMPLATE--
-{{ "I like %this% and %that%."|replace({'%this%': "foo", '%that%': "bar"}) }}
+{{ "I liké %this% and %that%."|replace({'%this%': "foo", '%that%': "bar"}) }}
+{{ 'I like single replace operation only %that%'|replace({'%that%' : '%that%1'}) }}
+{{ 'I like %this% and %that%.'|replace(traversable) }}
 --DATA--
-return array()
+return array('traversable' => new ArrayObject(array('%this%' => 'foo', '%that%' => 'bar')))
 --EXPECT--
+I liké foo and bar.
+I like single replace operation only %that%1
 I like foo and bar.

--- a/test/Twig/Tests/Fixtures/filters/replace_invalid_arg.test
+++ b/test/Twig/Tests/Fixtures/filters/replace_invalid_arg.test
@@ -1,0 +1,8 @@
+--TEST--
+Exception for invalid argument type in replace call
+--TEMPLATE--
+{{ 'test %foo%'|replace(stdClass) }}
+--DATA--
+return array('stdClass' => new \stdClass())
+--EXCEPTION--
+Twig_Error_Runtime: The "replace" filter expects an array or "Traversable" as replace values, got "stdClass" in "index.twig" at line 2.

--- a/test/Twig/Tests/Fixtures/filters/sort.test
+++ b/test/Twig/Tests/Fixtures/filters/sort.test
@@ -3,8 +3,10 @@
 --TEMPLATE--
 {{ array1|sort|join }}
 {{ array2|sort|join }}
+{{ traversable|sort|join }}
 --DATA--
-return array('array1' => array(4, 1), 'array2' => array('foo', 'bar'))
+return array('array1' => array(4, 1), 'array2' => array('foo', 'bar'), 'traversable' => new ArrayObject(array(0 => 3, 1 => 2, 2 => 1)))
 --EXPECT--
 14
 barfoo
+123


### PR DESCRIPTION
Add traversable support to:
* replace
* merge
* sort

Other changes:
* Removes some not need checks
* ~~Make unit test skip if it cannot write to cache because of the user running the test~~
* Tests added for traversable support
* Doc updates

Deprecating:
I think the undocumented (and multibyte not supported) use of `replace(string, string)` can be removed in Twig 2.0.
Adding MB support and documentation of the feature was turned down (https://github.com/twigphp/Twig/pull/1618)
However removing it is a BC break (https://github.com/twigphp/Twig/pull/1445#issuecomment-48746926)
