### PR TITLE
ignore template filename in string representation

### DIFF
--- a/lib/Twig/Node.php
+++ b/lib/Twig/Node.php
@@ -45,6 +45,10 @@ class Twig_Node implements Countable, IteratorAggregate
     {
         $attributes = array();
         foreach ($this->attributes as $name => $value) {
+            if ('module_filename' === $name) {
+                continue;
+            }
+
             $attributes[] = sprintf('%s: %s', $name, str_replace("\n", '', var_export($value, true)));
         }
 

--- a/lib/Twig/Test/NodeTestCase.php
+++ b/lib/Twig/Test/NodeTestCase.php
@@ -20,6 +20,20 @@ abstract class Twig_Test_NodeTestCase extends PHPUnit_Framework_TestCase
         $this->assertNodeCompilation($source, $node, $environment, $isPattern);
     }
 
+    /**
+     * @dataProvider getTests
+     */
+    public function testToString($node)
+    {
+        $withoutFilename = (string) $node;
+
+        $node->setAttribute('module_filename', 'index');
+
+        $withFilename = (string) $node;
+
+        $this->assertSame($withoutFilename, $withFilename);
+    }
+
     public function assertNodeCompilation($source, Twig_Node $node, Twig_Environment $environment = null, $isPattern = false)
     {
         $compiler = $this->getCompiler($environment);


### PR DESCRIPTION
Adding the template filename to the node attributes changes the node's string representation. This breaks the behaviour of the `hasElement()` of the `Twig_Node_Expression_Array` class.

I am not sure if this is really the best way to fix it or if we shouldn't rather introduce a different property to store the filename instead.