### PR TITLE
Allow returning of instance instead of arrays for small/simple custom extensions

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -1284,7 +1284,11 @@ class Twig_Environment
     protected function initExtension(Twig_ExtensionInterface $extension)
     {
         // filters
-        foreach ($extension->getFilters() as $name => $filter) {
+        if (is_object(($filters = $extension->getFilters()))) {
+            $filters = array($filters);
+        }
+
+        foreach ($filters as $name => $filter) {
             if ($filter instanceof Twig_SimpleFilter) {
                 $name = $filter->getName();
             } else {
@@ -1295,7 +1299,11 @@ class Twig_Environment
         }
 
         // functions
-        foreach ($extension->getFunctions() as $name => $function) {
+        if (is_object(($functions = $extension->getFunctions()))) {
+            $functions = array($functions);
+        }
+
+        foreach ($functions as $name => $function) {
             if ($function instanceof Twig_SimpleFunction) {
                 $name = $function->getName();
             } else {
@@ -1306,7 +1314,10 @@ class Twig_Environment
         }
 
         // tests
-        foreach ($extension->getTests() as $name => $test) {
+        if (is_object(($tests = $extension->getTests()))) {
+            $tests = array($tests);
+        }
+        foreach ($tests as $name => $test) {
             if ($test instanceof Twig_SimpleTest) {
                 $name = $test->getName();
             } else {
@@ -1317,7 +1328,10 @@ class Twig_Environment
         }
 
         // token parsers
-        foreach ($extension->getTokenParsers() as $parser) {
+        if (is_object(($tokenParsers = $extension->getTokenParsers()))) {
+            $tokenParsers = array($tokenParsers);
+        }
+        foreach ($tokenParsers as $parser) {
             if ($parser instanceof Twig_TokenParserInterface) {
                 $this->parsers->addTokenParser($parser);
             } elseif ($parser instanceof Twig_TokenParserBrokerInterface) {
@@ -1330,7 +1344,10 @@ class Twig_Environment
         }
 
         // node visitors
-        foreach ($extension->getNodeVisitors() as $visitor) {
+        if (is_object(($nodeVisitors = $extension->getNodeVisitors()))) {
+            $nodeVisitors = array($nodeVisitors);
+        }
+        foreach ($nodeVisitors as $visitor) {
             $this->visitors[] = $visitor;
         }
 

--- a/lib/Twig/ExtensionInterface.php
+++ b/lib/Twig/ExtensionInterface.php
@@ -28,35 +28,35 @@ interface Twig_ExtensionInterface
     /**
      * Returns the token parser instances to add to the existing list.
      *
-     * @return Twig_TokenParserInterface[]
+     * @return Twig_TokenParserInterface[]|Twig_TokenParserInterface
      */
     public function getTokenParsers();
 
     /**
      * Returns the node visitor instances to add to the existing list.
      *
-     * @return Twig_NodeVisitorInterface[] An array of Twig_NodeVisitorInterface instances
+     * @return Twig_NodeVisitorInterface[]|Twig_NodeVisitorInterface An array of Twig_NodeVisitorInterface instances
      */
     public function getNodeVisitors();
 
     /**
      * Returns a list of filters to add to the existing list.
      *
-     * @return Twig_SimpleFilter[]
+     * @return Twig_SimpleFilter[]|Twig_SimpleFilter
      */
     public function getFilters();
 
     /**
      * Returns a list of tests to add to the existing list.
      *
-     * @return Twig_SimpleTest[]
+     * @return Twig_SimpleTest[]|Twig_SimpleTest
      */
     public function getTests();
 
     /**
      * Returns a list of functions to add to the existing list.
      *
-     * @return Twig_SimpleFunction[]
+     * @return Twig_SimpleFunction[]|Twig_SimpleFunction
      */
     public function getFunctions();
 

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -312,37 +312,27 @@ class Twig_Tests_EnvironmentTest_Extension extends Twig_Extension
 {
     public function getTokenParsers()
     {
-        return array(
-            new Twig_Tests_EnvironmentTest_TokenParser(),
-        );
+        return new Twig_Tests_EnvironmentTest_TokenParser();
     }
 
     public function getNodeVisitors()
     {
-        return array(
-            new Twig_Tests_EnvironmentTest_NodeVisitor(),
-        );
+        return new Twig_Tests_EnvironmentTest_NodeVisitor();
     }
 
     public function getFilters()
     {
-        return array(
-            new Twig_SimpleFilter('foo_filter', 'foo_filter'),
-        );
+        return new Twig_SimpleFilter('foo_filter', 'foo_filter');
     }
 
     public function getTests()
     {
-        return array(
-            new Twig_SimpleTest('foo_test', 'foo_test'),
-        );
+        return new Twig_SimpleTest('foo_test', 'foo_test');
     }
 
     public function getFunctions()
     {
-        return array(
-            new Twig_SimpleFunction('foo_function', 'foo_function'),
-        );
+        return new Twig_SimpleFunction('foo_function', 'foo_function');
     }
 
     public function getOperators()


### PR DESCRIPTION
Allow the methods `\Twig_Environment::getFilters`, `\Twig_Environment::getFunctions`, `\Twig_Environment::getTests`, `\Twig_Environment::getNodeVisitors` and `\Twig_Environment::getTokenParsers` to return the respective object instance instead of surrounding it in an array.

This is more elegant and intuitive in cases where an extensions is exposing only one filter, function and etc. 