### PR TITLE
[DOC] Fixed typos in advanced.rst

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -541,7 +541,7 @@ An extension is a class that implements the following interface::
          *
          * @param Twig_Environment $environment The current Twig_Environment instance
          *
-         * @deprecated since 1.23 (to be removed in 2.0), implement Twig_Extension_InitRuntimeInterace instead
+         * @deprecated since 1.23 (to be removed in 2.0), implement Twig_Extension_InitRuntimeInterface instead
          */
         public function initRuntime(Twig_Environment $environment);
 
@@ -592,7 +592,7 @@ An extension is a class that implements the following interface::
          *
          * @return array An array of global variables
          *
-         * @deprecated since 1.23 (to be removed in 2.0), implement Twig_Extension_GlobalsProviderInterace instead
+         * @deprecated since 1.23 (to be removed in 2.0), implement Twig_Extension_GlobalsProviderInterface instead
          */
         public function getGlobals();
 


### PR DESCRIPTION
Hey,

there are two typos of `Interace`. Although it sounds cool, `Interface` works better for copy and paste.

Cheers
Matthais