### PR TITLE
Reintroduce Twig_TemplateInterface, since it should be removed only in 3.0

### DIFF
--- a/lib/Twig/TemplateInterface.php
+++ b/lib/Twig/TemplateInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Interface implemented by all compiled templates.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since 1.12 (to be removed in 3.0)
+ */
+interface Twig_TemplateInterface
+{
+    const ANY_CALL = 'any';
+    const ARRAY_CALL = 'array';
+    const METHOD_CALL = 'method';
+
+    /**
+     * Renders the template with the given context and returns it as string.
+     *
+     * @param array $context An array of parameters to pass to the template
+     *
+     * @return string The rendered template
+     */
+    public function render(array $context);
+
+    /**
+     * Displays the template with the given context.
+     *
+     * @param array $context An array of parameters to pass to the template
+     * @param array $blocks  An array of blocks to pass to the template
+     */
+    public function display(array $context, array $blocks = array());
+
+    /**
+     * Returns the bound environment for this template.
+     *
+     * @return Twig_Environment The current environment
+     */
+    public function getEnvironment();
+}


### PR DESCRIPTION
As mentioned in https://github.com/twigphp/Twig/issues/1914, docs say this interface should be removed in 3.0, and not in 2.0