### PR TITLE
skip read-only dir tests on windows and cleanup tmp dirs correctly

### DIFF
--- a/test/Twig/Tests/Cache/FilesystemTest.php
+++ b/test/Twig/Tests/Cache/FilesystemTest.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+require_once dirname(dirname(__FILE__)).'/FilesystemHelper.php';
+
 class Twig_Tests_Cache_FilesystemTest extends PHPUnit_Framework_TestCase
 {
     private $classname;
@@ -26,15 +28,7 @@ class Twig_Tests_Cache_FilesystemTest extends PHPUnit_Framework_TestCase
     protected function tearDown()
     {
         if (file_exists($this->directory)) {
-            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->directory, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST);
-            foreach ($iterator as $filename => $fileInfo) {
-                if ($fileInfo->isDir()) {
-                    rmdir($filename);
-                } else {
-                    unlink($filename);
-                }
-            }
-            rmdir($this->directory);
+            Twig_Tests_FilesystemHelper::removeDir($this->directory);
         }
     }
 

--- a/test/Twig/Tests/Cache/FilesystemTest.php
+++ b/test/Twig/Tests/Cache/FilesystemTest.php
@@ -11,30 +11,27 @@
 
 class Twig_Tests_Cache_FilesystemTest extends PHPUnit_Framework_TestCase
 {
-    private $nonce;
     private $classname;
     private $directory;
     private $cache;
 
     protected function setUp()
     {
-        $this->nonce = hash('sha256', uniqid(mt_rand(), true));
-        $this->classname = '__Twig_Tests_Cache_FilesystemTest_Template_'.$this->nonce;
-        $this->directory = sys_get_temp_dir().'/twig-test-'.$this->nonce;
+        $nonce = hash('sha256', uniqid(mt_rand(), true));
+        $this->classname = '__Twig_Tests_Cache_FilesystemTest_Template_'.$nonce;
+        $this->directory = sys_get_temp_dir().'/twig-test';
         $this->cache = new Twig_Cache_Filesystem($this->directory);
     }
 
     protected function tearDown()
     {
         if (file_exists($this->directory)) {
-            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->directory), RecursiveIteratorIterator::CHILD_FIRST);
+            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->directory, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST);
             foreach ($iterator as $filename => $fileInfo) {
-                if (!$iterator->isDot()) {
-                    if ($fileInfo->isDir()) {
-                        rmdir($filename);
-                    } else {
-                        unlink($filename);
-                    }
+                if ($fileInfo->isDir()) {
+                    rmdir($filename);
+                } else {
+                    unlink($filename);
                 }
             }
             rmdir($this->directory);
@@ -86,10 +83,14 @@ class Twig_Tests_Cache_FilesystemTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessageRegExp #^Unable to create the cache directory #
+     * @expectedExceptionMessage Unable to create the cache directory
      */
     public function testWriteFailMkdir()
     {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Read-only directories not possible on Windows.');
+        }
+
         $key = $this->directory.'/cache/cachefile.php';
         $content = $this->generateSource();
 
@@ -104,10 +105,14 @@ class Twig_Tests_Cache_FilesystemTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessageRegExp #^Unable to write in the cache directory #
+     * @expectedExceptionMessage Unable to write in the cache directory
      */
     public function testWriteFailDirWritable()
     {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Read-only directories not possible on Windows.');
+        }
+
         $key = $this->directory.'/cache/cachefile.php';
         $content = $this->generateSource();
 
@@ -124,7 +129,7 @@ class Twig_Tests_Cache_FilesystemTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessageRegExp #^Failed to write cache file #
+     * @expectedExceptionMessage Failed to write cache file
      */
     public function testWriteFailWriteFile()
     {

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+require_once dirname(__FILE__).'/FilesystemHelper.php';
+
 class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
 {
     private $deprecations = array();
@@ -177,15 +179,7 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $output = $twig->render('index', array('foo' => 'bar'));
         $this->assertEquals('bar', $output);
 
-        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST);
-        foreach ($iterator as $filename => $fileInfo) {
-            if ($fileInfo->isDir()) {
-                rmdir($filename);
-            } else {
-                unlink($filename);
-            }
-        }
-        rmdir($dir);
+        Twig_Tests_FilesystemHelper::removeDir($dir);
     }
 
     public function testAutoReloadCacheMiss()

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -154,8 +154,7 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
 
     public function testExtensionsAreNotInitializedWhenRenderingACompiledTemplate()
     {
-        $uid = function_exists('posix_getuid') ? posix_getuid() : '';
-        $cache = new Twig_Cache_Filesystem($dir = sys_get_temp_dir().'/twig'.$uid);
+        $cache = new Twig_Cache_Filesystem($dir = sys_get_temp_dir().'/twig');
         $options = array('cache' => $cache, 'auto_reload' => false, 'debug' => false);
 
         // force compilation
@@ -178,7 +177,15 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $output = $twig->render('index', array('foo' => 'bar'));
         $this->assertEquals('bar', $output);
 
-        unlink($key);
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST);
+        foreach ($iterator as $filename => $fileInfo) {
+            if ($fileInfo->isDir()) {
+                rmdir($filename);
+            } else {
+                unlink($filename);
+            }
+        }
+        rmdir($dir);
     }
 
     public function testAutoReloadCacheMiss()

