### PR TITLE
Move check for isDebug() to determine to show source to Parser.

### DIFF
--- a/lib/Twig/Lexer.php
+++ b/lib/Twig/Lexer.php
@@ -136,7 +136,7 @@ class Twig_Lexer implements Twig_LexerInterface
             mb_internal_encoding($mbEncoding);
         }
 
-        return new Twig_TokenStream($this->tokens, $this->filename, $this->env->isDebug() ? $code : '');
+        return new Twig_TokenStream($this->tokens, $this->filename, $code);
     }
 
     protected function lexData()

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -114,7 +114,7 @@ class Twig_Parser implements Twig_ParserInterface
             throw $e;
         }
 
-        $node = new Twig_Node_Module(new Twig_Node_Body(array($body)), $this->parent, new Twig_Node($this->blocks), new Twig_Node($this->macros), new Twig_Node($this->traits), $this->embeddedTemplates, $this->getFilename(), $stream->getSource());
+        $node = new Twig_Node_Module(new Twig_Node_Body(array($body)), $this->parent, new Twig_Node($this->blocks), new Twig_Node($this->macros), new Twig_Node($this->traits), $this->embeddedTemplates, $this->getFilename(), $this->env->isDebug() ? $stream->getSource() : '');
 
         $traverser = new Twig_NodeTraverser($this->env, $this->visitors);
 

--- a/test/Twig/Tests/LexerTest.php
+++ b/test/Twig/Tests/LexerTest.php
@@ -16,7 +16,7 @@ class Twig_Tests_LexerTest extends PHPUnit_Framework_TestCase
         $lexer = new Twig_Lexer($env);
 
         $env->disableDebug();
-        $this->assertSame('', $lexer->tokenize('foo')->getSource());
+        $this->assertSame('foo', $lexer->tokenize('foo')->getSource());
 
         $env->enableDebug();
         $this->assertSame('foo', $lexer->tokenize('foo')->getSource());


### PR DESCRIPTION
This might need a new test to ensure isDebug() disables showing source in getSource() method.

Closes: #2167