### PR TITLE
use str_replace instead of strtr to escape the source in the template

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -641,7 +641,7 @@ class Twig_Environment
             $compiled = $this->compile($this->parse($this->tokenize($source, $name)), $source);
 
             if (isset($source[0])) {
-                $compiled .= '/* '.strtr($source, array('*/' => '*//*', "\r\n" => "*/\n/* ", "\r" => "*/\n/* ", "\n" => "*/\n/* "))."*/\n";
+                $compiled .= '/* '.str_replace(array('*/', "\r\n", "\n", "\r"), array('*//*', "\n", "*/\n/* ", "*/\n/* "), $source)."*/\n";
             }
 
             return $compiled;

--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -233,7 +233,7 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
 
     protected function normalizeName($name)
     {
-        return preg_replace('#/{2,}#', '/', strtr((string) $name, '\\', '/'));
+        return preg_replace('#/{2,}#', '/', str_replace('\\', '/', (string) $name));
     }
 
     protected function validateName($name)


### PR DESCRIPTION
strtr is really slow when used this way.

Benchmark https://3v4l.org/PXWDg/perf#tabs vs https://3v4l.org/iuq1Z/perf#tabs

strtr is only slightly faster when used with a byte-by-byte replacement as done in https://github.com/twigphp/Twig/blob/1.x/lib/Twig/Lexer.php#L263