### PR TITLE
[Performance] Added a cache for extension freshness test

### DIFF
--- a/test/Twig/Tests/Cache/FilesystemTest.php
+++ b/test/Twig/Tests/Cache/FilesystemTest.php
@@ -11,12 +11,12 @@
 
 class Twig_Tests_Cache_FilesystemTest extends PHPUnit_Framework_TestCase
 {
-    protected $nonce;
-    protected $classname;
-    protected $directory;
-    protected $cache;
+    private $nonce;
+    private $classname;
+    private $directory;
+    private $cache;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->nonce = hash('sha256', uniqid(mt_rand(), true));
         $this->classname = '__Twig_Tests_Cache_FilesystemTest_Template_'.$this->nonce;
@@ -24,7 +24,7 @@ class Twig_Tests_Cache_FilesystemTest extends PHPUnit_Framework_TestCase
         $this->cache = new Twig_Cache_Filesystem($this->directory);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         if (file_exists($this->directory)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->directory), RecursiveIteratorIterator::CHILD_FIRST);
@@ -48,7 +48,6 @@ class Twig_Tests_Cache_FilesystemTest extends PHPUnit_Framework_TestCase
         $dir = dirname($key);
         @mkdir($dir, 0777, true);
         $this->assertTrue(is_dir($dir));
-
         $this->assertFalse(class_exists($this->classname, false));
 
         $content = $this->generateSource();

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -180,13 +180,12 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
 
     public function testAutoReloadCacheMiss()
     {
-        $template_name = __FUNCTION__;
-        $template_content = __FUNCTION__;
+        $templateName = __FUNCTION__;
+        $templateContent = __FUNCTION__;
 
         $cache = $this->getMock('Twig_CacheInterface');
-        $loader = $this->getMockLoader($template_name, $template_content);
-        $options = array('cache' => $cache, 'auto_reload' => true, 'debug' => false);
-        $twig = new Twig_Environment($loader, $options);
+        $loader = $this->getMockLoader($templateName, $templateContent);
+        $twig = new Twig_Environment($loader, array('cache' => $cache, 'auto_reload' => true, 'debug' => false));
 
         // Cache miss: getTimestamp returns 0 and as a result the load() is
         // skipped.
@@ -201,18 +200,17 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $cache->expects($this->never())
             ->method('load');
 
-        $twig->loadTemplate($template_name);
+        $twig->loadTemplate($templateName);
     }
 
     public function testAutoReloadCacheHit()
     {
-        $template_name = __FUNCTION__;
-        $template_content = __FUNCTION__;
+        $templateName = __FUNCTION__;
+        $templateContent = __FUNCTION__;
 
         $cache = $this->getMock('Twig_CacheInterface');
-        $loader = $this->getMockLoader($template_name, $template_content);
-        $options = array('cache' => $cache, 'auto_reload' => true, 'debug' => false);
-        $twig = new Twig_Environment($loader, $options);
+        $loader = $this->getMockLoader($templateName, $templateContent);
+        $twig = new Twig_Environment($loader, array('cache' => $cache, 'auto_reload' => true, 'debug' => false));
 
         $now = time();
 
@@ -230,18 +228,17 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $cache->expects($this->once())
             ->method('load');
 
-        $twig->loadTemplate($template_name);
+        $twig->loadTemplate($templateName);
     }
 
     public function testAutoReloadOutdatedCacheHit()
     {
-        $template_name = __FUNCTION__;
-        $template_content = __FUNCTION__;
+        $templateName = __FUNCTION__;
+        $templateContent = __FUNCTION__;
 
         $cache = $this->getMock('Twig_CacheInterface');
-        $loader = $this->getMockLoader($template_name, $template_content);
-        $options = array('cache' => $cache, 'auto_reload' => true, 'debug' => false);
-        $twig = new Twig_Environment($loader, $options);
+        $loader = $this->getMockLoader($templateName, $templateContent);
+        $twig = new Twig_Environment($loader, array('cache' => $cache, 'auto_reload' => true, 'debug' => false));
 
         $now = time();
 
@@ -257,7 +254,7 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $cache->expects($this->never())
             ->method('load');
 
-        $twig->loadTemplate($template_name);
+        $twig->loadTemplate($templateName);
     }
 
     public function testAddExtension()
@@ -295,17 +292,17 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $this->assertCount(2, $twig->getNodeVisitors());
     }
 
-    protected function getMockLoader($template_name, $template_content)
+    protected function getMockLoader($templateName, $templateContent)
     {
         $loader = $this->getMock('Twig_LoaderInterface');
         $loader->expects($this->any())
           ->method('getSource')
-          ->with($template_name)
-          ->will($this->returnValue($template_content));
+          ->with($templateName)
+          ->will($this->returnValue($templateContent));
         $loader->expects($this->any())
           ->method('getCacheKey')
-          ->with($template_name)
-          ->will($this->returnValue($template_name));
+          ->with($templateName)
+          ->will($this->returnValue($templateName));
 
         return $loader;
     }


### PR DESCRIPTION
Freshness of each extension was been checked everytime a template was loaded.
Projects with many templates and extension benefit noticeably with this cache.
Only environments with debug or autoload set are affected.