### PR TITLE
Added skipping empty paths

### DIFF
--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -89,7 +89,9 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
     {
         // invalidate the cache
         $this->cache = $this->errorCache = array();
-
+        if ($path === null) {
+            return;
+        }
         if (!is_dir($path)) {
             throw new Twig_Error_Loader(sprintf('The "%s" directory does not exist.', $path));
         }


### PR DESCRIPTION
```php
<?php
class Foo {
protected $twig;
public function __construct($otherDir = null) {
        $this->twig = new \Twig_Environment(
            new \Twig_Loader_Filesystem([
                $otherDir,
                dirname(__DIR__).'/Templates'
            ])
        );
    }
}

$foo = new Foo();
$foo->.....
$foo2 = new Foo('call directory');
$foo2->...

before:  //The "" directory does not exist.
after: ....
```