### PR TITLE
Use cryptographically secure functions, if possible

### DIFF
--- a/lib/Twig/Compiler.php
+++ b/lib/Twig/Compiler.php
@@ -266,6 +266,6 @@ class Twig_Compiler
 
     public function getVarName()
     {
-        return sprintf('__internal_%s', hash('sha256', uniqid(mt_rand(), true), false));
+        return sprintf('__internal_%s', bin2hex(twig_random_bytes(32)));
     }
 }

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -346,7 +346,7 @@ class Twig_Environment
      */
     public function createTemplate($template)
     {
-        $name = sprintf('__string_template__%s', hash('sha256', uniqid(mt_rand(), true), false));
+        $name = sprintf('__string_template__%s', bin2hex(twig_random_bytes(32)));
 
         $loader = new Twig_Loader_Chain(array(
             new Twig_Loader_Array(array($name => $template)),

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -321,6 +321,48 @@ function twig_cycle($values, $position)
 }
 
 /**
+ * Wrapper for random bytes functions
+ *
+ * @param int               $length The length of the random string that should be returned in bytes.
+ *
+ * @return string Returns a string containing the requested number of random bytes
+ */
+function twig_random_bytes($length) {
+    if (function_exists('random_bytes')) {
+        return random_bytes($length);
+    }
+
+    // Warning: Might not be cryptographically secure!
+    if (function_exists('openssl_random_pseudo_bytes')) {
+        return openssl_random_pseudo_bytes($length);
+    }
+
+    // Warning: Not cryptographically secure!
+    $output = '';
+    while(strlen($output) < $length) {
+        $output .= hash('sha256', uniqid(mt_rand(), true), true);
+    }
+    return substr($output, 0, $length);
+}
+
+/**
+ * Wrapper for random integer functions
+ *
+ * @param int               $min The lowest value to be returned
+ * @param int               $max The highest value to be returned
+ *
+ * @return int Returns an integer in the range min to max, inclusive
+ */
+function twig_random_int($min, $max) {
+    if (function_exists('random_int')) {
+        return random_int($min, $max);
+    }
+
+    // Warning: Not cryptographically secure!
+    return mt_rand($min, $max);
+}
+
+/**
  * Returns a random value depending on the supplied parameter type:
  * - a random item from a Traversable or array
  * - a random character from a string
@@ -336,11 +378,11 @@ function twig_cycle($values, $position)
 function twig_random(Twig_Environment $env, $values = null)
 {
     if (null === $values) {
-        return mt_rand();
+        return twig_random_int(0, mt_getrandmax());
     }
 
     if (is_int($values) || is_float($values)) {
-        return $values < 0 ? mt_rand($values, 0) : mt_rand(0, $values);
+        return $values < 0 ? twig_random_int($values, 0) : twig_random_int(0, $values);
     }
 
     if ($values instanceof Traversable) {

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -321,13 +321,14 @@ function twig_cycle($values, $position)
 }
 
 /**
- * Wrapper for random bytes functions
+ * Wrapper for random bytes functions.
  *
- * @param int               $length The length of the random string that should be returned in bytes.
+ * @param int $length The length of the random string that should be returned in bytes.
  *
  * @return string Returns a string containing the requested number of random bytes
  */
-function twig_random_bytes($length) {
+function twig_random_bytes($length)
+{
     if (function_exists('random_bytes')) {
         return random_bytes($length);
     }
@@ -339,21 +340,23 @@ function twig_random_bytes($length) {
 
     // Warning: Not cryptographically secure!
     $output = '';
-    while(strlen($output) < $length) {
+    while (strlen($output) < $length) {
         $output .= hash('sha256', uniqid(mt_rand(), true), true);
     }
+
     return substr($output, 0, $length);
 }
 
 /**
- * Wrapper for random integer functions
+ * Wrapper for random integer functions.
  *
- * @param int               $min The lowest value to be returned
- * @param int               $max The highest value to be returned
+ * @param int $min The lowest value to be returned
+ * @param int $max The highest value to be returned
  *
  * @return int Returns an integer in the range min to max, inclusive
  */
-function twig_random_int($min, $max) {
+function twig_random_int($min, $max)
+{
     if (function_exists('random_int')) {
         return random_int($min, $max);
     }

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -48,7 +48,7 @@ class Twig_Parser
 
     public function getVarName()
     {
-        return sprintf('__internal_%s', hash('sha256', uniqid(mt_rand(), true), false));
+        return sprintf('__internal_%s', bin2hex(twig_random_bytes(32)));
     }
 
     public function getFilename()
@@ -282,7 +282,7 @@ class Twig_Parser
 
     public function embedTemplate(Twig_Node_Module $template)
     {
-        $template->setIndex(mt_rand());
+        $template->setIndex(twig_random_int(0, mt_getrandmax()));
 
         $this->embeddedTemplates[] = $template;
     }

--- a/lib/Twig/Profiler/NodeVisitor/Profiler.php
+++ b/lib/Twig/Profiler/NodeVisitor/Profiler.php
@@ -59,7 +59,7 @@ class Twig_Profiler_NodeVisitor_Profiler extends Twig_BaseNodeVisitor
 
     private function getVarName()
     {
-        return sprintf('__internal_%s', hash('sha256', uniqid(mt_rand(), true), false));
+        return sprintf('__internal_%s', bin2hex(twig_random_bytes(32)));
     }
 
     /**

--- a/lib/Twig/Test/IntegrationTestCase.php
+++ b/lib/Twig/Test/IntegrationTestCase.php
@@ -156,7 +156,7 @@ abstract class Twig_Test_IntegrationTestCase extends PHPUnit_Framework_TestCase
             // avoid using the same PHP class name for different cases
             $p = new ReflectionProperty($twig, 'templateClassPrefix');
             $p->setAccessible(true);
-            $p->setValue($twig, '__TwigTemplate_'.hash('sha256', uniqid(mt_rand(), true), false).'_');
+            $p->setValue($twig, '__TwigTemplate_'.bin2hex(twig_random_bytes(32)).'_');
 
             try {
                 $template = $twig->loadTemplate('index.twig');

--- a/test/Twig/Tests/Cache/FilesystemTest.php
+++ b/test/Twig/Tests/Cache/FilesystemTest.php
@@ -19,7 +19,7 @@ class Twig_Tests_Cache_FilesystemTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $nonce = hash('sha256', uniqid(mt_rand(), true));
+        $nonce = bin2hex(twig_random_bytes(32));
         $this->classname = '__Twig_Tests_Cache_FilesystemTest_Template_'.$nonce;
         $this->directory = sys_get_temp_dir().'/twig-test';
         $this->cache = new Twig_Cache_Filesystem($this->directory);


### PR DESCRIPTION
PHP 7 and [random_compat](https://github.com/paragonie/random_compat) library provide proper `random_bytes` and `random_int` functions. Use those, where possible, by adding two wrapper functions: `twig_random_bytes` and `twig_random_int`

For example:
`hash('sha256', uniqid(mt_rand(), true), false)` -> `bin2hex(twig_random_bytes(32))`
`mt_rand` -> `twig_random_int`