### PR TITLE
undeprecated _self

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.23.2 (2015-XX-XX)
 
+ * undeprecated _self (should only be used to get the template name, not the template instance)
  * added versions in deprecated messages
  * made file cache tolerant for trailing (back)slashes on directory configuration
  * deprecated unused Twig_Node_Expression_ExtensionReference class

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -144,9 +144,11 @@ Globals
   or the extensions have been initialized is not possible anymore (but
   changing the value of an already registered global is possible).
 
-* As of Twig 1.x, the ``_self`` global variable is deprecated except for usage
-  in the ``from`` and the ``import`` tags. In Twig 2.0, ``_self`` is not
-  exposed anymore but still usable in the ``from`` and the ``import`` tags.
+* As of Twig 1.x, using the ``_self`` global variable to get access to the
+  current ``Twig_Template`` instance is deprecated; most usages only need the
+  current template name, which will continue to work in Twig 2.0. In Twig 2.0,
+  ``_self`` returns the current template name instead of the current
+  ``Twig_Template`` instance.
 
 Miscellaneous
 -------------

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -127,7 +127,7 @@ Global Variables
 
 The following variables are always available in templates:
 
-* ``_self``: references the current template (deprecated since Twig 1.20);
+* ``_self``: references the current template;
 * ``_context``: references the current context;
 * ``_charset``: references the current charset.
 

--- a/lib/Twig/Node/Expression/Name.php
+++ b/lib/Twig/Node/Expression/Name.php
@@ -30,19 +30,11 @@ class Twig_Node_Expression_Name extends Twig_Node_Expression
 
         if ($this->getAttribute('is_defined_test')) {
             if ($this->isSpecial()) {
-                if ('_self' === $name) {
-                    @trigger_error(sprintf('Global variable "_self" is deprecated since version 1.21 in %s at line %d', '?', $this->getLine()), E_USER_DEPRECATED);
-                }
-
                 $compiler->repr(true);
             } else {
                 $compiler->raw('array_key_exists(')->repr($name)->raw(', $context)');
             }
         } elseif ($this->isSpecial()) {
-            if ('_self' === $name) {
-                @trigger_error(sprintf('Global variable "_self" is deprecated since version 1.21 in %s at line %d', '?', $this->getLine()), E_USER_DEPRECATED);
-            }
-
             $compiler->raw($this->specialVars[$name]);
         } elseif ($this->getAttribute('always_defined')) {
             $compiler


### PR DESCRIPTION
Un-deprecated `_self`. As mentioned in #1932, `_self` is sometimes used to get the current template name, which is a legitimate usage and almost always the user intent. Moreover, when `_self` is used in a template, it is mostly passed to Twig functions that are able to deal with Twig templates or Twig template names indifferently.

fixes #1932 
