### PR TITLE
Do not mix indention levels

### DIFF
--- a/doc/coding_standards.rst
+++ b/doc/coding_standards.rst
@@ -95,7 +95,7 @@ standards:
   .. code-block:: jinja
 
      {% block foo %}
-        {% if true %}
-            true
-        {% endif %}
+         {% if true %}
+             true
+         {% endif %}
      {% endblock %}


### PR DESCRIPTION
Not sure if this was intentional, but the "if" line had an indention of 3 spaces,
while the "true" line has an indention of 4 spaces.