### PR TITLE
marked some Twig_Environment methods as being internal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 * 1.24.1 (2016-XX-XX)
 
- * n/a
+ * marked the following methods as being internals on Twig_Environment: 
+   getFunctions(), getFilters(), getTests(), getFunction(), getFilter(), getTest(),
+   getTokenParsers(), getTags(), getNodeVisitors(), getUnaryOperators(), getBinaryOperators(),
+   getFunctions(), getFilters(), getGlobals(), initGlobals(), initExtensions(), and initExtension()
 
 * 1.24.0 (2016-01-25)
 

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -855,6 +855,8 @@ class Twig_Environment
      * Gets the registered Token Parsers.
      *
      * @return Twig_TokenParserBrokerInterface A broker containing token parsers
+     *
+     * @internal
      */
     public function getTokenParsers()
     {
@@ -871,6 +873,8 @@ class Twig_Environment
      * Be warned that this method cannot return tags defined by Twig_TokenParserBrokerInterface classes.
      *
      * @return Twig_TokenParserInterface[] An array of Twig_TokenParserInterface instances
+     *
+     * @internal
      */
     public function getTags()
     {
@@ -902,6 +906,8 @@ class Twig_Environment
      * Gets the registered Node Visitors.
      *
      * @return Twig_NodeVisitorInterface[] An array of Twig_NodeVisitorInterface instances
+     *
+     * @internal
      */
     public function getNodeVisitors()
     {
@@ -947,6 +953,8 @@ class Twig_Environment
      * @param string $name The filter name
      *
      * @return Twig_Filter|false A Twig_Filter instance or false if the filter does not exist
+     *
+     * @internal
      */
     public function getFilter($name)
     {
@@ -993,6 +1001,8 @@ class Twig_Environment
      * @return Twig_FilterInterface[] An array of Twig_FilterInterface instances
      *
      * @see registerUndefinedFilterCallback
+     *
+     * @internal
      */
     public function getFilters()
     {
@@ -1033,6 +1043,8 @@ class Twig_Environment
      * Gets the registered Tests.
      *
      * @return Twig_TestInterface[] An array of Twig_TestInterface instances
+     *
+     * @internal
      */
     public function getTests()
     {
@@ -1049,6 +1061,8 @@ class Twig_Environment
      * @param string $name The test name
      *
      * @return Twig_Test|false A Twig_Test instance or false if the test does not exist
+     *
+     * @internal
      */
     public function getTest($name)
     {
@@ -1098,6 +1112,8 @@ class Twig_Environment
      * @param string $name function name
      *
      * @return Twig_Function|false A Twig_Function instance or false if the function does not exist
+     *
+     * @internal
      */
     public function getFunction($name)
     {
@@ -1144,6 +1160,8 @@ class Twig_Environment
      * @return Twig_FunctionInterface[] An array of Twig_FunctionInterface instances
      *
      * @see registerUndefinedFunctionCallback
+     *
+     * @internal
      */
     public function getFunctions()
     {
@@ -1189,6 +1207,8 @@ class Twig_Environment
      * Gets the registered Globals.
      *
      * @return array An array of globals
+     *
+     * @internal
      */
     public function getGlobals()
     {
@@ -1227,6 +1247,8 @@ class Twig_Environment
      * Gets the registered unary Operators.
      *
      * @return array An array of unary operators
+     *
+     * @internal
      */
     public function getUnaryOperators()
     {
@@ -1241,6 +1263,8 @@ class Twig_Environment
      * Gets the registered binary Operators.
      *
      * @return array An array of binary operators
+     *
+     * @internal
      */
     public function getBinaryOperators()
     {
@@ -1261,6 +1285,9 @@ class Twig_Environment
         return Twig_Error_Syntax::computeAlternatives($name, $items);
     }
 
+    /**
+     * @internal
+     */
     protected function initGlobals()
     {
         $globals = array();
@@ -1286,6 +1313,9 @@ class Twig_Environment
         return call_user_func_array('array_merge', $globals);
     }
 
+    /**
+     * @internal
+     */
     protected function initExtensions()
     {
         if ($this->extensionInitialized) {
@@ -1307,6 +1337,9 @@ class Twig_Environment
         $this->initExtension($this->staging);
     }
 
+    /**
+     * @internal
+     */
     protected function initExtension(Twig_ExtensionInterface $extension)
     {
         // filters


### PR DESCRIPTION
This PR marks some `Twig_Environment` methods as being internals:
- `getFunctions()`, `getFilters()`, `getTests()`, `getFunction()`, `getFilter()`, `getTest()`, `getTokenParsers()`, `getTags()`, `getNodeVisitors()`, `getUnaryOperators()`, `getBinaryOperators()` because I don't see how they can be used in any useful way and anyway, `getFunctions()` and `getFilters()` do not return all possible functions or filters. Moreover, I think that all this logic could be refactored and moved into its own class for 2.0 (could be done by deprecating those existing methods in 1.x if we agree to merge this PR).
- `getGlobals()` because it should only be called in a runtime context, not in a compilation one (so limiting its usage to internal use only allows for better control of usage).
- `initGlobals()`, `initExtensions()`, `initExtension()` because they are private in Twig 2.0.
