### PR TITLE
Added source file in debug info when available

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
-* 1.26.2 (2016-XX-XX)
+* 1.27.0 (2016-XX-XX)
 
- * Fixed template paths when a template name contains a protocol like vfs://
+ * added source file in debug info when available
+ * fixed template paths when a template name contains a protocol like vfs://
  * improved debugging with Twig_Sandbox_SecurityError exceptions for disallowed methods and properties
 
 * 1.26.1 (2016-10-05)

--- a/lib/Twig/Node/Module.php
+++ b/lib/Twig/Node/Module.php
@@ -384,10 +384,18 @@ class Twig_Node_Module extends Twig_Node
 
     protected function compileDebugInfo(Twig_Compiler $compiler)
     {
+        $debugInfo = array_reverse($compiler->getDebugInfo(), true);
+        $loader = $compiler->getEnvironment()->getLoader();
+        $name = $this->getAttribute('filename');
+
+        if ($loader instanceof Twig_Loader_Filesystem && file_exists($file = $loader->getCacheKey($name))) {
+            $debugInfo['file'] = $file;
+        }
+
         $compiler
             ->write("public function getDebugInfo()\n", "{\n")
             ->indent()
-            ->write(sprintf("return %s;\n", str_replace("\n", '', var_export(array_reverse($compiler->getDebugInfo(), true), true))))
+            ->write(sprintf("return %s;\n", str_replace("\n", '', var_export($debugInfo, true))))
             ->outdent()
             ->write("}\n\n")
         ;

--- a/test/Twig/Tests/ErrorTest.php
+++ b/test/Twig/Tests/ErrorTest.php
@@ -29,7 +29,8 @@ class Twig_Tests_ErrorTest extends PHPUnit_Framework_TestCase
 
     public function testTwigExceptionAddsFileAndLineWhenMissingWithInheritanceOnDisk()
     {
-        $loader = new Twig_Loader_Filesystem(dirname(__FILE__).'/Fixtures/errors');
+        $dir = dirname(__FILE__).DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'errors'.DIRECTORY_SEPARATOR;
+        $loader = new Twig_Loader_Filesystem($dir);
         $twig = new Twig_Environment($loader, array('strict_variables' => true, 'debug' => true, 'cache' => false));
 
         $template = $twig->loadTemplate('index.html');
@@ -41,6 +42,9 @@ class Twig_Tests_ErrorTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('Variable "foo" does not exist in "index.html" at line 3.', $e->getMessage());
             $this->assertEquals(3, $e->getTemplateLine());
             $this->assertEquals('index.html', $e->getTemplateFile());
+
+            $debugInfo = $template->getDebugInfo();
+            $this->assertEquals($dir.'index.html', $debugInfo['file']);
         }
 
         try {


### PR DESCRIPTION
We need the source file to create IDE links from `$template` objects found in e.g. exceptions'' trace/context.