### PR TITLE
Floor - use cast and not intval

### DIFF
--- a/lib/Twig/Node/Expression/Binary/FloorDiv.php
+++ b/lib/Twig/Node/Expression/Binary/FloorDiv.php
@@ -12,7 +12,7 @@ class Twig_Node_Expression_Binary_FloorDiv extends Twig_Node_Expression_Binary
 {
     public function compile(Twig_Compiler $compiler)
     {
-        $compiler->raw('(int)floor(');
+        $compiler->raw('(int) floor(');
         parent::compile($compiler);
         $compiler->raw(')');
     }

--- a/lib/Twig/Node/Expression/Binary/FloorDiv.php
+++ b/lib/Twig/Node/Expression/Binary/FloorDiv.php
@@ -12,9 +12,9 @@ class Twig_Node_Expression_Binary_FloorDiv extends Twig_Node_Expression_Binary
 {
     public function compile(Twig_Compiler $compiler)
     {
-        $compiler->raw('intval(floor(');
+        $compiler->raw('(int)floor(');
         parent::compile($compiler);
-        $compiler->raw('))');
+        $compiler->raw(')');
     }
 
     public function operator(Twig_Compiler $compiler)

--- a/test/Twig/Tests/Node/Expression/Binary/FloorDivTest.php
+++ b/test/Twig/Tests/Node/Expression/Binary/FloorDivTest.php
@@ -28,7 +28,7 @@ class Twig_Tests_Node_Expression_Binary_FloorDivTest extends Twig_Test_NodeTestC
         $node = new Twig_Node_Expression_Binary_FloorDiv($left, $right, 1);
 
         return array(
-            array($node, 'intval(floor((1 / 2)))'),
+            array($node, '(int)floor((1 / 2))'),
         );
     }
 }

--- a/test/Twig/Tests/Node/Expression/Binary/FloorDivTest.php
+++ b/test/Twig/Tests/Node/Expression/Binary/FloorDivTest.php
@@ -28,7 +28,7 @@ class Twig_Tests_Node_Expression_Binary_FloorDivTest extends Twig_Test_NodeTestC
         $node = new Twig_Node_Expression_Binary_FloorDiv($left, $right, 1);
 
         return array(
-            array($node, '(int)floor((1 / 2))'),
+            array($node, '(int) floor((1 / 2))'),
         );
     }
 }


### PR DESCRIPTION
Use cast in fav. of the `inval`, because;
- its faster
- cannot be overloaded
- less chars