### PR TITLE
added enabled extension names in the generated template class names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.22.0 (2015-XX-XX)
 
+ * changed template cache names to take into account enabled extensions
  * deprecated Twig_Environment::clearCacheFiles(), Twig_Environment::getCacheFilename(),
    and Twig_Environment::writeCacheFile()
  * added a way to override the filesystem template cache system

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -298,7 +298,9 @@ class Twig_Environment
      */
     public function getTemplateClass($name, $index = null)
     {
-        return $this->templateClassPrefix.hash('sha256', $this->getLoader()->getCacheKey($name)).(null === $index ? '' : '_'.$index);
+        $key = $this->getLoader()->getCacheKey($name).'__'.implode('__', array_keys($this->extensions));
+
+        return $this->templateClassPrefix.hash('sha256', $key).(null === $index ? '' : '_'.$index);
     }
 
     /**

--- a/test/Twig/Tests/Node/ModuleTest.php
+++ b/test/Twig/Tests/Node/ModuleTest.php
@@ -46,7 +46,7 @@ class Twig_Tests_Node_ModuleTest extends Twig_Test_NodeTestCase
 <?php
 
 /* foo.twig */
-class __TwigTemplate_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 extends Twig_Template
+class __TwigTemplate_5b706c6f89df245f237e41d0b65b7019c02dcd93c31ba69e652ac1da78575a09 extends Twig_Template
 {
     public function __construct(Twig_Environment \$env)
     {
@@ -87,7 +87,7 @@ EOF
 <?php
 
 /* foo.twig */
-class __TwigTemplate_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 extends Twig_Template
+class __TwigTemplate_5b706c6f89df245f237e41d0b65b7019c02dcd93c31ba69e652ac1da78575a09 extends Twig_Template
 {
     public function __construct(Twig_Environment \$env)
     {
@@ -144,7 +144,7 @@ EOF
 <?php
 
 /* foo.twig */
-class __TwigTemplate_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 extends Twig_Template
+class __TwigTemplate_5b706c6f89df245f237e41d0b65b7019c02dcd93c31ba69e652ac1da78575a09 extends Twig_Template
 {
     protected function doGetParent(array \$context)
     {


### PR DESCRIPTION
The generated template class names now take into account enabled extensions.

fixes #1742

