### PR TITLE
Changed initialization and default value of auto_reload setting

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -95,9 +95,9 @@ The following options are available:
 * ``auto_reload`` *boolean*
 
   When developing with Twig, it's useful to recompile the
-  template whenever the source code changes. If you don't provide a value for
-  the ``auto_reload`` option, it will be determined automatically based on the
-  ``debug`` value.
+  template whenever the source code changes. If ``debug`` is set to ``true`` 
+  value of ``auto_reload`` will also be ``true``. Otherwise it's configurable 
+  (default to ``true``).
 
 * ``strict_variables`` *boolean*
 

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -103,14 +103,14 @@ class Twig_Environment
             'strict_variables' => false,
             'autoescape' => 'html',
             'cache' => false,
-            'auto_reload' => null,
+            'auto_reload' => true,
             'optimizations' => -1,
         ), $options);
 
         $this->debug = (bool) $options['debug'];
         $this->charset = strtoupper($options['charset']);
         $this->baseTemplateClass = $options['base_template_class'];
-        $this->autoReload = null === $options['auto_reload'] ? $this->debug : (bool) $options['auto_reload'];
+        $this->autoReload = !$options['auto_reload'] ? $this->debug : true;
         $this->strictVariables = (bool) $options['strict_variables'];
         $this->setCache($options['cache']);
 


### PR DESCRIPTION
Fixing error during template rendering when:
* debug set to false
* cache directory defined and empty
* auto_reload not defined

Making auto_reload always enabled during debug is enabled.