### PR TITLE
Notice log show

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -38,6 +38,8 @@ class Twig_Environment
     protected $extensionInitialized = false;
     protected $loadedTemplates;
     protected $strictVariables;
+    protected $strictVariablesNoticeLog;
+    protected $strictVariablesNoticeShow;
     protected $unaryOperators;
     protected $binaryOperators;
     protected $templateClassPrefix = '__TwigTemplate_';
@@ -101,6 +103,8 @@ class Twig_Environment
             'charset' => 'UTF-8',
             'base_template_class' => 'Twig_Template',
             'strict_variables' => false,
+            'strict_variables_notice_log' => true,
+            'strict_variables_notice_show' => false,
             'autoescape' => 'html',
             'cache' => false,
             'auto_reload' => null,
@@ -112,6 +116,8 @@ class Twig_Environment
         $this->baseTemplateClass = $options['base_template_class'];
         $this->autoReload = null === $options['auto_reload'] ? $this->debug : (bool) $options['auto_reload'];
         $this->strictVariables = (bool) $options['strict_variables'];
+        $this->strictVariablesNoticeLog = (bool) $options['strict_variables_notice_log'];
+        $this->strictVariablesNoticeShow = (bool) $options['strict_variables_notice_show'];
         $this->setCache($options['cache']);
 
         $this->addExtension(new Twig_Extension_Core());
@@ -226,6 +232,38 @@ class Twig_Environment
     }
 
     /**
+     * Enables the strict_variables_notice_log option.
+     */
+    public function enableStrictVariablesNoticeLog() 
+    {
+        $this->strictVariablesNoticeLog = true;
+    }
+
+    /**
+     * Disables the strict_variables_notice_log option.
+     */
+    public function disableStrictVariablesNoticeLog() 
+    {
+        $this->strictVariablesNoticeLog = false;
+    }
+
+    /**
+     * Enables the strict_variables_notice_show option.
+     */
+    public function enableStrictVariablesNoticeShow() 
+    {
+        $this->strictVariablesNoticeShow = true;
+    }
+
+    /**
+     * Disables the strict_variables_notice_show option.
+     */
+    public function disableStrictVariablesNoticeShow() 
+    {
+        $this->strictVariablesNoticeShow = false;
+    }
+
+    /**
      * Checks if the strict_variables option is enabled.
      *
      * @return bool true if strict_variables is enabled, false otherwise
@@ -233,6 +271,26 @@ class Twig_Environment
     public function isStrictVariables()
     {
         return $this->strictVariables;
+    }
+    
+    /**
+     * Checks if the strict_variables_notice_log option is enabled.
+     *
+     * @return bool true if strict_variables_notice_log is enabled, false otherwise
+     */
+    public function isStrictVariablesNoticeLog() 
+    {
+        return $this->strictVariablesNoticeLog;
+    }
+
+    /**
+     * Checks if the strict_variables_notice_log option is enabled.
+     *
+     * @return bool true if strict_variables_notice_log is enabled, false otherwise
+     */
+    public function isStrictVariablesNoticeShow() 
+    {
+        return $this->strictVariablesNoticeShow;
     }
 
     /**

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -234,7 +234,7 @@ class Twig_Environment
     /**
      * Enables the strict_variables_notice_log option.
      */
-    public function enableStrictVariablesNoticeLog() 
+    public function enableStrictVariablesNoticeLog()
     {
         $this->strictVariablesNoticeLog = true;
     }
@@ -242,7 +242,7 @@ class Twig_Environment
     /**
      * Disables the strict_variables_notice_log option.
      */
-    public function disableStrictVariablesNoticeLog() 
+    public function disableStrictVariablesNoticeLog()
     {
         $this->strictVariablesNoticeLog = false;
     }
@@ -250,7 +250,7 @@ class Twig_Environment
     /**
      * Enables the strict_variables_notice_show option.
      */
-    public function enableStrictVariablesNoticeShow() 
+    public function enableStrictVariablesNoticeShow()
     {
         $this->strictVariablesNoticeShow = true;
     }
@@ -258,7 +258,7 @@ class Twig_Environment
     /**
      * Disables the strict_variables_notice_show option.
      */
-    public function disableStrictVariablesNoticeShow() 
+    public function disableStrictVariablesNoticeShow()
     {
         $this->strictVariablesNoticeShow = false;
     }
@@ -272,13 +272,13 @@ class Twig_Environment
     {
         return $this->strictVariables;
     }
