### PR TITLE
added support for {{@ ... }}, {%@ ... %}, and {#@ ... #} notation to keep blocks verbatim

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.25.0 (2016-XX-XX)
 
+ * added support for {{@ ... }}, {%@ ... %}, and {#@ ... #} notation to keep blocks verbatim
  * changed the way we store template source in template classes
  * removed usage of realpath in cache keys
  * fixed Twig cache sharing when used with different versions of PHP

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -480,19 +480,22 @@ Escaping
 --------
 
 It is sometimes desirable or even necessary to have Twig ignore parts it would
-otherwise handle as variables or blocks. For example if the default syntax is
-used and you want to use ``{{`` as raw string in the template and not start a
-variable you have to use a trick.
+otherwise handle as variables or blocks. For example when using a JavaScript
+framework that also uses ``{{`` ``}}`` delimiters.
 
-The easiest way is to output the variable delimiter (``{{``) by using a variable
-expression:
+The easiest way to tell Twig to not "evaluate" some blocks is to add ``@``
+after the opening delimiter (``{{``, ``{%``, or ``{#``):
 
 .. code-block:: jinja
 
-    {{ '{{' }}
+    Hello {{@ firstname }}!
 
 For bigger sections it makes sense to mark a block
 :doc:`verbatim<tags/verbatim>`.
+
+.. versionadded:: 1.25
+    Support for the ``@`` notation was added in Twig 1.25. In previous
+    versions, you can wrap the opening delimiter like this: ``{{ '{{' }}``
 
 Macros
 ------

--- a/lib/Twig/Lexer.php
+++ b/lib/Twig/Lexer.php
@@ -33,6 +33,8 @@ class Twig_Lexer implements Twig_LexerInterface
     protected $positions;
     protected $currentVarBlockLine;
 
+    private $verbatimReplacements;
+
     const STATE_DATA = 0;
     const STATE_BLOCK = 1;
     const STATE_VAR = 2;
@@ -55,6 +57,7 @@ class Twig_Lexer implements Twig_LexerInterface
             'tag_block' => array('{%', '%}'),
             'tag_variable' => array('{{', '}}'),
             'whitespace_trim' => '-',
+            'verbatim_flag' => '@',
             'interpolation' => array('#{', '}'),
         ), $options);
 
@@ -66,9 +69,14 @@ class Twig_Lexer implements Twig_LexerInterface
             'lex_comment' => '/(?:'.preg_quote($this->options['whitespace_trim'], '/').preg_quote($this->options['tag_comment'][1], '/').'\s*|'.preg_quote($this->options['tag_comment'][1], '/').')\n?/s',
             'lex_block_raw' => '/\s*(raw|verbatim)\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')/As',
             'lex_block_line' => '/\s*line\s+(\d+)\s*'.preg_quote($this->options['tag_block'][1], '/').'/As',
-            'lex_tokens_start' => '/('.preg_quote($this->options['tag_variable'][0], '/').'|'.preg_quote($this->options['tag_block'][0], '/').'|'.preg_quote($this->options['tag_comment'][0], '/').')('.preg_quote($this->options['whitespace_trim'], '/').')?/s',
+            'lex_tokens_start' => '/('.preg_quote($this->options['tag_variable'][0], '/').'|'.preg_quote($this->options['tag_block'][0], '/').'|'.preg_quote($this->options['tag_comment'][0], '/').')(?!'.preg_quote($this->options['verbatim_flag'], '/').')('.preg_quote($this->options['whitespace_trim'], '/').')?/s',
             'interpolation_start' => '/'.preg_quote($this->options['interpolation'][0], '/').'\s*/A',
             'interpolation_end' => '/\s*'.preg_quote($this->options['interpolation'][1], '/').'/A',
+        );
+
+        $this->verbatimReplacements = array(
+            array($this->options['tag_comment'][0].$this->options['verbatim_flag'], $this->options['tag_block'][0].$this->options['verbatim_flag'], $this->options['tag_variable'][0].$this->options['verbatim_flag']),
+            array($this->options['tag_comment'][0], $this->options['tag_block'][0], $this->options['tag_variable'][0]),
         );
     }
 
@@ -143,7 +151,7 @@ class Twig_Lexer implements Twig_LexerInterface
     {
         // if no matches are left we return the rest of the template as simple text token
         if ($this->position == count($this->positions[0]) - 1) {
-            $this->pushToken(Twig_Token::TEXT_TYPE, substr($this->code, $this->cursor));
+            $this->pushToken(Twig_Token::TEXT_TYPE, $this->unescapeDelimiters(substr($this->code, $this->cursor)));
             $this->cursor = $this->end;
 
             return;
@@ -163,7 +171,7 @@ class Twig_Lexer implements Twig_LexerInterface
         if (isset($this->positions[2][$this->position][0])) {
             $text = rtrim($text);
         }
-        $this->pushToken(Twig_Token::TEXT_TYPE, $text);
+        $this->pushToken(Twig_Token::TEXT_TYPE, $this->unescapeDelimiters($text));
         $this->moveCursor($textContent.$position[0]);
 
         switch ($this->positions[1][$this->position][0]) {
@@ -407,5 +415,10 @@ class Twig_Lexer implements Twig_LexerInterface
         }
 
         $this->state = array_pop($this->states);
+    }
+
+    private function unescapeDelimiters($text)
+    {
+        return str_replace($this->verbatimReplacements[0], $this->verbatimReplacements[1], $text);
     }
 }

--- a/test/Twig/Tests/Fixtures/verbatim_blocks.test
+++ b/test/Twig/Tests/Fixtures/verbatim_blocks.test
@@ -1,0 +1,18 @@
+--TEST--
+verbatim blocks
+--TEMPLATE--
+{{ foo ~ " {{@" }}
+{{@ foo }}
+"{{@ foo }}"
+{%@ foo %}
+{#@ foo #}
+{{ foo ~ " {{@" }}
+--DATA--
+return array('foo' => 'foo');
+--EXPECT--
+foo {{@
+{{ foo }}
+"{{ foo }}"
+{% foo %}
+{# foo #}
+foo {{@


### PR DESCRIPTION
As some JS frameworks use the same block notation as Twig (mainly ``{{ }}``), it is quite inconvenient to mix them with Twig.

This PR adds a new way to escape a Twig block by adding ``@`` just after the opening delimiter (a bit like Blade: https://laravel.com/docs/5.3/blade#blade-and-javascript-frameworks).

closes #2032

What do you think @romainneutron?