### PR TITLE
Fix "name" variable undefined in deprecated method

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -736,7 +736,7 @@ class Twig_Environment
             if (!$extension instanceof Twig_Extension_InitRuntimeInterface) {
                 $m = new ReflectionMethod($extension, 'initRuntime');
 
-                if ('Twig_Extension' !== $m->getDeclaringClass()->getName()) {
+                if ('Twig_Extension' !== $name = $m->getDeclaringClass()->getName()) {
                     @trigger_error(sprintf('Defining the initRuntime() method in an extension is deprecated. Use the `needs_environment` option to get the Twig_Environment instance in filters, functions, or tests; or explicitly implement Twig_Extension_InitRuntimeInterface if needed (not recommended).', $name), E_USER_DEPRECATED);
                 }
             }

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -736,8 +736,8 @@ class Twig_Environment
             if (!$extension instanceof Twig_Extension_InitRuntimeInterface) {
                 $m = new ReflectionMethod($extension, 'initRuntime');
 
-                if ('Twig_Extension' !== $name = $m->getDeclaringClass()->getName()) {
-                    @trigger_error(sprintf('Defining the initRuntime() method in an extension is deprecated. Use the `needs_environment` option to get the Twig_Environment instance in filters, functions, or tests; or explicitly implement Twig_Extension_InitRuntimeInterface if needed (not recommended).', $name), E_USER_DEPRECATED);
+                if ('Twig_Extension' !== $m->getDeclaringClass()->getName()) {
+                    @trigger_error('Defining the initRuntime() method in an extension is deprecated. Use the `needs_environment` option to get the Twig_Environment instance in filters, functions, or tests; or explicitly implement Twig_Extension_InitRuntimeInterface if needed (not recommended).', E_USER_DEPRECATED);
                 }
             }
 


### PR DESCRIPTION
Variable "name" is not defined in deprecated method "initRuntime". Patch should fix it.