### PR TITLE
changed the way we store template source in template classes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.25.0 (2016-XX-XX)
 
+ * changed the way we store template source in template classes
  * removed usage of realpath in cache keys
  * fixed Twig cache sharing when used with different versions of PHP
  * removed embed parent workaround for simple use cases

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -693,13 +693,7 @@ class Twig_Environment
     public function compileSource($source, $name = null)
     {
         try {
-            $compiled = $this->compile($this->parse($this->tokenize($source, $name)));
-
-            if (isset($source[0])) {
-                $compiled .= '/* '.str_replace(array('*/', "\r\n", "\r", "\n"), array('*//* ', "\n", "\n", "*/\n/* "), $source)."*/\n";
-            }
-
-            return $compiled;
+            return $this->compile($this->parse($this->tokenize($source, $name)));
         } catch (Twig_Error $e) {
             $e->setTemplateFile($name);
             throw $e;

--- a/lib/Twig/Lexer.php
+++ b/lib/Twig/Lexer.php
@@ -136,7 +136,7 @@ class Twig_Lexer implements Twig_LexerInterface
             mb_internal_encoding($mbEncoding);
         }
 
-        return new Twig_TokenStream($this->tokens, $this->filename);
+        return new Twig_TokenStream($this->tokens, $this->filename, $code);
     }
 
     protected function lexData()

--- a/lib/Twig/Node/Module.php
+++ b/lib/Twig/Node/Module.php
@@ -21,7 +21,7 @@
  */
 class Twig_Node_Module extends Twig_Node
 {
-    public function __construct(Twig_NodeInterface $body, Twig_Node_Expression $parent = null, Twig_NodeInterface $blocks, Twig_NodeInterface $macros, Twig_NodeInterface $traits, $embeddedTemplates, $filename)
+    public function __construct(Twig_NodeInterface $body, Twig_Node_Expression $parent = null, Twig_NodeInterface $blocks, Twig_NodeInterface $macros, Twig_NodeInterface $traits, $embeddedTemplates, $filename, $source = '')
     {
         $nodes = array(
             'body' => $body,
@@ -40,6 +40,7 @@ class Twig_Node_Module extends Twig_Node
 
         // embedded templates are set as attributes so that they are only visited once by the visitors
         parent::__construct($nodes, array(
+            'source' => $source,
             'filename' => $filename,
             'index' => null,
             'embedded_templates' => $embeddedTemplates,
@@ -92,6 +93,8 @@ class Twig_Node_Module extends Twig_Node
         $this->compileIsTraitable($compiler);
 
         $this->compileDebugInfo($compiler);
+
+        $this->compileGetSource($compiler);
 
         $this->compileClassFooter($compiler);
     }
@@ -385,6 +388,19 @@ class Twig_Node_Module extends Twig_Node
             ->write("public function getDebugInfo()\n", "{\n")
             ->indent()
             ->write(sprintf("return %s;\n", str_replace("\n", '', var_export(array_reverse($compiler->getDebugInfo(), true), true))))
+            ->outdent()
+            ->write("}\n\n")
+        ;
+    }
+
+    protected function compileGetSource(Twig_Compiler $compiler)
+    {
+        $compiler
+            ->write("public function getSource()\n", "{\n")
+            ->indent()
+            ->write('return ')
+            ->string($this->getAttribute('source'))
+            ->raw(";\n")
             ->outdent()
             ->write("}\n")
         ;

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -114,7 +114,7 @@ class Twig_Parser implements Twig_ParserInterface
             throw $e;
         }
 
-        $node = new Twig_Node_Module(new Twig_Node_Body(array($body)), $this->parent, new Twig_Node($this->blocks), new Twig_Node($this->macros), new Twig_Node($this->traits), $this->embeddedTemplates, $this->getFilename());
+        $node = new Twig_Node_Module(new Twig_Node_Body(array($body)), $this->parent, new Twig_Node($this->blocks), new Twig_Node($this->macros), new Twig_Node($this->traits), $this->embeddedTemplates, $this->getFilename(), $stream->getSource());
 
         $traverser = new Twig_NodeTraverser($this->env, $this->visitors);
 

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -52,6 +52,13 @@ abstract class Twig_Template implements Twig_TemplateInterface
     abstract public function getDebugInfo();
 
     /**
+     * Returns the template source code.
+     *
+     * @return string The template source code
+     */
+    abstract public function getSource();
+
+    /**
      * @deprecated since 1.20 (to be removed in 2.0)
      */
     public function getEnvironment()
@@ -327,33 +334,6 @@ abstract class Twig_Template implements Twig_TemplateInterface
     public function getBlocks()
     {
         return $this->blocks;
-    }
-
-    /**
-     * Returns the template source code.
-     *
-     * @return string|null The template source code or null if it is not available
-     */
-    public function getSource()
-    {
-        $reflector = new ReflectionClass($this);
-        $file = $reflector->getFileName();
-
-        if (!file_exists($file)) {
-            return;
-        }
-
-        $source = file($file, FILE_IGNORE_NEW_LINES);
-        array_splice($source, 0, $reflector->getEndLine());
-
-        $i = 0;
-        while (isset($source[$i]) && '/* */' === substr_replace($source[$i], '', 3, -2)) {
-            $source[$i] = str_replace('*//* ', '*/', substr($source[$i], 3, -2));
-            ++$i;
-        }
-        array_splice($source, $i);
-
-        return implode("\n", $source);
     }
 
     /**

--- a/lib/Twig/TokenStream.php
+++ b/lib/Twig/TokenStream.php
@@ -21,16 +21,20 @@ class Twig_TokenStream
     protected $current = 0;
     protected $filename;
 
+    private $source;
+
     /**
      * Constructor.
      *
      * @param array  $tokens        An array of tokens
      * @param string $filename|null The name of the filename which tokens are associated with
+     * @param string $source|null   The source code associated with the tokens
      */
-    public function __construct(array $tokens, $filename = null)
+    public function __construct(array $tokens, $filename = null, $source = null)
     {
         $this->tokens = $tokens;
         $this->filename = $filename;
+        $this->source = $source ? $source : '';
     }
 
     /**
@@ -151,5 +155,15 @@ class Twig_TokenStream
     public function getFilename()
     {
         return $this->filename;
+    }
+
+    /**
+     * Gets the source code associated with this stream.
+     *
+     * @return string
+     */
+    public function getSource()
+    {
+        return $this->source;
     }
 }

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -143,18 +143,6 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         */
     }
 
-    public function testCompileSourceInlinesSource()
-    {
-        $twig = new Twig_Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock());
-
-        $source = "<? */*foo*/ ?>\r\nbar\n";
-        $expected = "/* <? *//* *foo*//*  ?>*/\n/* bar*/\n/* */\n";
-        $compiled = $twig->compileSource($source, 'index');
-
-        $this->assertContains($expected, $compiled);
-        $this->assertNotContains('/**', $compiled);
-    }
-
     public function testExtensionsAreNotInitializedWhenRenderingACompiledTemplate()
     {
         $cache = new Twig_Cache_Filesystem($dir = sys_get_temp_dir().'/twig');

--- a/test/Twig/Tests/Node/ModuleTest.php
+++ b/test/Twig/Tests/Node/ModuleTest.php
@@ -73,6 +73,11 @@ class __TwigTemplate_%x extends Twig_Template
     {
         return array (  19 => 1,);
     }
+
+    public function getSource()
+    {
+        return "";
+    }
 }
 EOF
         , $twig, true);
