### PR TITLE
[Doc] Add a note about escaping backslashes inside strings

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -588,7 +588,7 @@ exist:
   example as arguments to function calls, filters or just to extend or include
   a template). A string can contain a delimiter if it is preceded by a
   backslash (``\``) -- like in ``'It\'s good'``. If the string contains a
-  backslash (e.g. for PHP namespaces) escape it doubling it
+  backslash (e.g. for PHP namespaces) escape it by doubling it
   (e.g. ``Symfony\\Component\\HttpFoundation\\Request``).
 
 * ``42`` / ``42.23``: Integers and floating point numbers are created by just

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -589,7 +589,7 @@ exist:
   a template). A string can contain a delimiter if it is preceded by a
   backslash (``\``) -- like in ``'It\'s good'``. If the string contains a
   backslash (e.g. for PHP namespaces) escape it by doubling it
-  (e.g. ``Symfony\\Component\\HttpFoundation\\Request``).
+  (e.g. ``'Symfony\\Component\\HttpFoundation\\Request'``).
 
 * ``42`` / ``42.23``: Integers and floating point numbers are created by just
   writing the number down. If a dot is present the number is a float,

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -587,7 +587,9 @@ exist:
   string. They are useful whenever you need a string in the template (for
   example as arguments to function calls, filters or just to extend or include
   a template). A string can contain a delimiter if it is preceded by a
-  backslash (``\``) -- like in ``'It\'s good'``.
+  backslash (``\``) -- like in ``'It\'s good'``. If the string contains a
+  backslash (e.g. for PHP namespaces) escape it doubling it
+  (e.g. ``Symfony\\Component\\HttpFoundation\\Request``).
 
 * ``42`` / ``42.23``: Integers and floating point numbers are created by just
   writing the number down. If a dot is present the number is a float,

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -588,8 +588,8 @@ exist:
   example as arguments to function calls, filters or just to extend or include
   a template). A string can contain a delimiter if it is preceded by a
   backslash (``\``) -- like in ``'It\'s good'``. If the string contains a
-  backslash (e.g. for PHP namespaces) escape it by doubling it
-  (e.g. ``'Symfony\\Component\\HttpFoundation\\Request'``).
+  backslash (e.g. ``'c:\Program Files'``) escape it by doubling it
+  (e.g. ``'c:\\Program Files'``).
 
 * ``42`` / ``42.23``: Integers and floating point numbers are created by just
   writing the number down. If a dot is present the number is a float,


### PR DESCRIPTION
Backslashes inside strings caused some confusion for some users. See https://github.com/symfony/symfony/issues/18207