### PR TITLE
Allow tests to be chained

### DIFF
--- a/test/Twig/Tests/Fixtures/tests/chain.test
+++ b/test/Twig/Tests/Fixtures/tests/chain.test
@@ -1,0 +1,22 @@
+--TEST--
+chained test
+--TEMPLATE--
+{{ definedVar    is     defined  and not empty          ? 'ok' : 'ko' }}
+{{ undefinedVar  is not defined  and     empty          ? 'ok' : 'ko' }}
+{{ numeric       is not empty    and     sameas(12)     ? 'ok' : 'ko' }}
+{{ numeric       is     even     and     divisibleby(3) ? 'ok' : 'ko' }}
+{{ definedVar    is not iterable and not empty          ? 'ok' : 'ko' }}
+{{ array         is     iterable and not empty          ? 'ok' : 'ko' }}
+--DATA--
+return array(
+    'definedVar' => 'defined',
+    'numeric'    => 12,
+    'array'      => array('a', 'b', 'c')
+);
+--EXPECT--
+ok
+ok
+ok
+ok
+ok
+ok


### PR DESCRIPTION
This allows multiple tests to be chained, where the original value is used for the tests, and you don't have to explicitly set the value. A common case is to check if a variable is defined and not empty.
So this makes the following possible:

```twig
{% if somevar is defined and not empty %}
   ... do something
{% endif %}
```

Normal cases still works where the value is defined for each test

```twig
{% if somevar is defined and somevar is not empty %}
```

And multiple tests can be chained together

```twig
{% if myvar is even and divisible by(3) and not same as(144) %}
```