### PR TITLE
fix escaping strategy detection based on filename

### DIFF
--- a/lib/Twig/FileExtensionEscapingStrategy.php
+++ b/lib/Twig/FileExtensionEscapingStrategy.php
@@ -27,15 +27,21 @@ class Twig_FileExtensionEscapingStrategy
      *
      * @param string $filename The template file name
      *
-     * @return string The escaping strategy name to use
+     * @return string|false The escaping strategy name to use or false to disable
      */
     public static function guess($filename)
     {
-        if (!preg_match('{\.(js|css|txt)(?:\.[^/\\\\]+)?$}', $filename, $match)) {
-            return 'html';
+        if (in_array(substr($filename, -1), array('/', '\\'))) {
+            return 'html'; // return html for directories
         }
 
-        switch ($match[1]) {
+        if ('.twig' === substr($filename, -5)) {
+            $filename = substr($filename, 0, -5);
+        }
+
+        $extension = pathinfo($filename, PATHINFO_EXTENSION);
+
+        switch ($extension) {
             case 'js':
                 return 'js';
 
@@ -44,6 +50,9 @@ class Twig_FileExtensionEscapingStrategy
 
             case 'txt':
                 return false;
+
+            default:
+                return 'html';
         }
     }
 }

--- a/test/Twig/Tests/FileExtensionEscapingStrategyTest.php
+++ b/test/Twig/Tests/FileExtensionEscapingStrategyTest.php
@@ -16,7 +16,7 @@ class Twig_Tests_FileExtensionEscapingStrategyTest extends PHPUnit_Framework_Tes
      */
     public function testGuess($strategy, $filename)
     {
-        $this->assertEquals($strategy, Twig_FileExtensionEscapingStrategy::guess($filename));
+        $this->assertSame($strategy, Twig_FileExtensionEscapingStrategy::guess($filename));
     }
 
     public function getGuessData()
@@ -34,6 +34,8 @@ class Twig_Tests_FileExtensionEscapingStrategyTest extends PHPUnit_Framework_Tes
             array('css', 'foo.css'),
             array('css', 'foo.css.twig'),
             array('css', 'foo.twig.css'),
+            array('css', 'foo.js.css'),
+            array('css', 'foo.js.css.twig'),
 
             // js
             array('js', 'foo.js'),


### PR DESCRIPTION
Fixes symfony/symfony#15095

It previously excluded any fileextension (not just `.twig`) which is pretty wrong.