@@ -126,6 +131,11 @@ class __TwigTemplate_%x extends Twig_Template
     {
         return array (  26 => 1,  24 => 2,  11 => 1,);
     }
+
+    public function getSource()
+    {
+        return "";
+    }
 }
 EOF
         , $twig, true);
@@ -139,7 +149,7 @@ EOF
                         2
                     );
 
-        $node = new Twig_Node_Module($body, $extends, $blocks, $macros, $traits, new Twig_Node(array()), $filename);
+        $node = new Twig_Node_Module($body, $extends, $blocks, $macros, $traits, new Twig_Node(array()), $filename, '{{ foo }}');
         $tests[] = array($node, <<<EOF
 <?php
 
@@ -173,6 +183,11 @@ class __TwigTemplate_%x extends Twig_Template
     public function getDebugInfo()
     {
         return array (  17 => 2,  15 => 4,  9 => 2,);
+    }
+
+    public function getSource()
+    {
+        return "{{ foo }}";
     }
 }
 EOF

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -84,13 +84,6 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
         return $tests;
     }
 
-    public function testGetSource()
-    {
-        $template = new Twig_TemplateTest(new Twig_Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()), false);
-
-        $this->assertSame("<? */*bar*/ ?>\n", $template->getSource());
-    }
-
     /**
      * @dataProvider getGetAttributeWithSandbox
      */
@@ -453,6 +446,11 @@ class Twig_TemplateTest extends Twig_Template
         return array();
     }
 
+    public function getSource()
+    {
+        return '';
+    }
+
     protected function doGetParent(array $context)
     {
     }
@@ -470,8 +468,6 @@ class Twig_TemplateTest extends Twig_Template
         }
     }
 }
-/* <? *//* *bar*//*  ?>*/
-/* */
 
 class Twig_TemplateArrayAccessObject implements ArrayAccess
 {


### PR DESCRIPTION
In #1807 and #1813, we added a way to get the original template source code from a template. This PR greatly simplifies the approach by removing all the black magic :)

This should also fix #2011

ping @nicolas-grekas 