### PR TITLE
use is_file instead of error suppression operator

### DIFF
--- a/lib/Twig/Cache/Filesystem.php
+++ b/lib/Twig/Cache/Filesystem.php
@@ -87,6 +87,6 @@ class Twig_Cache_Filesystem implements Twig_CacheInterface
      */
     public function getTimestamp($key)
     {
-        return (int) @filemtime($key);
+        return is_file($key) ? filemtime($key) : 0;
     }
 }


### PR DESCRIPTION
I am not 100% sure if changing this was intended in #1840 and related to race condition or accidental.

We were using custom error handler and ignored this part of php doc:

> If you have set a custom error handler function with set_error_handler() then it will still get called, but this custom error handler can (and should) call error_reporting() which will return 0 when the call that triggered the error was preceded by an @.

So we hit issues after this changed.
Of course we fixed our error handler but afaik "@" should be avoided when it does not have a good reason.

So, unless there is a reason, please pull this in coz i want to be famous.