### PR TITLE
fixed embed parent token for simple use cases

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.25.0 (2016-XX-XX)
 
+ * removed embed parent workaround for simple use cases
  * deprecated the ability to store non Node instances in Node::$nodes
  * deprecated Twig_Environment::getLexer(), Twig_Environment::getParser(), Twig_Environment::getCompiler()
  * deprecated Twig_Compiler::getFilename()

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@
 * 1.24.2 (2016-09-01)
 
  * fixed static callables
- * fixed a potential PHP warning when load the cache
+ * fixed a potential PHP warning when loading the cache
  * fixed a case where the autoescaping does not work as expected
 
 * 1.24.1 (2016-05-30)

--- a/test/Twig/Tests/Fixtures/tags/embed/complex_dynamic_parent.test
+++ b/test/Twig/Tests/Fixtures/tags/embed/complex_dynamic_parent.test
@@ -1,0 +1,35 @@
+--TEST--
+"embed" tag
+--TEMPLATE--
+FOO
+{% embed foo ~ ".twig" %}
+    {% block c1 %}
+        {{ parent() }}
+        block1extended
+    {% endblock %}
+{% endembed %}
+
+BAR
+--TEMPLATE(foo.twig)--
+A
+{% block c1 %}
+    block1
+{% endblock %}
+B
+{% block c2 %}
+    block2
+{% endblock %}
+C
+--DATA--
+return array('foo' => 'foo')
+--EXPECT--
+FOO
+
+A
+            block1
+
+        block1extended
+    B
+    block2
+C
+BAR

--- a/test/Twig/Tests/Fixtures/tags/embed/dynamic_parent.test
+++ b/test/Twig/Tests/Fixtures/tags/embed/dynamic_parent.test
@@ -1,0 +1,35 @@
+--TEST--
+"embed" tag
+--TEMPLATE--
+FOO
+{% embed foo %}
+    {% block c1 %}
+        {{ parent() }}
+        block1extended
+    {% endblock %}
+{% endembed %}
+
+BAR
+--TEMPLATE(foo.twig)--
+A
+{% block c1 %}
+    block1
+{% endblock %}
+B
+{% block c2 %}
+    block2
+{% endblock %}
+C
+--DATA--
+return array('foo' => 'foo.twig')
+--EXPECT--
+FOO
+
+A
+            block1
+
+        block1extended
+    B
+    block2
+C
+BAR


### PR DESCRIPTION
Not the most elegant solution but solves the problem for when `embed` is used on a non-dynamic template, which should cover almost all use cases.
