### PR TITLE
Ensure the template passed to createTemplate is always a string

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -426,7 +426,8 @@ class Twig_Environment
     public function createTemplate($template)
     {
         $name = sprintf('__string_template__%s', hash('sha256', uniqid(mt_rand(), true), false));
-
+        $template = (string) $template;
+        
         $loader = new Twig_Loader_Chain(array(
             new Twig_Loader_Array(array($name => $template)),
             $current = $this->getLoader(),


### PR DESCRIPTION
If you pass `null` to createTemplate you end up with an error like Template "__string_template__6d8f7c778df0b84ad07aa37e18f237bd84beee3d268093cb88941253f539b3a2" is not defined.

In general `null` does not make sense as template, but as in my use case it can happen when you try to validate dynamic templates, e.g. based on input from the form component. 

Either we throw an Exception which states that null as a template is not allowed or we cast it as propesed by this PR.

- fixes #1892 