### PR TITLE
Add 'type' tag to avoid calling getAttribute()

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -34,6 +34,7 @@ class Twig_Environment
     private $tests;
     private $functions;
     private $globals;
+    private $globalSymbols;
     private $runtimeInitialized = false;
     private $extensionInitialized = false;
     private $loadedTemplates;
@@ -483,7 +484,7 @@ class Twig_Environment
     public function getParser()
     {
         if (null === $this->parser) {
-            $this->parser = new Twig_Parser($this);
+            $this->parser = new Twig_Parser($this, $this->globalSymbols);
         }
 
         return $this->parser;
@@ -1028,6 +1029,18 @@ class Twig_Environment
         } else {
             $this->staging->addGlobal($name, $value);
         }
+    }
+
+    /**
+     * Sets the expected class of a global var
+     * Setting this allows the parser to do extra optimizations.
+     *
+     * @param string $name The global variable name
+     * @param string $type The class name
+     */
+    public function addGlobalType($name, $type)
+    {
+        $this->globalSymbols['types'][$name] = array('name' => $type);
     }
 
     /**

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -132,6 +132,7 @@ class Twig_Extension_Core extends Twig_Extension
             new Twig_TokenParser_Flush(),
             new Twig_TokenParser_Do(),
             new Twig_TokenParser_Embed(),
+            new Twig_TokenParser_Type(),
         );
     }
 
@@ -502,7 +503,7 @@ function twig_replace_filter($str, $from)
     if ($from instanceof Traversable) {
         $from = iterator_to_array($from);
     } elseif (!is_array($from)) {
-        throw new Twig_Error_Runtime(sprintf('The "replace" filter expects an array or "Traversable" as replace values, got "%s".',is_object($from) ? get_class($from) : gettype($from)));
+        throw new Twig_Error_Runtime(sprintf('The "replace" filter expects an array or "Traversable" as replace values, got "%s".', is_object($from) ? get_class($from) : gettype($from)));
     }
 
     return strtr($str, $from);

--- a/lib/Twig/Node/Expression/GetProperty.php
+++ b/lib/Twig/Node/Expression/GetProperty.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2012 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class Twig_Node_Expression_GetProperty extends Twig_Node_Expression
+{
+    public function __construct(Twig_Node_Expression $node, $name, $lineno)
+    {
+        parent::__construct(array('node' => $node), array('name' => $name, 'safe' => false), $lineno);
+
+        if ($node instanceof Twig_Node_Expression_Name) {
+            $node->setAttribute('always_defined', true);
+        }
+    }
+
+    public function compile(Twig_Compiler $compiler)
+    {
+        $compiler
+            ->subcompile($this->getNode('node'))
+            ->raw('->')
+            ->raw($this->getAttribute('name'))
+        ;
+    }
+}

--- a/lib/Twig/Node/Expression/Test/Defined.php
+++ b/lib/Twig/Node/Expression/Test/Defined.php
@@ -31,7 +31,7 @@ class Twig_Node_Expression_Test_Defined extends Twig_Node_Expression_Test
             $node->setAttribute('is_defined_test', true);
 
             $this->changeIgnoreStrictCheck($node);
-        } elseif ($node instanceof Twig_Node_Expression_Constant || $node instanceof Twig_Node_Expression_Array) {
+        } elseif ($node instanceof Twig_Node_Expression_Constant || $node instanceof Twig_Node_Expression_Array || $node instanceof Twig_Node_Expression_GetProperty || $node instanceof Twig_Node_Expression_MethodCall) {
             $node = new Twig_Node_Expression_Constant(true, $node->getLine());
         } else {
             throw new Twig_Error_Syntax('The "defined" test only works with simple variables.', $this->getLine());

--- a/lib/Twig/Node/Type.php
+++ b/lib/Twig/Node/Type.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ * (c) 2009 Armin Ronacher
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Represents a type node.
+ *
+ * @author David Stone <david@nnucomputerwhiz.com>
+ */
+class Twig_Node_Type extends Twig_Node
+{
+    public function __construct($name, $value, $lineno, $tag = null)
+    {
+        parent::__construct(array(), array('name' => $name, 'type' => $value), $lineno, $tag);
+    }
+
+    public function compile(Twig_Compiler $compiler)
+    {
+        if ($compiler->getEnvironment()->isStrictVariables()) {
+            $name = $this->getAttribute('name');
+            $type = $this->getAttribute('type');
+            $compiler->addDebugInfo($this);
+
+            if (0 === strcasecmp($type, 'array')) {
+                $compiler->write("if (false === is_array(\$context['$name'])) {\n");
+            } else {
+                $compiler->write("if (false === \$context['$name'] instanceof $type) {\n");
+            }
+            $compiler
+                ->indent()
+                ->write("throw new Twig_Error_Runtime('variable \'$name\' is expected to be of type $type but '.get_class(\$context['$name']).' was provided.', {$this->getLine()}, '{$compiler->getFilename()}');\n")
+                ->outdent()
+                ->write("}\n")
+            ;
+        }
+    }
+}

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -28,6 +28,7 @@ class Twig_Parser
     private $macros;
     private $env;
     private $importedSymbols;
