### PR TITLE
Add $template->getSource()

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -596,7 +596,7 @@ class Twig_Environment
             $compiled = $this->compile($this->parse($this->tokenize($source, $name)), $source);
 
             if (isset($source[0])) {
-                $compiled .= '// '.str_replace(array("\r\n", "\r", "\n"), "\n// ", $source)."\n";
+                $compiled .= '/* '.str_replace(array("\r\n", "\r", "\n"), "*/\n/* ", str_replace('*/', '*//*', $source))."*/\n";
             }
 
             return $compiled;

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -305,6 +305,33 @@ abstract class Twig_Template implements Twig_TemplateInterface
     }
 
     /**
+     * Returns the template source code.
+     *
+     * @return string|null The template source code or null if it is not available
+     */
+    public function getSource()
+    {
+        $reflector = new ReflectionClass($this);
+        $file = $reflector->getFileName();
+
+        if (!file_exists($file)) {
+            return;
+        }
+
+        $source = file($file, FILE_IGNORE_NEW_LINES);
+        array_splice($source, 0, $reflector->getEndLine());
+
+        $i = 0;
+        while (isset($source[$i]) && '/* */' === substr_replace($source[$i], '', 3, -2)) {
+            $source[$i] = str_replace('*//*', '*/', substr($source[$i], 3, -2));
+            ++$i;
+        }
+        array_splice($source, $i);
+
+        return implode("\n", $source);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function display(array $context, array $blocks = array())

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -142,8 +142,8 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
     {
         $twig = new Twig_Environment($this->getMock('Twig_LoaderInterface'));
 
-        $source = "{{ foo }}\n{{ bar }}\n";
-        $expected = "// {{ foo }}\n// {{ bar }}\n// \n";
+        $source = "<? /*foo*/ ?>\nbar\n";
+        $expected = "/* <? /*foo*//* ?>*/\n/* bar*/\n/* */\n";
 
         $this->assertContains($expected, $twig->compileSource($source, 'index'));
     }

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -84,6 +84,13 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
         return $tests;
     }
 
+    public function testGetSource()
+    {
+        $template = new Twig_TemplateTest(new Twig_Environment($this->getMock('Twig_LoaderInterface')), false);
+
+        $this->assertSame("<? /*bar*/ ?>\n", $template->getSource());
+    }
+
     /**
      * @dataProvider getGetAttributeWithSandbox
      */
@@ -463,6 +470,8 @@ class Twig_TemplateTest extends Twig_Template
         }
     }
 }
+/* <? /*bar*//* ?>*/
+/* */
 
 class Twig_TemplateArrayAccessObject implements ArrayAccess
 {


### PR DESCRIPTION
Now that we have the source inlined, we should provide a way to get it. This also make it possible to feature-test if the source is available for backward/forward compat.