### PR TITLE
Remove deprecated return types from the PHPDocs.

### DIFF
--- a/lib/Twig/Extension.php
+++ b/lib/Twig/Extension.php
@@ -24,7 +24,7 @@ abstract class Twig_Extension implements Twig_ExtensionInterface
     /**
      * Returns the token parser instances to add to the existing list.
      *
-     * @return array An array of Twig_TokenParserInterface or Twig_TokenParserBrokerInterface instances
+     * @return Twig_TokenParserInterface[]
      */
     public function getTokenParsers()
     {
@@ -44,7 +44,7 @@ abstract class Twig_Extension implements Twig_ExtensionInterface
     /**
      * Returns a list of filters to add to the existing list.
      *
-     * @return array An array of filters
+     * @return Twig_SimpleFilter[]
      */
     public function getFilters()
     {
@@ -54,7 +54,7 @@ abstract class Twig_Extension implements Twig_ExtensionInterface
     /**
      * Returns a list of tests to add to the existing list.
      *
-     * @return array An array of tests
+     * @return Twig_SimpleTest[]
      */
     public function getTests()
     {
@@ -64,7 +64,7 @@ abstract class Twig_Extension implements Twig_ExtensionInterface
     /**
      * Returns a list of functions to add to the existing list.
      *
-     * @return array An array of functions
+     * @return Twig_SimpleFunction[]
      */
     public function getFunctions()
     {

--- a/lib/Twig/ExtensionInterface.php
+++ b/lib/Twig/ExtensionInterface.php
@@ -28,7 +28,7 @@ interface Twig_ExtensionInterface
     /**
      * Returns the token parser instances to add to the existing list.
      *
-     * @return array An array of Twig_TokenParserInterface or Twig_TokenParserBrokerInterface instances
+     * @return Twig_TokenParserInterface[]
      */
     public function getTokenParsers();
 
@@ -42,21 +42,21 @@ interface Twig_ExtensionInterface
     /**
      * Returns a list of filters to add to the existing list.
      *
-     * @return array An array of filters
+     * @return Twig_SimpleFilter[]
      */
     public function getFilters();
 
     /**
      * Returns a list of tests to add to the existing list.
      *
-     * @return array An array of tests
+     * @return Twig_SimpleTest[]
      */
     public function getTests();
 
     /**
      * Returns a list of functions to add to the existing list.
      *
-     * @return array An array of functions
+     * @return Twig_SimpleFunction[]
      */
     public function getFunctions();
 


### PR DESCRIPTION
There are deprecation warnings added to the environment (for example https://github.com/twigphp/Twig/blob/1.x/lib/Twig/Environment.php#L1287).

This PR aims to remove the deprecated return types from the PHPDocs as well. It will be useful for developers, but for for IDE's/SCA as well.