### PR TITLE
default implementation of getDebugInfo() for BC

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -49,7 +49,10 @@ abstract class Twig_Template implements Twig_TemplateInterface
      *
      * @internal
      */
-    abstract public function getDebugInfo();
+    public function getDebugInfo()
+    {
+        return array();
+    }
 
     /**
      * Returns the template source code.


### PR DESCRIPTION
eZ updated the code on their side in the meantime (see ezsystems/LegacyBridge#63), but there may be other projects doing similar things (fixes https://github.com/twigphp/Twig/pull/2129#discussion_r80250969).