### PR TITLE
fix a case where the autoescaping does not work as expected

### DIFF
--- a/lib/Twig/NodeVisitor/Escaper.php
+++ b/lib/Twig/NodeVisitor/Escaper.php
@@ -58,6 +58,7 @@ class Twig_NodeVisitor_Escaper extends Twig_BaseNodeVisitor
         if ($node instanceof Twig_Node_Module) {
             $this->defaultStrategy = false;
             $this->safeVars = array();
+            $this->blocks = array();
         } elseif ($node instanceof Twig_Node_Expression_Filter) {
             return $this->preEscapeFilterNode($node, $env);
         } elseif ($node instanceof Twig_Node_Print) {

--- a/lib/Twig/NodeVisitor/Escaper.php
+++ b/lib/Twig/NodeVisitor/Escaper.php
@@ -38,6 +38,7 @@ class Twig_NodeVisitor_Escaper extends Twig_BaseNodeVisitor
                 $this->defaultStrategy = $defaultStrategy;
             }
             $this->safeVars = array();
+            $this->blocks = array();
         } elseif ($node instanceof Twig_Node_AutoEscape) {
             $this->statusStack[] = $node->getAttribute('value');
         } elseif ($node instanceof Twig_Node_Block) {

--- a/test/Twig/Tests/Fixtures/autoescape/block.test
+++ b/test/Twig/Tests/Fixtures/autoescape/block.test
@@ -1,0 +1,21 @@
+--TEST--
+blocks and autoescape
+--TEMPLATE--
+{{ include('unrelated.txt.twig') -}}
+{{ include('template.html.twig') -}}
+--TEMPLATE(unrelated.txt.twig)--
+{% block content %}{% endblock %}
+--TEMPLATE(template.html.twig)--
+{% extends 'parent.html.twig' %}
+{% block content %}
+{{ br -}}
+{% endblock %}
+--TEMPLATE(parent.html.twig)--
+{% set _content = block('content')|raw %}
+{{ _content|raw }}
+--DATA--
+return array('br' => '<br />')
+--CONFIG--
+return array('autoescape' => 'filename')
+--EXPECT--
+&lt;br /&gt;


### PR DESCRIPTION
The Twig_NodeVisitor_Escaper collects a list of blocks for all templates that it visits. If you define the same block (i.e. with the same name) in txt and html templates this results sometimes in the html block not being escapes.

This is illustrated in the added test.

To fix it, I propose to reset the list of the blocks for each module.

Alternatively we need to make clear that blocks should not share names between text and html templates.