+    private $globalSymbols;
     private $traits;
     private $embeddedTemplates = array();
 
@@ -36,9 +37,10 @@ class Twig_Parser
      *
      * @param Twig_Environment $env A Twig_Environment instance
      */
-    public function __construct(Twig_Environment $env)
+    public function __construct(Twig_Environment $env, $globalSymbols = array())
     {
         $this->env = $env;
+        $this->globalSymbols = $globalSymbols;
     }
 
     public function getEnvironment()
@@ -96,7 +98,7 @@ class Twig_Parser
         $this->macros = array();
         $this->traits = array();
         $this->blockStack = array();
-        $this->importedSymbols = array(array());
+        $this->importedSymbols = array($this->globalSymbols);
         $this->embeddedTemplates = array();
 
         try {

--- a/lib/Twig/TokenParser/Type.php
+++ b/lib/Twig/TokenParser/Type.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Defines a variable.
+ *
+ * <pre>
+ *  {% type foo = 'FooClassName' %}
+ *
+ *  {% type foo = 'FooNamespace//FooClassName' %}
+ * </pre>
+ *
+ * @author David Stone <david@nnucomputerwhiz.com>
+ */
+class Twig_TokenParser_Type extends Twig_TokenParser
+{
+    public function parse(Twig_Token $token)
+    {
+        $stream = $this->parser->getStream();
+
+        $name = $this->parser->getStream()->expect(Twig_Token::NAME_TYPE)->getValue();
+        $stream->expect(Twig_Token::OPERATOR_TYPE, '=');
+        $type = $this->parser->getStream()->expect(Twig_Token::STRING_TYPE)->getValue();
+        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+
+        if (0 !== strcasecmp('array', $type) && false === class_exists($type)) {
+            throw new Twig_Error_Syntax(sprintf('Class "%s" not found for type set on "%s".', $type, $name), $stream->getCurrent()->getLine(), $stream->getFilename());
+        }
+
+        $this->parser->addImportedSymbol('types', $name, $type);
+
+        return new Twig_Node_Type($name, $type, $token->getLine(), $this->getTag());
+    }
+
+    public function getTag()
+    {
+        return 'type';
+    }
+}

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -125,6 +125,21 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function testAddGlobalType()
+    {
+        $twig = new Twig_Environment($this->getMock('Twig_LoaderInterface'));
+
+        $twig->addGlobalType('bar', 'ArrayObject');
+        $twig->addGlobal('bar', new ArrayObject());
+
+        $source = '{{ bar.count|raw }}';
+        $expected = 'echo $context["bar"]->count();';
+        $compiled = $twig->compileSource($source, 'index');
+
+        $this->assertContains($expected, $compiled);
+        $this->assertNotContains('$this->getAttribute', $compiled);
+    }
+
     public function testCompileSourceInlinesSource()
     {
         $twig = new Twig_Environment($this->getMock('Twig_LoaderInterface'));

--- a/test/Twig/Tests/Fixtures/tags/type/basic.test
+++ b/test/Twig/Tests/Fixtures/tags/type/basic.test
@@ -1,0 +1,15 @@
+--TEST--
+"type" tag
+--TEMPLATE--
+{% type obj = 'TwigTestFoo' %}
+{% type arr = 'array' %}
+
+{{ obj.foo }}
+{{ obj.position }}
+{{ arr.foo }}
+--DATA--
+return array('obj' => new TwigTestFoo(), 'arr' => array('foo' => 'bar'))
+--EXPECT--
+foo
+0
+bar

--- a/test/Twig/Tests/Fixtures/tags/type/missing_class_exception.test
+++ b/test/Twig/Tests/Fixtures/tags/type/missing_class_exception.test
@@ -1,0 +1,10 @@
+--TEST--
+"type" tag undefined class exception
+--TEMPLATE--
+{% type obj = 'MissingClassBogus' %}
+
+{{ obj.foo }}
+--DATA--
+return array('obj' => new TwigTestFoo())
+--EXCEPTION--
+Twig_Error_Syntax: Class "MissingClassBogus" not found for type set on "obj" in "index.twig" at line 3.

--- a/test/Twig/Tests/Fixtures/tags/type/wrong_class_exception.test
+++ b/test/Twig/Tests/Fixtures/tags/type/wrong_class_exception.test
@@ -1,0 +1,10 @@
+--TEST--
+"type" tag undefined class exception
+--TEMPLATE--
+{% type obj = 'TwigTestFoo' %}
+
+{{ obj.foo }}
+--DATA--
+return array('obj' => new ArrayObject(array(1, 2, 3, 4)))
+--EXCEPTION--
+Twig_Error_Runtime: variable 'obj' is expected to be of type TwigTestFoo but ArrayObject was provided in "index.twig" at line 2.

--- a/test/Twig/Tests/Node/TypeTest.php
+++ b/test/Twig/Tests/Node/TypeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Twig_Tests_Node_TypeTest extends Twig_Test_NodeTestCase
+{
+    public function testConstructor()
+    {
+        $node = new Twig_Node_Type('foo', 'FooClass', 1);
+
+        $this->assertEquals('foo', $node->getAttribute('name'));
+        $this->assertEquals('FooClass', $node->getAttribute('type'));
+    }
+
+    public function getTests()
+    {
+        $tests = array();
+
+        $node = new Twig_Node_Type('foo', 'FooClass', 1);
+        $tests[] = array($node, <<<EOF
+// line 1
+if (false === \$context['foo'] instanceof FooClass) {
+    throw new Twig_Error_Runtime('variable \'foo\' is expected to be of type FooClass but '.get_class(\$context['foo']).' was provided.', 1, '');
+}
+EOF
+        );
+
+        return $tests;
+    }
+
+    protected function getEnvironment()
+    {
+        return new Twig_Environment(new Twig_Loader_Array(array()), array('strict_variables' => true));
+    }
+}


### PR DESCRIPTION
This is a proposal for a new tag which could enable some significant optimizations.

``` twig
{% type obj = 'SomeClass' %}
```

With this tag added to a template `{{ obj.id }}` could compile to `$context['obj']->getId()` provided `getId()` was a public accessible method. You can see the unit tests for more examples.

Unfortunately as it's handled by the parser the type of each variable will need to be set in each template. I would recommend its use with variables that are used many times in one template such as loops or templates included in loops.

Twig_Template::getAttribute() is a rather expensive method as many people have experienced. Essentially this will allow us to move the work of getAttribute to compile time instead of render time. I have been this tag in a large project and it has made a significant improvement on performance, especially with variables in large for loops.  
