### PR TITLE
Let PHP convert Twig_Markup to JSON instead of pre-filtering it

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -149,7 +149,7 @@ class Twig_Extension_Core extends Twig_Extension
 
             // encoding
             new Twig_Filter('url_encode', 'twig_urlencode_filter'),
-            new Twig_Filter('json_encode', 'twig_jsonencode_filter'),
+            new Twig_Filter('json_encode', 'json_encode'),
             new Twig_Filter('convert_encoding', 'twig_convert_encoding'),
 
             // string filters
@@ -580,29 +580,6 @@ function twig_urlencode_filter($url)
     }
 
     return rawurlencode($url);
-}
-
-/**
- * JSON encodes a variable.
- *
- * @param mixed $value   The value to encode.
- * @param int   $options Bitmask consisting of JSON_HEX_QUOT, JSON_HEX_TAG, JSON_HEX_AMP, JSON_HEX_APOS, JSON_NUMERIC_CHECK, JSON_PRETTY_PRINT, JSON_UNESCAPED_SLASHES, JSON_FORCE_OBJECT
- *
- * @return mixed The JSON encoded value
- */
-function twig_jsonencode_filter($value, $options = 0)
-{
-    if ($value instanceof Twig_Markup) {
-        $value = (string) $value;
-    } elseif (is_array($value)) {
-        array_walk_recursive($value, function (&$value) {
-            if ($value instanceof Twig_Markup) {
-                $value = (string) $value;
-            }
-        });
-    }
-
-    return json_encode($value, $options);
 }
 
 /**

--- a/lib/Twig/Markup.php
+++ b/lib/Twig/Markup.php
@@ -14,7 +14,7 @@
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Twig_Markup implements Countable
+class Twig_Markup implements Countable, JsonSerializable
 {
     private $content;
     private $charset;
@@ -33,5 +33,10 @@ class Twig_Markup implements Countable
     public function count()
     {
         return mb_strlen($this->content, $this->charset);
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->content;
     }
 }


### PR DESCRIPTION
See http://blog.blackfire.io/blackfire-on-blackfire-twig-and-json.html for the reason to do this.
The bump of the requirement to PHP 5.5+ in Twig 2 makes it possible to rely on ``JsonSerializable``