### PR TITLE
Disable the PHP 7 build with the C extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,5 @@ matrix:
     exclude:
         - php: hhvm
           env: TWIG_EXT=yes
-    allow_failures:
         - php: 7.0
-          env: TWIG_EXT=yes
+          env: TWIG_EXT=yes # The C extension has not been rewritten for PHP 7


### PR DESCRIPTION
Trying to see whether it can work on each build is a waste of resources. The extension will not magically rewrite itself to compile on PHP 7
