### PR TITLE
Can we use empty() php function for twig_test_empty() to allow "0", "0.0" as well?

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1435,7 +1435,7 @@ function twig_test_empty($value)
         return 0 == count($value);
     }
 
-    return '' === $value || false === $value || null === $value || array() === $value;
+    return empty($value);
 }
 
 /**


### PR DESCRIPTION
Because the fact that {% if var is empty %} not same as <?php if (empty($var)) ?> is confusing...