### PR TITLE
Adding support for SORT_LOCALE_STRING flag

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -953,7 +953,7 @@ function twig_sort_filter($array)
         throw new Twig_Error_Runtime(sprintf('The sort filter only works with arrays or "Traversable", got "%s".', gettype($array)));
     }
 
-    asort($array);
+    asort($array, SORT_LOCALE_STRING);
 
     return $array;
 }


### PR DESCRIPTION
Adds support for SORT_LOCALE_STRING flag on the `asort()` used within twig_sort_filter.

This is proposed to help support correct alphabetical sorted within different locales.  Inspired by http://stackoverflow.com/questions/10273165/how-to-sort-an-array-considering-localization
