### PR TITLE
Fix codeblock for recipe

### DIFF
--- a/doc/recipes.rst
+++ b/doc/recipes.rst
@@ -499,9 +499,7 @@ Loading a Template from a String
 
 From a template, you can easily load a template stored in a string via the
 ``template_from_string`` function (available as of Twig 1.11 via the
-``Twig_Extension_StringLoader`` extension):
-
-.. code-block:: jinja
+``Twig_Extension_StringLoader`` extension)::
 
     {{ include(template_from_string("Hello {{ name }}")) }}
 


### PR DESCRIPTION
See http://twig.sensiolabs.org/doc/recipes.html#loading-a-template-from-a-string
That is malformed currently.