### PR TITLE
no need to call setTimezone on a current date

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -536,12 +536,17 @@ function twig_date_converter(Twig_Environment $env, $date = null, $timezone = nu
         return $date;
     }
 
-    $asString = (string) $date;
-    if (ctype_digit($asString) || (!empty($asString) && '-' === $asString[0] && ctype_digit(substr($asString, 1)))) {
-        $date = '@'.$date;
+    if (null === $date || 'now' === $date) {
+        return new DateTime($date, false !== $timezone ? $timezone : $env->getExtension('core')->getTimezone());
     }
 
-    $date = new DateTime($date, $env->getExtension('core')->getTimezone());
+    $asString = (string) $date;
+    if (ctype_digit($asString) || (!empty($asString) && '-' === $asString[0] && ctype_digit(substr($asString, 1)))) {
+        $date = new DateTime('@'.$date);
+    } else {
+        $date = new DateTime($date, $env->getExtension('core')->getTimezone());
+    }
+
     if (false !== $timezone) {
         $date->setTimezone($timezone);
     }


### PR DESCRIPTION
Avoiding unnecessary method calls.

- When retrieving the current time, there is no point changing the timezone from default to the specified timezone, e.g. if you just use twigs `date()` function.
- When dealing with timestamps, the initial timezone is irrelevant as well since unix timstamps are always in GMT.