### PR TITLE
fixed Twig cache sharing when used with different versions of PHP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.25.0 (2016-XX-XX)
 
+ * fixed Twig cache sharing when used with different versions of PHP
  * removed embed parent workaround for simple use cases
  * deprecated the ability to store non Node instances in Node::$nodes
  * deprecated Twig_Environment::getLexer(), Twig_Environment::getParser(), Twig_Environment::getCompiler()

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -312,6 +312,7 @@ class Twig_Environment
         $key = $this->getLoader()->getCacheKey($name);
         $key .= json_encode(array_keys($this->extensions));
         $key .= function_exists('twig_template_get_attributes');
+        $key .= ':'.PHP_MAJOR_VERSION.':'.PHP_MINOR_VERSION;
 
         return $this->templateClassPrefix.hash('sha256', $key).(null === $index ? '' : '_'.$index);
     }


### PR DESCRIPTION
closes #2013