### PR TITLE
[DX] "Unexpected" vs. "Unknown" -tag exception message.

### DIFF
--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -175,8 +175,14 @@ class Twig_Parser implements Twig_ParserInterface
                                 $e->appendMessage(sprintf(' (expecting closing tag for the "%s" tag defined near line %s).', $test[0]->getTag(), $lineno));
                             }
                         } else {
-                            $e = new Twig_Error_Syntax(sprintf('Unknown "%s" tag.', $token->getValue()), $token->getLine(), $this->getFilename());
-                            $e->addSuggestions($token->getValue(), array_keys($this->env->getTags()));
+                            $tokenValue = $token->getValue();
+                            if (1 === preg_match('#^end(autoescape|block|filter|for|if|macro|spaceless|verbatim)$#', $tokenValue)) {
+                                $e = new Twig_Error_Syntax(sprintf('Unexpected "%s" tag.', $tokenValue), $token->getLine(), $this->getFilename());
+                            } else {
+                                $e = new Twig_Error_Syntax(sprintf('Unknown "%s" tag.', $tokenValue), $token->getLine(), $this->getFilename());
+                            }
+
+                            $e->addSuggestions($tokenValue, array_keys($this->env->getTags()));
                         }
 
                         throw $e;

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -176,12 +176,14 @@ class Twig_Parser implements Twig_ParserInterface
                             }
                         } else {
                             $tokenValue = $token->getValue();
-                            if (1 === preg_match('#^end(autoescape|block|filter|for|if|macro|spaceless|verbatim)$#', $tokenValue)) {
-                                $e = new Twig_Error_Syntax(sprintf('Unexpected "%s" tag.', $tokenValue), $token->getLine(), $this->getFilename());
-                            } else {
-                                $e = new Twig_Error_Syntax(sprintf('Unknown "%s" tag.', $tokenValue), $token->getLine(), $this->getFilename());
-                            }
-
+                            $e = new Twig_Error_Syntax(
+                                sprintf(
+                                    '%s "%s" tag.',
+                                    1 === preg_match('#^end(autoescape|block|filter|for|if|macro|spaceless|verbatim)$#', $tokenValue) ? 'Unexpected' : 'Unknown',
+                                    $tokenValue
+                                ),
+                                $token->getLine(),
+                                $this->getFilename());
                             $e->addSuggestions($tokenValue, array_keys($this->env->getTags()));
                         }
 

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -179,7 +179,7 @@ class Twig_Parser implements Twig_ParserInterface
                             $e = new Twig_Error_Syntax(
                                 sprintf(
                                     '%s "%s" tag.',
-                                    1 === preg_match('#^end(autoescape|block|filter|for|if|macro|spaceless|verbatim)$#', $tokenValue) ? 'Unexpected' : 'Unknown',
+                                    1 === preg_match('#^end(autoescape|block|embed|filter|for|if|macro|sandbox|set|spaceless|verbatim)$#', $tokenValue) ? 'Unexpected' : 'Unknown',
                                     $tokenValue
                                 ),
                                 $token->getLine(),

--- a/test/Twig/Tests/Fixtures/exceptions/unexpected_endblock.test
+++ b/test/Twig/Tests/Fixtures/exceptions/unexpected_endblock.test
@@ -1,0 +1,12 @@
+--TEST--
+Test exception raised for misplaced "endblock".
+--TEMPLATE--
+{% block my-test %}
+This fails because the block name is not valid, it is actually an expression.
+
+This used to throw an exception with the message:
+Twig_Error_Syntax: Unknown "endblock" tag in "index.twig" at line X.
+
+{% endblock %}
+--EXCEPTION--
+Twig_Error_Syntax: Unexpected "endblock" tag in "index.twig" at line 8.


### PR DESCRIPTION
Templates like this:

```twig
{% block my-test %}
{% endblock %}
```

Would result in:
>Twig_Error_Syntax: Unknown "endblock" tag in "index.twig" at line

This PR changes that to:
>Twig_Error_Syntax: Unexpected "endblock" tag in "index.twig" at line

I think this is better because:
* more accurate message, the `endblock` is known to system (and well typed by the developer); it is however misplaced in the template
* having the test file in the repo will help developers to figure out what is going wrong more easy, since a lot of the time this exception is a result of trying to use an expression as block name