### PR TITLE
fixed regression on static calls for functions/filters/tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 1.26.1 (2016-XX-XX)
 
- * n/a
+ * fixed regression on static calls for functions/filters/tests
 
 * 1.26.0 (2016-10-02)
 

--- a/test/Twig/Tests/Fixtures/expressions/magic_call.test
+++ b/test/Twig/Tests/Fixtures/expressions/magic_call.test
@@ -6,21 +6,21 @@ Twig supports __call() for attributes
 --DATA--
 class TestClassForMagicCallAttributes
 {
-  public function getBar()
-  {
-    return 'bar_from_getbar';
-  }
-
-  public function __call($method, $arguments)
-  {
-    if ('foo' === $method)
+    public function getBar()
     {
-      return 'foo_from_call';
+        return 'bar_from_getbar';
     }
 
-    return false;
-  }
+    public function __call($method, $arguments)
+    {
+        if ('foo' === $method) {
+            return 'foo_from_call';
+        }
+
+        return false;
+    }
 }
+
 return array('foo' => new TestClassForMagicCallAttributes())
 --EXPECT--
 foo_from_call

--- a/test/Twig/Tests/Fixtures/functions/magic_call.test
+++ b/test/Twig/Tests/Fixtures/functions/magic_call.test
@@ -1,0 +1,8 @@
+--TEST--
+__call calls
+--TEMPLATE--
+{{ 'foo'|magic_call }}
+--DATA--
+return array()
+--EXPECT--
+magic_foo

--- a/test/Twig/Tests/Fixtures/functions/magic_call53.test
+++ b/test/Twig/Tests/Fixtures/functions/magic_call53.test
@@ -1,0 +1,12 @@
+--TEST--
+__staticCall calls
+--CONDITION--
+version_compare(phpversion(), '5.3.0', '>=')
+--TEMPLATE--
+{{ 'foo'|magic_call_string }}
+{{ 'foo'|magic_call_array }}
+--DATA--
+return array()
+--EXPECT--
+static_magic_foo
+static_magic_foo

--- a/test/Twig/Tests/IntegrationTest.php
+++ b/test/Twig/Tests/IntegrationTest.php
@@ -143,6 +143,9 @@ class TwigTestExtension extends Twig_Extension
             new Twig_SimpleFilter('preserves_safety', array($this, 'preserves_safety'), array('preserves_safety' => array('html'))),
             new Twig_SimpleFilter('static_call_string', 'TwigTestExtension::staticCall'),
             new Twig_SimpleFilter('static_call_array', array('TwigTestExtension', 'staticCall')),
+            new Twig_SimpleFilter('magic_call', array($this, 'magicCall')),
+            new Twig_SimpleFilter('magic_call_string', 'TwigTestExtension::magicStaticCall'),
+            new Twig_SimpleFilter('magic_call_array', array('TwigTestExtension', 'magicStaticCall')),
             new Twig_SimpleFilter('*_path', array($this, 'dynamic_path')),
             new Twig_SimpleFilter('*_foo_*_bar', array($this, 'dynamic_foo')),
         );
@@ -229,5 +232,23 @@ class TwigTestExtension extends Twig_Extension
     public function is_multi_word($value)
     {
         return false !== strpos($value, ' ');
+    }
+
+    public function __call($method, $arguments)
+    {
+        if ('magicCall' !== $method) {
+            throw new BadMethodCallException('Unexpected call to __call');
+        }
+
+        return 'magic_'.$arguments[0];
+    }
+
+    public static function __callStatic($method, $arguments)
+    {
+        if ('magicStaticCall' !== $method) {
+            throw new BadMethodCallException('Unexpected call to __callStatic');
+        }
+
+        return 'static_magic_'.$arguments[0];
     }
 }


### PR DESCRIPTION
fixes #2160

What about deprecate this possibility? Using `__call()`/`__staticCall()` means that we don't support named arguments for instance.
