### PR TITLE
Checking sandbox for ArrayAccess

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -466,6 +466,10 @@ abstract class Twig_Template implements Twig_TemplateInterface
                     return true;
                 }
 
+                if ($object instanceof ArrayAccess && $this->env->hasExtension('sandbox')) {
+                    $this->env->getExtension('sandbox')->checkMethodAllowed($object, 'offsetGet');
+                }
+
                 return $object[$arrayItem];
             }
 

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -123,6 +123,8 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
             array(new Twig_TemplatePropertyObject(), 'defined', true, false),
             array(new Twig_TemplateMethodObject(), 'defined', false, false),
             array(new Twig_TemplateMethodObject(), 'defined', true, false),
+            array(new Twig_TemplateArrayAccessObject(), 'defined', false, false),
+            array(new Twig_TemplateArrayAccessObject(), 'defined', true, false),
         );
 
         if (function_exists('twig_template_get_attributes')) {


### PR DESCRIPTION
Fixes #106

Allows this to be prevented in sandbox:

``` twig
{{ app.secret_key }} {# app is \Pimple #}
```
