### PR TITLE
Fixes sub-second freshness in filesystem loader

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -468,7 +468,7 @@ class Twig_Environment
             }
         }
 
-        return $this->lastModifiedExtension <= $time && $this->getLoader()->isFresh($name, $time);
+        return $this->lastModifiedExtension < $time && $this->getLoader()->isFresh($name, $time);
     }
 
     /**

--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -162,7 +162,7 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
      */
     public function isFresh($name, $time)
     {
-        return filemtime($this->findTemplate($name)) <= $time;
+        return filemtime($this->findTemplate($name)) < $time;
     }
 
     protected function findTemplate($name)

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -328,7 +328,7 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $twig->addExtension($extension);
 
         $this->assertInstanceOf('Twig_ExtensionInterface', $twig->getExtension('mock'));
-        
+
         // Test sub second freshness
         $this->assertFalse($twig->isTemplateFresh('page', time()));
         $this->assertTrue($twig->isTemplateFresh('page', time() + 1));

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -328,7 +328,10 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $twig->addExtension($extension);
 
         $this->assertInstanceOf('Twig_ExtensionInterface', $twig->getExtension('mock'));
-        $this->assertTrue($twig->isTemplateFresh('page', time()));
+        
+        // Test sub second freshness
+        $this->assertFalse($twig->isTemplateFresh('page', time()));
+        $this->assertTrue($twig->isTemplateFresh('page', time() + 1));
     }
 
     public function testInitRuntimeWithAnExtensionUsingInitRuntimeNoDeprecation()


### PR DESCRIPTION
This fixes the invalid freshness state in the filesystem loader for template updates within a second.