-    
+
     /**
      * Checks if the strict_variables_notice_log option is enabled.
      *
      * @return bool true if strict_variables_notice_log is enabled, false otherwise
      */
-    public function isStrictVariablesNoticeLog() 
+    public function isStrictVariablesNoticeLog()
     {
         return $this->strictVariablesNoticeLog;
     }
@@ -288,7 +288,7 @@ class Twig_Environment
      *
      * @return bool true if strict_variables_notice_log is enabled, false otherwise
      */
-    public function isStrictVariablesNoticeShow() 
+    public function isStrictVariablesNoticeShow()
     {
         return $this->strictVariablesNoticeShow;
     }

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -103,7 +103,7 @@ class Twig_Environment
             'charset' => 'UTF-8',
             'base_template_class' => 'Twig_Template',
             'strict_variables' => false,
-            'strict_variables_notice_log' => true,
+            'strict_variables_notice_log' => false,
             'strict_variables_notice_show' => false,
             'autoescape' => 'html',
             'cache' => false,

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -437,9 +437,21 @@ abstract class Twig_Template implements Twig_TemplateInterface
         if (!array_key_exists($item, $context)) {
             if ($ignoreStrictCheck || !$this->env->isStrictVariables()) {
                 return;
-            }
+            } else {
+                $errorMessage = sprintf('Variable "%s" does not exist', $item);
+                $templateName = $this->getTemplateName();
+                $lineno = -1;
 
-            throw new Twig_Error_Runtime(sprintf('Variable "%s" does not exist', $item), -1, $this->getTemplateName());
+                if ($log = $this->env->isStrictVariablesNoticeLog() || $show = $this->env->isStrictVariablesNoticeShow()) {
+                    $error = new Twig_Error($errorMessage, $lineno, $templateName);
+                    if ($log) {
+                        trigger_error($error->getMessage(), E_USER_NOTICE);
+                        $show = $this->env->isStrictVariablesNoticeShow();
+                    }
+                    return $show ? 'Notice: ' . $error->getMessage() : null;
+                }
+            }
+            throw new Twig_Error_Runtime($errorMessage, $lineno, $templateName);
         }
 
         return $context[$item];

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -448,7 +448,8 @@ abstract class Twig_Template implements Twig_TemplateInterface
                         trigger_error($error->getMessage(), E_USER_NOTICE);
                         $show = $this->env->isStrictVariablesNoticeShow();
                     }
-                    return $show ? 'Notice: ' . $error->getMessage() : null;
+
+                    return $show ? 'Notice: '.$error->getMessage() : null;
                 }
             }
             throw new Twig_Error_Runtime($errorMessage, $lineno, $templateName);


### PR DESCRIPTION
This request related to issue #1430 (and some of more). I think I understand what is this guy (@lathspell) would, the problem is not that the `strict_variables` option doesn't work, I think he need some "Report" instead of an exception. Typical use case when the back-end (php) developer working with an other front-end (html) site builder. The sitebuilder can not add any more ("un-substituted") variable to the template because the back-end developer switched on the `strict_variables` (typically in dev-environment) and the front-end colleague doesn't see nothing html/css/{{ variables }} etc of his work.. (only the Exception Page) but if the `strict_variables` switched Off the back-end colleague doesn't see nothing because there is not exception or any error message only an empty string (so nothing) replaced into the variable placeholder. I wish to open this feature/change request and I attach a change commit to see how I imaging to resolve this "conflict" with some extra development environment arguments for `strict_variables` option. I added (and practically used on debugging) two more option witches related to `strict_variables` and these options working only if the `strict_variables` is switched on (so only in dev-environment):

if `strict_variables` is ON and `strict_variables_notice_log` is ON also, the notices of "undefined" variables added to the `error.log` by `trigger_error` (like to native PHP style) and doesn't throw exception.

if `strict_variables` is ON and `strict_variables_notice_show` is ON also, the notices of "undefined" variables assigned to the template (like as Twig variables) and doesn't throw exception.

if `strict_variables` is ON and both of `strict_variables_notice_log` and `strict_variables_notice_show` also ON, the error going to `error.log` and notice message into Twig template too.

if `strict_variables` is Off or both of `strict_variables_notice_log` and `strict_variables_notice_show` also Off (as default) then nothing to changed everything is working originally.
- so the developers can choose some of more option how they want to use Twig and they dev-environments, potentially differents environment for back-end and front-end colleagues depends on how is they development process (e.g typically template-first or back-end-logic first...)
