### PR TITLE
DisplayCallGraphTemplate: a visual way to debug templates and blocks

### DIFF
--- a/lib/Twig/Template/DisplayCallGraphTemplate.php
+++ b/lib/Twig/Template/DisplayCallGraphTemplate.php
@@ -16,10 +16,10 @@
  */
 abstract class Twig_Template_DisplayCallGraphTemplate extends Twig_Template
 {
-    private $templateStart = '<div style="border: 1px solid rgba(240, 181, 24, 0.3); margin: 5px;"><span style="background-color: rgba(240, 181, 24, 0.3); color: black; font-family: monospace;">Template "%s"</span>';
-    private $templateEnd = '</div>';
-    private $blockStart = '<div style="border: 1px solid rgba(100, 189, 99, 0.2); margin: 5px;"><span style="background-color: rgba(100, 189, 99, 0.2); color: black; font-family: monospace;">Block "%s"</span>';
-    private $blockEnd = '</div>';
+    protected $templateStart = '<div style="border: 1px solid rgba(240, 181, 24, 0.3); margin: 5px;"><span style="background-color: rgba(240, 181, 24, 0.3); color: black; font-family: monospace;">Template "%s"</span>';
+    protected $templateEnd = '</div>';
+    protected $blockStart = '<div style="border: 1px solid rgba(100, 189, 99, 0.2); margin: 5px;"><span style="background-color: rgba(100, 189, 99, 0.2); color: black; font-family: monospace;">Block "%s"</span>';
+    protected $blockEnd = '</div>';
 
     /**
      * @var string[]

--- a/lib/Twig/Template/DisplayCallGraphTemplate.php
+++ b/lib/Twig/Template/DisplayCallGraphTemplate.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2010 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Displays the call graph (templates names and block names) in a visual way directly in the generated HTML.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+abstract class Twig_Template_DisplayCallGraphTemplate extends Twig_Template
+{
+    private $templateStart = '<div style="border: 1px solid rgba(240, 181, 24, 0.3); margin: 5px;"><span style="background-color: rgba(240, 181, 24, 0.3); color: black; font-family: monospace;">Template "%s"</span>';
+    private $templateEnd = '</div>';
+    private $blockStart = '<div style="border: 1px solid rgba(100, 189, 99, 0.2); margin: 5px;"><span style="background-color: rgba(100, 189, 99, 0.2); color: black; font-family: monospace;">Block "%s"</span>';
+    private $blockEnd = '</div>';
+
+    /**
+     * @var string[]
+     */
+    protected $templateBlackList = array(
+        '@WebProfiler',
+        '@Security',
+        '@Doctrine',
+        '@Swiftmailer',
+        '@Debug',
+    );
+
+    /**
+     * @var string[]
+     */
+    protected $blockBlackList = array(
+        'toolbar',
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function display(array $context, array $blocks = array())
+    {
+        if (!$this->isTemplateEnabled()) {
+            parent::display($context, $blocks);
+
+            return;
+        }
+
+        echo sprintf($this->templateStart, htmlspecialchars($this->getTemplateName()));
+        parent::display($context, $blocks);
+        echo $this->templateEnd;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function displayBlock($name, array $context, array $blocks = array(), $useBlocks = true)
+    {
+        if (!$this->isTemplateEnabled() || !$this->isBlockEnabled($name)) {
+            parent::displayBlock($name, $context, $blocks, $useBlocks);
+
+            return;
+        }
+
+        echo sprintf($this->blockStart, htmlspecialchars($name));
+        parent::displayBlock($name, $context, $blocks, $useBlocks);
+        echo $this->blockEnd;
+    }
+
+    /**
+     * Checks if the call graph must be displayed for this template.
+     *
+     * @return bool
+     */
+    protected function isTemplateEnabled()
+    {
+        foreach ($this->templateBlackList as $prefix) {
+            if (false !== strpos($this->getTemplateName(), $prefix)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks if the call graph must be displayed for the given block.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    protected function isBlockEnabled($name)
+    {
+        foreach ($this->blockBlackList as $prefix) {
+            if (false !== strpos($name, $prefix)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/lib/Twig/Template/DisplayCallGraphTemplate.php
+++ b/lib/Twig/Template/DisplayCallGraphTemplate.php
@@ -24,20 +24,12 @@ abstract class Twig_Template_DisplayCallGraphTemplate extends Twig_Template
     /**
      * @var string[]
      */
-    protected $templateBlackList = array(
-        '@WebProfiler',
-        '@Security',
-        '@Doctrine',
-        '@Swiftmailer',
-        '@Debug',
-    );
+    protected $templateBlackList = array();
 
     /**
      * @var string[]
      */
-    protected $blockBlackList = array(
-        'toolbar',
-    );
+    protected $blockBlackList = array();
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
A picture is worth a thousand words:

![capture d ecran 2015-12-17 a 16 27 55](https://cloud.githubusercontent.com/assets/57224/11875470/0be621da-a4e5-11e5-881b-b4cc42af37d8.png)

To enable it:

```php
$twig = new Twig_Environment(null, array('base_template_class' => 'Twig_Template_DisplayCallGraphTemplate');
```

Using Symfony:

```yaml
# app/config/config_dev.yml

twig:
    base_template_class: Twig_Template_DisplayCallGraphTemplate
```

The color scheme and the font are the same than in the Symfony Profiler. 

/cc @xavierleune @cssyren