### PR TITLE
String-cast in template_from_string

### DIFF
--- a/lib/Twig/Extension/StringLoader.php
+++ b/lib/Twig/Extension/StringLoader.php
@@ -37,11 +37,11 @@ class Twig_Extension_StringLoader extends Twig_Extension
  * </pre>
  *
  * @param Twig_Environment $env      A Twig_Environment instance
- * @param string           $template A template as a string
+ * @param string           $template A template as a string or object implementing __toString()
  *
  * @return Twig_Template A Twig_Template instance
  */
 function twig_template_from_string(Twig_Environment $env, $template)
 {
-    return $env->createTemplate($template);
+    return $env->createTemplate((string) $template);
 }


### PR DESCRIPTION
Fixes #1829 caused by https://github.com/twigphp/Twig/pull/1807/files#diff-5e190f538c5c328c7473a5cfd3b7cd95R578

As twig allows many types in twig templates, e.g. array or traversable, we can do the same for string.
But we only take this approach for twig exposed function/filters etc, i.e. template code, but not core code.