### PR TITLE
Improved the error message when a child template defines contents outside parent blocks

### DIFF
--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -373,7 +373,7 @@ class Twig_Parser implements Twig_ParserInterface
             (!$node instanceof Twig_Node_Text && !$node instanceof Twig_Node_BlockReference && $node instanceof Twig_NodeOutputInterface)
         ) {
             if (false !== strpos((string) $node, chr(0xEF).chr(0xBB).chr(0xBF))) {
-                throw new Twig_Error_Syntax('The file of a template that extends another one cannot start with a byte order mark (BOM); it must be removed', $node->getLine(), $this->getFilename());
+                throw new Twig_Error_Syntax('A template that extends another one cannot start with a byte order mark (BOM); it must be removed', $node->getLine(), $this->getFilename());
             }
 
             throw new Twig_Error_Syntax('A template that extends another one cannot include contents outside Twig blocks. Did you forget to put the contents inside a {% block %} tag.', $node->getLine(), $this->getFilename());

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -373,10 +373,10 @@ class Twig_Parser implements Twig_ParserInterface
             (!$node instanceof Twig_Node_Text && !$node instanceof Twig_Node_BlockReference && $node instanceof Twig_NodeOutputInterface)
         ) {
             if (false !== strpos((string) $node, chr(0xEF).chr(0xBB).chr(0xBF))) {
-                throw new Twig_Error_Syntax('A template that extends another one cannot have a body but a byte order mark (BOM) has been detected; it must be removed.', $node->getLine(), $this->getFilename());
+                throw new Twig_Error_Syntax('The file of a template that extends another one cannot start with a byte order mark (BOM); it must be removed', $node->getLine(), $this->getFilename());
             }
 
-            throw new Twig_Error_Syntax('A template that extends another one cannot have a body.', $node->getLine(), $this->getFilename());
+            throw new Twig_Error_Syntax('A template that extends another one cannot include contents outside Twig blocks. Did you forget to put the contents inside a {% block %} tag.', $node->getLine(), $this->getFilename());
         }
 
         // bypass "set" nodes as they "capture" the output

--- a/test/Twig/Tests/Fixtures/exceptions/child_contents_outside_blocks.test
+++ b/test/Twig/Tests/Fixtures/exceptions/child_contents_outside_blocks.test
@@ -1,0 +1,15 @@
+--TEST--
+Exception for child templates defining contents outside blocks defined by parent
+--TEMPLATE--
+{% extends 'base.twig' %}
+
+Content outside a block.
+
+{% block sidebar %}
+    Content inside a block.
+{% endblock %}
+--TEMPLATE(base.twig)--
+{% block sidebar %}
+{% endblock %}
+--EXCEPTION--
+Twig_Error_Syntax: A template that extends another one cannot include contents outside Twig blocks. Did you forget to put the contents inside a {% block %} tag in "index.twig" at line 3.

--- a/test/Twig/Tests/ParserTest.php
+++ b/test/Twig/Tests/ParserTest.php
@@ -100,7 +100,7 @@ class Twig_Tests_ParserTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Twig_Error_Syntax
-     * @expectedExceptionMessage A template that extends another one cannot have a body but a byte order mark (BOM) has been detected; it must be removed at line 1.
+     * @expectedExceptionMessage The file of a template that extends another one cannot start with a byte order mark (BOM); it must be removed at line 1
      */
     public function testFilterBodyNodesWithBOM()
     {

--- a/test/Twig/Tests/ParserTest.php
+++ b/test/Twig/Tests/ParserTest.php
@@ -100,7 +100,7 @@ class Twig_Tests_ParserTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Twig_Error_Syntax
-     * @expectedExceptionMessage The file of a template that extends another one cannot start with a byte order mark (BOM); it must be removed at line 1
+     * @expectedExceptionMessage A template that extends another one cannot start with a byte order mark (BOM); it must be removed at line 1
      */
     public function testFilterBodyNodesWithBOM()
     {


### PR DESCRIPTION
### Context

When using template inheritance, you cannot put template contents outside Twig blocks (except some special tags (form_theme), macros, etc.) Sadly, making this mistake is very common when learning Twig.

### Problem

The error message associated to this issue is cryptic and "impossible to understand" for newcomers:

```
A template that extends another one cannot have a body.
```

I recently delivered a Symfony training and nobody was able to understand what the error was. They didn't have the slightest clue. I explained it to them ... and a few days latter they had the same problem and again they couldn't remember what this error was related to.

### Solution

Most of the Twig/Symfony errors are very helpful. Let's improve this one to make it useful too.

Two years ago I tried to fix this error message (see #1396). Let's see if this new PR is accepted.