### PR TITLE
Expanded definition of empty

### DIFF
--- a/doc/tests/empty.rst
+++ b/doc/tests/empty.rst
@@ -4,9 +4,9 @@
 ``empty`` checks if a variable is
  - an empty string
  - an empty array
+ - an empty hash
  - exactly ``false``
  - exactly ``null``
- - an instance of Countable_ and has a count_ of zero
 
 .. code-block:: jinja
 

--- a/doc/tests/empty.rst
+++ b/doc/tests/empty.rst
@@ -1,12 +1,7 @@
 ``empty``
 =========
 
-``empty`` checks if a variable is
- - an empty string
- - an empty array
- - an empty hash
- - exactly ``false``
- - exactly ``null``
+``empty`` checks if a variable is an empty string, an empty array, an empty hash, exactly ``false``, exactly ``null``:
 
 .. code-block:: jinja
 

--- a/doc/tests/empty.rst
+++ b/doc/tests/empty.rst
@@ -1,7 +1,12 @@
 ``empty``
 =========
 
-``empty`` checks if a variable is empty:
+``empty`` checks if a variable is
+ - an empty string
+ - an empty array
+ - exactly ``false``
+ - exactly ``null``
+ - an instance of Countable_ and has a count_ of zero
 
 .. code-block:: jinja
 
@@ -9,3 +14,7 @@
     {% if foo is empty %}
         ...
     {% endif %}
+
+.. _Countable: http://php.net/manual/en/class.countable.php
+.. _count: http://php.net/manual/en/function.count.php
+

--- a/doc/tests/empty.rst
+++ b/doc/tests/empty.rst
@@ -17,4 +17,3 @@
 
 .. _Countable: http://php.net/manual/en/class.countable.php
 .. _count: http://php.net/manual/en/function.count.php
-


### PR DESCRIPTION
Based on the [source](https://github.com/twigphp/Twig/blob/f61bc838a97c26e2952af09070d1c4847eeedbe7/lib/Twig/Extension/Core.php#L1405), defined 'empty'. The comment in the code block is too subtle and I didn't notice it until I got to the edit page, and it also does not fully describe the definition of empty based on what the code does.