### PR TITLE
Profiler root duration fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.22.0 (2015-XX-XX)
 
+ * fixed the profiler duration for the root node
  * deprecated Twig_Environment::clearCacheFiles(), Twig_Environment::getCacheFilename(),
    and Twig_Environment::writeCacheFile()
  * added a way to override the filesystem template cache system

--- a/lib/Twig/Profiler/Profile.php
+++ b/lib/Twig/Profiler/Profile.php
@@ -86,6 +86,16 @@ class Twig_Profiler_Profile implements IteratorAggregate, Serializable
      */
     public function getDuration()
     {
+        if ($this->isRoot() && $this->profiles) {
+            // for the root node with children, duration is the sum of all child durations
+            $duration = 0;
+            foreach ($this->profiles as $profile) {
+                $duration += $profile->getDuration();
+            }
+
+            return $duration;
+        }
+
         return isset($this->ends['wt']) && isset($this->starts['wt']) ? $this->ends['wt'] - $this->starts['wt'] : 0;
     }
 


### PR DESCRIPTION
When using the Twig profiler, the root node is a bit special and the duration should really be the sum of the children duration. That should fix #1792