### PR TITLE
Non-existing files are not cached by statcache

### DIFF
--- a/lib/Twig/Cache/Filesystem.php
+++ b/lib/Twig/Cache/Filesystem.php
@@ -64,11 +64,8 @@ class Twig_Cache_Filesystem implements Twig_CacheInterface
     {
         $dir = dirname($key);
         if (!is_dir($dir)) {
-            if (false === @mkdir($dir, 0777, true)) {
-                clearstatcache(false, $dir);
-                if (!is_dir($dir)) {
-                    throw new RuntimeException(sprintf('Unable to create the cache directory (%s).', $dir));
-                }
+            if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
+                throw new RuntimeException(sprintf('Unable to create the cache directory (%s).', $dir));
             }
         } elseif (!is_writable($dir)) {
             throw new RuntimeException(sprintf('Unable to write in the cache directory (%s).', $dir));


### PR DESCRIPTION
Reverts #1583

Based on the docs this cannot happen because the stat cache is only active for existing files.

> You should also note that PHP doesn't cache information about non-existent files. So, if you call file_exists() on a file that doesn't exist, it will return FALSE until you create the file. If you create the file, it will return TRUE even if you then delete the file. However unlink() clears the cache automatically.

http://php.net/manual/en/function.clearstatcache.php

Also the arugments you pass to clearstatcache(false, $filename) make no sense according the documentation and are not effective.

> filename
Clear the realpath and the stat cache for a specific filename only; only used if clear_realpath_cache is TRUE.

Also doctrine cachee does't use this approach either: https://github.com/doctrine/cache/blob/master/lib/Doctrine/Common/Cache/FileCache.php#L185 And nobody reported problems with this as far as I can see.