### PR TITLE
Fix Parser context push on stack

### DIFF
--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -63,16 +63,14 @@ class Twig_Parser implements Twig_ParserInterface
     public function parse(Twig_TokenStream $stream, $test = null, $dropNeedle = false)
     {
         // push all variables into the stack to keep the current state of the parser
-        $vars = get_object_vars($this);
-        unset($vars['stack'], $vars['env'], $vars['handlers'], $vars['visitors'], $vars['expressionParser'], $vars['reservedMacroNames']);
-
-        // copy all references (that still points to a "$this property")
-        $varsCopy = array();
-        foreach ($vars as $key => $value) {
-            $varsCopy[$key] = $value;
+        // using get_object_vars() instead of foreach would lead to https://bugs.php.net/71336
+        $vars = array();
+        foreach ($this as $k => $v) {
+            $vars[$k] = $v;
         }
 
-        $this->stack[] = $varsCopy;
+        unset($vars['stack'], $vars['env'], $vars['handlers'], $vars['visitors'], $vars['expressionParser'], $vars['reservedMacroNames']);
+        $this->stack[] = $vars;
 
         // tag handlers
         if (null === $this->handlers) {

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -65,7 +65,14 @@ class Twig_Parser implements Twig_ParserInterface
         // push all variables into the stack to keep the current state of the parser
         $vars = get_object_vars($this);
         unset($vars['stack'], $vars['env'], $vars['handlers'], $vars['visitors'], $vars['expressionParser'], $vars['reservedMacroNames']);
-        $this->stack[] = $vars;
+
+        // copy all references (that still points to a "$this property")
+        $varsCopy = array();
+        foreach ($vars as $key => $value) {
+            $varsCopy[$key] = $value;
+        }
+
+        $this->stack[] = $varsCopy;
 
         // tag handlers
         if (null === $this->handlers) {

--- a/test/Twig/Tests/Fixtures/tags/embed/with_extends.test
+++ b/test/Twig/Tests/Fixtures/tags/embed/with_extends.test
@@ -17,6 +17,7 @@
             block1extended
         {% endblock %}
     {% endembed %}
+    {{ parent() }}
 {% endblock %}
 --TEMPLATE(base.twig)--
 A
@@ -54,4 +55,6 @@ A
             block1extended
         B
     block2
-CB
+C        blockc2base
+
+B


### PR DESCRIPTION
Hello,

With php7RC8, in Twig_Parser, parse method starts by saving current context in
copying self properties on stack. It sounds like get_object_vars returns now
references instead of copies of properties (at least for arrays). Consequently,
when reinitializing Parser for subparse line 92 to 99, the preserved context on
stack was also erased.

As a result, when calling {{ parent() }} after a {%embed%}{%endembed%}, the restored blockStack being empty, Twig throws a Twig_Error_Syntax('Calling "parent" outside a block is forbidden.'), despite the fact it is really in a block that extends another. 
When calling {{ parent() }} before  the embed tag, all works properly. (It seems that the empty context, resulting of subparses, is not a problem as far as you don't need to access it)