### PR TITLE
Implement Twig_Extension_GlobalsInterface on getGlobals example

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -646,7 +646,7 @@ Globals
 Global variables can be registered in an extension via the ``getGlobals()``
 method::
 
-    class Project_Twig_Extension extends Twig_Extension
+    class Project_Twig_Extension extends Twig_Extension implements Twig_Extension_GlobalsInterface
     {
         public function getGlobals()
         {


### PR DESCRIPTION
I'm not sure if more information is required on when and why getGlobals was deprecated from Twig_Extension.

Refs #2001