### PR TITLE
[DOC] recipes.rst uses Twig_Function_Function

### DIFF
--- a/doc/recipes.rst
+++ b/doc/recipes.rst
@@ -280,7 +280,7 @@ For functions, use ``registerUndefinedFunctionCallback()``::
     // don't try this at home as it's not secure at all!
     $twig->registerUndefinedFunctionCallback(function ($name) {
         if (function_exists($name)) {
-            return new Twig_Function_Function($name);
+            return new Twig_SimpleFunction($name, $name);
         }
 
         return false;


### PR DESCRIPTION
Hello,
Here's a minor update for recipes.rst
I rewrite the code sample for registerUndefinedFunctionCallback to remove usage of deprecated class Twig_Function_Function.