### PR TITLE
fixed Twig_Extension_GlobalsInterface name in comments

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -605,7 +605,7 @@ An extension is a class that implements the following interface::
          *
          * @return array An array of global variables
          *
-         * @deprecated since 1.23 (to be removed in 2.0), implement Twig_Extension_GlobalsProviderInterace instead
+         * @deprecated since 1.23 (to be removed in 2.0), implement Twig_Extension_GlobalsInterface instead
          */
         function getGlobals();
 

--- a/lib/Twig/Extension.php
+++ b/lib/Twig/Extension.php
@@ -70,7 +70,7 @@ abstract class Twig_Extension implements Twig_ExtensionInterface
     /**
      * {@inheritdoc}
      *
-     * @deprecated since 1.23 (to be removed in 2.0), implement Twig_Extension_GlobalsProviderInterace instead
+     * @deprecated since 1.23 (to be removed in 2.0), implement Twig_Extension_GlobalsInterface instead
      */
     public function getGlobals()
     {

--- a/lib/Twig/ExtensionInterface.php
+++ b/lib/Twig/ExtensionInterface.php
@@ -74,7 +74,7 @@ interface Twig_ExtensionInterface
      *
      * @return array An array of global variables
      *
-     * @deprecated since 1.23 (to be removed in 2.0), implement Twig_Extension_GlobalsProviderInterace instead
+     * @deprecated since 1.23 (to be removed in 2.0), implement Twig_Extension_GlobalsInterface instead
      */
     public function getGlobals();
 


### PR DESCRIPTION
It looks like renaming `Twig_Extension_GlobalsProviderInterace` to `Twig_Extension_GlobalsInterface` was done only partially while working on #1897.