### PR TITLE
Minor rst syntax tweaks

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -78,16 +78,16 @@ The following options are available:
   ``__toString()`` method that you can use to display the generated nodes
   (default to ``false``).
 
-* ``charset`` *string (default to ``utf-8``)*
+* ``charset`` *string* (defaults to ``utf-8``)
 
   The charset used by the templates.
 
-* ``base_template_class`` *string (default to ``Twig_Template``)*
+* ``base_template_class`` *string* (defaults to ``Twig_Template``)
 
   The base template class to use for generated
   templates.
 
-* ``cache`` *string|false*
+* ``cache`` *string* or ``false``
 
   An absolute path where to store the compiled templates, or
   ``false`` to disable caching (which is the default).
@@ -106,7 +106,7 @@ The following options are available:
   replace them with a ``null`` value. When set to ``true``, Twig throws an
   exception instead (default to ``false``).
 
-* ``autoescape`` *string|boolean*
+* ``autoescape`` *string* or *boolean*
 
   If set to ``true``, HTML auto-escaping will be enabled by
   default for all templates (default to ``true``).


### PR DESCRIPTION
It looks like you can't show `<code>` inside italics with RST. This is how the current docs look when rendered:

![rst_syntax_issue](https://cloud.githubusercontent.com/assets/73419/16001277/7cf476ee-3151-11e6-99f7-da9d94ffff4e.png)
