### PR TITLE
reintroduced _self (returns the current template name)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
-* 2.0.0 (201X-XX-XX)
+* 2.0.0 (2016-XX-XX)
 
  * sped up the json_encode filter
  * removed reserved macro names; all names can be used as macro
  * removed Twig_Template::getEnvironment()
- * removed _self variable (except for usage in from and import tags)
+ * changed _self variable to return the current template name
  * made the loader a required argument of Twig_Environment constructor
  * removed Twig_Environment::clearTemplateCache()
  * removed Twig_Autoloader (use Composer instead)

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -127,6 +127,7 @@ Global Variables
 
 The following variables are always available in templates:
 
+* ``_self``: references the current template name;
 * ``_context``: references the current context;
 * ``_charset``: references the current charset.
 

--- a/lib/Twig/Node/Expression/Name.php
+++ b/lib/Twig/Node/Expression/Name.php
@@ -12,6 +12,7 @@
 class Twig_Node_Expression_Name extends Twig_Node_Expression
 {
     private $specialVars = array(
+        '_self' => '$this->getTemplateName()',
         '_context' => '$context',
         '_charset' => '$this->env->getCharset()',
     );

--- a/test/Twig/Tests/Fixtures/expressions/_self.test
+++ b/test/Twig/Tests/Fixtures/expressions/_self.test
@@ -1,0 +1,8 @@
+--TEST--
+_self returns the current template name
+--TEMPLATE--
+{{ _self }}
+--DATA--
+return array()
+--EXPECT--
+index.twig

--- a/test/Twig/Tests/Node/Expression/NameTest.php
+++ b/test/Twig/Tests/Node/Expression/NameTest.php
@@ -21,6 +21,7 @@ class Twig_Tests_Node_Expression_NameTest extends Twig_Test_NodeTestCase
     public function getTests()
     {
         $node = new Twig_Node_Expression_Name('foo', 1);
+        $self = new Twig_Node_Expression_Name('_self', 1);
         $context = new Twig_Node_Expression_Name('_context', 1);
 
         $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'), array('strict_variables' => true));
@@ -29,6 +30,7 @@ class Twig_Tests_Node_Expression_NameTest extends Twig_Test_NodeTestCase
         return array(
             array($node, "// line 1\n".'(isset($context["foo"]) || array_key_exists("foo", $context) ? $context["foo"] : $this->notFound("foo", 1))', $env),
             array($node, $this->getVariableGetter('foo', 1), $env1),
+            array($self, "// line 1\n\$this->getTemplateName()"),
             array($context, "// line 1\n\$context"),
         );
     }


### PR DESCRIPTION
fixes #1932, see #1964 fro the 1.x counterpart.