### PR TITLE
changed the arguments of generateKey

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 * 1.22.0 (2015-XX-XX)
 
  * deprecated Twig_Environment::clearCacheFiles(), Twig_Environment::getCacheFilename(),
-   and Twig_Environment::writeCacheFile()
+   Twig_Environment::writeCacheFile(), and Twig_Environment::getTemplateClassPrefix()
  * added a way to override the filesystem template cache system
  * added a way to get the original template source from Twig_Template
 

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -141,8 +141,8 @@ Miscellaneous
 -------------
 
 * As of Twig 1.x, ``Twig_Environment::clearTemplateCache()``, ``Twig_Environment::writeCacheFile()``,
-  ``Twig_Environment::clearCacheFiles()``, and ``Twig_Environment::getCacheFilename()`` are deprecated and
-  will be removed in 2.0.
+  ``Twig_Environment::clearCacheFiles()``, ``Twig_Environment::getCacheFilename()``, and
+  ``Twig_Environment::getTemplateClassPrefix()`` are deprecated and will be removed in 2.0.
 
 * As of Twig 1.x, ``Twig_Template::getEnvironment()`` and
   ``Twig_TemplateInterface::getEnvironment()`` are deprecated and will be

--- a/lib/Twig/Cache/Filesystem.php
+++ b/lib/Twig/Cache/Filesystem.php
@@ -29,11 +29,11 @@ class Twig_Cache_Filesystem implements Twig_CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function generateKey($className, $prefix)
+    public function generateKey($name, $className)
     {
-        $class = substr($className, strlen($prefix));
+        $hash = hash('sha256', $className);
 
-        return $this->directory.'/'.$class[0].'/'.$class[1].'/'.$class.'.php';
+        return $this->directory.'/'.$hash[0].'/'.$hash[1].'/'.$hash.'.php';
     }
 
     /**

--- a/lib/Twig/Cache/Null.php
+++ b/lib/Twig/Cache/Null.php
@@ -19,7 +19,7 @@ class Twig_Cache_Null implements Twig_CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function generateKey($className, $prefix)
+    public function generateKey($name, $className)
     {
         return '';
     }

--- a/lib/Twig/CacheInterface.php
+++ b/lib/Twig/CacheInterface.php
@@ -23,12 +23,12 @@ interface Twig_CacheInterface
     /**
      * Generates a cache key for the given template class name.
      *
+     * @param string $name      The template name
      * @param string $className The template class name
-     * @param string $prefix    A template class prefix
      *
      * @return string
      */
-    public function generateKey($className, $prefix);
+    public function generateKey($name, $className);
 
     /**
      * Checks if the cache key exists.

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -283,7 +283,7 @@ class Twig_Environment
     {
         @trigger_error(sprintf('The %s method is deprecated and will be removed in Twig 2.0.', __METHOD__), E_USER_DEPRECATED);
 
-        $key = $this->cache->generateKey($this->getTemplateClass($name), $this->templateClassPrefix);
+        $key = $this->cache->generateKey($name, $this->getTemplateClass($name));
 
         return !$key ? false : $key;
     }
@@ -370,7 +370,7 @@ class Twig_Environment
             if ($this->bcGetCacheFilename) {
                 $key = $this->getCacheFilename($name);
             } else {
-                $key = $this->cache->generateKey($cls, $this->templateClassPrefix);
+                $key = $this->cache->generateKey($name, $cls);
             }
 
             if (!$this->cache->has($key) || ($this->isAutoReload() && !$this->isTemplateFresh($name, $this->cache->getTimestamp($key)))) {

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -305,9 +305,13 @@ class Twig_Environment
      * Gets the template class prefix.
      *
      * @return string The template class prefix
+     *
+     * @deprecated since 1.22 (to be removed in 2.0)
      */
     public function getTemplateClassPrefix()
     {
+        @trigger_error(sprintf('The %s method is deprecated and will be removed in Twig 2.0.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->templateClassPrefix;
     }
 

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -156,7 +156,7 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         // force compilation
         $twig = new Twig_Environment($loader = new Twig_Loader_Array(array('index' => '{{ foo }}')), $options);
 
-        $key = $cache->generateKey($twig->getTemplateClass('index'), $twig->getTemplateClassPrefix());
+        $key = $cache->generateKey('index', $twig->getTemplateClass('index'));
         $cache->write($key, $twig->compileSource('{{ foo }}', 'index'));
 
         // check that extensions won't be initialized when rendering a template that is already in the cache


### PR DESCRIPTION
We now pass the template name and the template class, which seems much better from a UX standpoint.

Passing the prefix was really just a hack and an implementation leak to be able to determine the variable part of the class name and generate sub-directories for templates. Now, we generate the cache key by taking the last characters instead of the first ones, to avoid the need for the class prefix.

That should also make Drupal happy :)