--- a/test/Twig/Tests/Extension/SandboxTest.php
+++ b/test/Twig/Tests/Extension/SandboxTest.php
@@ -13,7 +13,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
 {
     protected static $params, $templates;
 
-    public function setUp()
+    protected function setUp()
     {
         self::$params = array(
             'name' => 'Fabien',

--- a/test/Twig/Tests/FileCachingTest.php
+++ b/test/Twig/Tests/FileCachingTest.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+require_once dirname(__FILE__).'/FilesystemHelper.php';
+
 class Twig_Tests_FileCachingTest extends PHPUnit_Framework_TestCase
 {
     private $env;
@@ -30,15 +32,7 @@ class Twig_Tests_FileCachingTest extends PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
-        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->tmpDir, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST);
-        foreach ($iterator as $filename => $fileInfo) {
-            if ($fileInfo->isDir()) {
-                rmdir($filename);
-            } else {
-                unlink($filename);
-            }
-        }
-        rmdir($this->tmpDir);
+        Twig_Tests_FilesystemHelper::removeDir($this->tmpDir);
     }
 
     /**

--- a/test/Twig/Tests/FilesystemHelper.php
+++ b/test/Twig/Tests/FilesystemHelper.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Twig_Tests_FilesystemHelper
+{
+    public static function removeDir($dir)
+    {
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, PHP_VERSION_ID < 50300 ? 0 : FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST);
+        foreach ($iterator as $filename => $fileInfo) {
+            if ($iterator->isDot()) {
+                continue;
+            }
+
+            if ($fileInfo->isDir()) {
+                rmdir($filename);
+            } else {
+                unlink($filename);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/test/Twig/Tests/TokenStreamTest.php
+++ b/test/Twig/Tests/TokenStreamTest.php
@@ -13,7 +13,7 @@ class Twig_Tests_TokenStreamTest extends PHPUnit_Framework_TestCase
 {
     protected static $tokens;
 
-    public function setUp()
+    protected function setUp()
     {
         self::$tokens = array(
             new Twig_Token(Twig_Token::TEXT_TYPE, 1, 1),

--- a/test/Twig/Tests/escapingTest.php
+++ b/test/Twig/Tests/escapingTest.php
@@ -144,7 +144,7 @@ class Twig_Test_EscapingTest extends PHPUnit_Framework_TestCase
 
     protected $env;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->env = new Twig_Environment($this->getMock('Twig_LoaderInterface'));
     }


### PR DESCRIPTION
- fix tests on windows (skipping them as read-only dirs are not possible on windows, only read-only files; read-only attribute on folders (`exec('attrib +R '`) does not prevent files to be created inside them)
- correctly cleanup tmp directories at the end of tests