### PR TITLE
Drop support for PHP < 5.5

### DIFF
--- a/test/Twig/Tests/Fixtures/filters/date_immutable.test
+++ b/test/Twig/Tests/Fixtures/filters/date_immutable.test
@@ -1,7 +1,5 @@
 --TEST--
 "date" filter
---CONDITION--
-version_compare(phpversion(), '5.5.0', '>=')
 --TEMPLATE--
 {{ date1|date }}
 {{ date1|date('d/m/Y') }}


### PR DESCRIPTION
I think this condition can be removed.
