### PR TITLE
Revert "feature #1757 deprecated Twig_Template::getEnvironment()"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
-* 1.24.3 (2016-XX-XX)
+* 1.25.0 (2016-XX-XX)
 
- * n/a
+ * reverted deprecation of Twig_Template::getEnvironment()
 
 * 1.24.2 (2016-09-01)
 

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -156,7 +156,3 @@ Miscellaneous
 * As of Twig 1.x, ``Twig_Environment::clearTemplateCache()``, ``Twig_Environment::writeCacheFile()``,
   ``Twig_Environment::clearCacheFiles()``, ``Twig_Environment::getCacheFilename()``, and
   ``Twig_Environment::getTemplateClassPrefix()`` are deprecated and will be removed in 2.0.
-
-* As of Twig 1.x, ``Twig_Template::getEnvironment()`` and
-  ``Twig_TemplateInterface::getEnvironment()`` are deprecated and will be
-  removed in 2.0.

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -43,12 +43,10 @@ abstract class Twig_Template implements Twig_TemplateInterface
     abstract public function getTemplateName();
 
     /**
-     * @deprecated since 1.20 (to be removed in 2.0)
+     * {@inheritdoc}
      */
     public function getEnvironment()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.20 and will be removed in 2.0.', E_USER_DEPRECATED);
-
         return $this->env;
     }
 


### PR DESCRIPTION
This reverts commit cfb0593028d164376abb8489b4534404616625f9, reversing
changes made to 1eb5fb26ef5847a5e8c11e24241bccfb54f17ddd.

WDYT? removing getEnvironment led to #1813, and now I'd like to get the filename (when using the Filesystem loader), but I can't.
If OK, I think we should also revert #1813 on master, and maybe also #1807 on 1.x