### PR TITLE
Activated template cache check with isAutoReload (auto_reload = false)

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -388,7 +388,7 @@ class Twig_Environment
                 $key = $this->cache->generateKey($name, $cls);
             }
 
-            if (!$this->isAutoReload() || $this->isTemplateFresh($name, $this->cache->getTimestamp($key))) {
+            if (!$this->isAutoReload() && $this->isTemplateFresh($name, $this->cache->getTimestamp($key))) {
                 $this->cache->load($key);
             }
 


### PR DESCRIPTION
Noticed that twig crashes with auto_reload disabled while trying to render templates from cache that are not cached yet. Here is some workaround.