### PR TITLE
fix template class name generation to prevent possible collisions

### DIFF
--- a/lib/Twig/Cache/Filesystem.php
+++ b/lib/Twig/Cache/Filesystem.php
@@ -38,7 +38,7 @@ class Twig_Cache_Filesystem implements Twig_CacheInterface
     {
         $hash = hash('sha256', $className);
 
-        return $this->directory.'/'.$hash[0].'/'.$hash[1].'/'.$hash.'.php';
+        return $this->directory.'/'.$hash[0].$hash[1].'/'.$hash.'.php';
     }
 
     /**

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -297,18 +297,16 @@ class Twig_Environment
      *  * The currently enabled extensions;
      *  * Whether the Twig C extension is available or not.
      *
-     * @param string $name  The name for which to calculate the template class name
-     * @param int    $index The index if it is an embedded template
+     * @param string   $name  The name for which to calculate the template class name
+     * @param int|null $index The index if it is an embedded template
      *
      * @return string The template class name
      */
     public function getTemplateClass($name, $index = null)
     {
-        $key = $this->getLoader()->getCacheKey($name).'__'.implode('__', array_keys($this->extensions));
-
-        if (function_exists('twig_template_get_attributes')) {
-            $key .= '__cext';
-        }
+        $key = $this->getLoader()->getCacheKey($name);
+        $key .= json_encode(array_keys($this->extensions));
+        $key .= function_exists('twig_template_get_attributes');
 
         return $this->templateClassPrefix.hash('sha256', $key).(null === $index ? '' : '_'.$index);
     }

--- a/lib/Twig/Test/NodeTestCase.php
+++ b/lib/Twig/Test/NodeTestCase.php
@@ -25,7 +25,7 @@ abstract class Twig_Test_NodeTestCase extends PHPUnit_Framework_TestCase
         $compiler = $this->getCompiler($environment);
         $compiler->compile($node);
 
-        $this->assertEquals($source, trim($compiler->getSource()));
+        $this->assertStringMatchesFormat($source, trim($compiler->getSource()));
     }
 
     protected function getCompiler(Twig_Environment $environment = null)

--- a/test/Twig/Tests/Node/ModuleTest.php
+++ b/test/Twig/Tests/Node/ModuleTest.php
@@ -46,7 +46,7 @@ class Twig_Tests_Node_ModuleTest extends Twig_Test_NodeTestCase
 <?php
 
 /* foo.twig */
-class __TwigTemplate_5b706c6f89df245f237e41d0b65b7019c02dcd93c31ba69e652ac1da78575a09 extends Twig_Template
+class __TwigTemplate_%x extends Twig_Template
 {
     public function __construct(Twig_Environment \$env)
     {
@@ -87,7 +87,7 @@ EOF
 <?php
 
 /* foo.twig */
-class __TwigTemplate_5b706c6f89df245f237e41d0b65b7019c02dcd93c31ba69e652ac1da78575a09 extends Twig_Template
+class __TwigTemplate_%x extends Twig_Template
 {
     public function __construct(Twig_Environment \$env)
     {
@@ -144,7 +144,7 @@ EOF
 <?php
 
 /* foo.twig */
-class __TwigTemplate_5b706c6f89df245f237e41d0b65b7019c02dcd93c31ba69e652ac1da78575a09 extends Twig_Template
+class __TwigTemplate_%x extends Twig_Template
 {
     protected function doGetParent(array \$context)
     {


### PR DESCRIPTION
- fix template class name generation to prevent possible collisions
- save one inode per file
- fix tests as they are broken with the cext since #1844