### PR TITLE
No need to check modification time when opcache_invalidate

### DIFF
--- a/lib/Twig/Cache/Filesystem.php
+++ b/lib/Twig/Cache/Filesystem.php
@@ -80,9 +80,9 @@ class Twig_Cache_Filesystem implements Twig_CacheInterface
 
             if (self::FORCE_BYTECODE_INVALIDATION == ($this->options & self::FORCE_BYTECODE_INVALIDATION)) {
                 // Compile cached file into bytecode cache
-                if (function_exists('opcache_invalidate') && ini_get('opcache.enable')) {
-                    opcache_invalidate($key);
-                } elseif (function_exists('apc_compile_file') && ini_get('apc.enabled')) {
+                if (function_exists('opcache_invalidate')) {
+                    opcache_invalidate($key, true);
+                } elseif (function_exists('apc_compile_file')) {
                     apc_compile_file($key);
                 }
             }


### PR DESCRIPTION
- We know the file is new
- No need to check if opcache/apc is enabled as these methods will just return false in this case