### PR TITLE
Improved Sandbox error handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 1.26.2 (2016-XX-XX)
 
- * n/a
+ * improved debugging with Twig_Sandbox_SecurityError exceptions for disallowed methods and properties
 
 * 1.26.1 (2016-10-05)
 

--- a/lib/Twig/Sandbox/SecurityNotAllowedMethodError.php
+++ b/lib/Twig/Sandbox/SecurityNotAllowedMethodError.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Exception thrown when a not allowed class method is used in a template.
+ *
+ * @author Kit Burton-Senior <mail@kitbs.com>
+ */
+class Twig_Sandbox_SecurityNotAllowedMethodError extends Twig_Sandbox_SecurityError
+{
+    private $className;
+    private $methodName;
+
+    public function __construct($message, $className, $methodName, $lineno = -1, $filename = null, Exception $previous = null)
+    {
+        parent::__construct($message, $lineno, $filename, $previous);
+        $this->className = $className;
+        $this->methodName = $methodName;
+    }
+
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    public function getMethodName()
+    {
+        return $this->methodName;
+    }
+}

--- a/lib/Twig/Sandbox/SecurityNotAllowedPropertyError.php
+++ b/lib/Twig/Sandbox/SecurityNotAllowedPropertyError.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Exception thrown when a not allowed class property is used in a template.
+ *
+ * @author Kit Burton-Senior <mail@kitbs.com>
+ */
+class Twig_Sandbox_SecurityNotAllowedPropertyError extends Twig_Sandbox_SecurityError
+{
+    private $className;
+    private $propertyName;
+
+    public function __construct($message, $className, $propertyName, $lineno = -1, $filename = null, Exception $previous = null)
+    {
+        parent::__construct($message, $lineno, $filename, $previous);
+        $this->className = $className;
+        $this->propertyName = $propertyName;
+    }
+
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    public function getPropertyName()
+    {
+        return $this->propertyName;
+    }
+}

--- a/lib/Twig/Sandbox/SecurityPolicy.php
+++ b/lib/Twig/Sandbox/SecurityPolicy.php
@@ -97,7 +97,8 @@ class Twig_Sandbox_SecurityPolicy implements Twig_Sandbox_SecurityPolicyInterfac
         }
 
         if (!$allowed) {
-            throw new Twig_Sandbox_SecurityError(sprintf('Calling "%s" method on a "%s" object is not allowed.', $method, get_class($obj)));
+            $class = get_class($obj);
+            throw new Twig_Sandbox_SecurityNotAllowedMethodError(sprintf('Calling "%s" method on a "%s" object is not allowed.', $method, $class), $class, $method);
         }
     }
 
@@ -113,7 +114,8 @@ class Twig_Sandbox_SecurityPolicy implements Twig_Sandbox_SecurityPolicyInterfac
         }
 
         if (!$allowed) {
-            throw new Twig_Sandbox_SecurityError(sprintf('Calling "%s" property on a "%s" object is not allowed.', $property, get_class($obj)));
+            $class = get_class($obj);
+            throw new Twig_Sandbox_SecurityNotAllowedPropertyError(sprintf('Calling "%s" property on a "%s" object is not allowed.', $property, $class), $class, $property);
         }
     }
 }

--- a/test/Twig/Tests/Extension/SandboxTest.php
+++ b/test/Twig/Tests/Extension/SandboxTest.php
@@ -57,6 +57,9 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic1')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed method is called');
         } catch (Twig_Sandbox_SecurityError $e) {
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e);
+            $this->assertEquals('FooObject', $e->getClassName());
+            $this->assertEquals('foo', $e->getMethodName());
         }
 
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -64,6 +67,8 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic2')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed filter is called');
         } catch (Twig_Sandbox_SecurityError $e) {
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedFilterError::class, $e);
+            $this->assertEquals('upper', $e->getFilterName());
         }
 
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -71,6 +76,8 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic3')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed tag is used in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedTagError::class, $e);
+            $this->assertEquals('if', $e->getTagName());
         }
 
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -78,6 +85,9 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic4')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed property is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedPropertyError::class, $e);
+            $this->assertEquals('FooObject', $e->getClassName());
+            $this->assertEquals('bar', $e->getPropertyName());
         }
 
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -85,6 +95,9 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic5')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed method (__toString()) is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e);
+            $this->assertEquals('FooObject', $e->getClassName());
+            $this->assertEquals('__tostring', $e->getMethodName());
         }
 
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -92,6 +105,9 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic6')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed method (__toString()) is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e);
+            $this->assertEquals('FooObject', $e->getClassName());
+            $this->assertEquals('__tostring', $e->getMethodName());
         }
 
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -99,6 +115,8 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic7')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed function is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedFunctionError::class, $e);
+            $this->assertEquals('cycle', $e->getFunctionName());
         }
 
         $twig = $this->getEnvironment(true, array(), self::$templates, array(), array(), array('FooObject' => 'foo'));
@@ -158,6 +176,8 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('3_basic')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception when the included file is sandboxed');
         } catch (Twig_Sandbox_SecurityError $e) {
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedTagError::class, $e);
+            $this->assertEquals('sandbox', $e->getTagName());
         }
     }
 

--- a/test/Twig/Tests/Extension/SandboxTest.php
+++ b/test/Twig/Tests/Extension/SandboxTest.php
@@ -60,7 +60,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic1')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed method is called');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedMethodError');
+            $this->assertInstanceOf('Twig_Sandbox_SecurityNotAllowedMethodError', $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedMethodError');
             $this->assertEquals('FooObject', $e->getClassName(), 'Exception should be raised on the "FooObject" class');
             $this->assertEquals('foo', $e->getMethodName(), 'Exception should be raised on the "foo" method');
         }
@@ -73,7 +73,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic2')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed filter is called');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedFilterError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFilterError');
+            $this->assertInstanceOf('Twig_Sandbox_SecurityNotAllowedFilterError', $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFilterError');
             $this->assertEquals('upper', $e->getFilterName(), 'Exception should be raised on the "upper" filter');
         }
     }
@@ -85,7 +85,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic3')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed tag is used in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedTagError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedTagError');
+            $this->assertInstanceOf('Twig_Sandbox_SecurityNotAllowedTagError', $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedTagError');
             $this->assertEquals('if', $e->getTagName(), 'Exception should be raised on the "if" tag');
         }
     }
@@ -97,7 +97,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic4')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed property is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedPropertyError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedPropertyError');
+            $this->assertInstanceOf('Twig_Sandbox_SecurityNotAllowedPropertyError', $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedPropertyError');
             $this->assertEquals('FooObject', $e->getClassName(), 'Exception should be raised on the "FooObject" class');
             $this->assertEquals('bar', $e->getPropertyName(), 'Exception should be raised on the "bar" property');
         }
@@ -110,7 +110,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic5')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed method (__toString()) is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedMethodError');
+            $this->assertInstanceOf('Twig_Sandbox_SecurityNotAllowedMethodError', $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedMethodError');
             $this->assertEquals('FooObject', $e->getClassName(), 'Exception should be raised on the "FooObject" class');
             $this->assertEquals('__tostring', $e->getMethodName(), 'Exception should be raised on the "__toString" method');
         }
@@ -123,7 +123,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic6')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed method (__toString()) is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedMethodError');
+            $this->assertInstanceOf('Twig_Sandbox_SecurityNotAllowedMethodError', $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedMethodError');
             $this->assertEquals('FooObject', $e->getClassName(), 'Exception should be raised on the "FooObject" class');
             $this->assertEquals('__tostring', $e->getMethodName(), 'Exception should be raised on the "__toString" method');
         }
@@ -136,7 +136,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('1_basic7')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed function is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedFunctionError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFunctionError');
+            $this->assertInstanceOf('Twig_Sandbox_SecurityNotAllowedFunctionError', $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFunctionError');
             $this->assertEquals('cycle', $e->getFunctionName(), 'Exception should be raised on the "cycle" function');
         }
     }
@@ -221,7 +221,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('3_basic')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception when the included file is sandboxed');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedTagError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedTagError');
+            $this->assertInstanceOf('Twig_Sandbox_SecurityNotAllowedTagError', $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedTagError');
             $this->assertEquals('sandbox', $e->getTagName());
         }
     }

--- a/test/Twig/Tests/Extension/SandboxTest.php
+++ b/test/Twig/Tests/Extension/SandboxTest.php
@@ -52,7 +52,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
         $twig = $this->getEnvironment(false, array(), self::$templates);
         $this->assertEquals('FOO', $twig->loadTemplate('1_basic')->render(self::$params), 'Sandbox does nothing if it is disabled globally');
     }
-    
+
     public function testSandboxUnallowedMethodAccessor()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -65,7 +65,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('foo', $e->getMethodName(), 'Exception should be raised on the "foo" method');
         }
     }
-    
+
     public function testSandboxUnallowedFilter()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -77,7 +77,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('upper', $e->getFilterName(), 'Exception should be raised on the "upper" filter');
         }
     }
-    
+
     public function testSandboxUnallowedTag()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -89,7 +89,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('if', $e->getTagName(), 'Exception should be raised on the "if" tag');
         }
     }
-    
+
     public function testSandboxUnallowedProperty()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -102,7 +102,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('bar', $e->getPropertyName(), 'Exception should be raised on the "bar" property');
         }
     }
-    
+
     public function testSandboxUnallowedToString()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -115,7 +115,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('__tostring', $e->getMethodName(), 'Exception should be raised on the "__toString" method');
         }
     }
-    
+
     public function testSandboxUnallowedToStringArray()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -128,7 +128,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('__tostring', $e->getMethodName(), 'Exception should be raised on the "__toString" method');
         }
     }
-    
+
     public function testSandboxUnallowedFunction()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates);
@@ -140,7 +140,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('cycle', $e->getFunctionName(), 'Exception should be raised on the "cycle" function');
         }
     }
-    
+
     public function testSandboxAllowMethodFoo()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates, array(), array(), array('FooObject' => 'foo'));
@@ -148,7 +148,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $twig->loadTemplate('1_basic1')->render(self::$params), 'Sandbox allow some methods');
         $this->assertEquals(1, FooObject::$called['foo'], 'Sandbox only calls method once');
     }
-    
+
     public function testSandboxAllowMethodToString()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates, array(), array(), array('FooObject' => '__toString'));
@@ -156,7 +156,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $twig->loadTemplate('1_basic5')->render(self::$params), 'Sandbox allow some methods');
         $this->assertEquals(1, FooObject::$called['__toString'], 'Sandbox only calls method once');
     }
-    
+
     public function testSandboxAllowMethodToStringDisabled()
     {
         $twig = $this->getEnvironment(false, array(), self::$templates);
@@ -164,31 +164,31 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $twig->loadTemplate('1_basic5')->render(self::$params), 'Sandbox allows __toString when sandbox disabled');
         $this->assertEquals(1, FooObject::$called['__toString'], 'Sandbox only calls method once');
     }
-    
+
     public function testSandboxAllowFilter()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates, array(), array('upper'));
         $this->assertEquals('FABIEN', $twig->loadTemplate('1_basic2')->render(self::$params), 'Sandbox allow some filters');
     }
-    
+
     public function testSandboxAllowTag()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates, array('if'));
         $this->assertEquals('foo', $twig->loadTemplate('1_basic3')->render(self::$params), 'Sandbox allow some tags');
     }
-    
+
     public function testSandboxAllowProperty()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates, array(), array(), array(), array('FooObject' => 'bar'));
         $this->assertEquals('bar', $twig->loadTemplate('1_basic4')->render(self::$params), 'Sandbox allow some properties');
     }
-    
+
     public function testSandboxAllowFunction()
     {
         $twig = $this->getEnvironment(true, array(), self::$templates, array(), array(), array(), array(), array('cycle'));
         $this->assertEquals('bar', $twig->loadTemplate('1_basic7')->render(self::$params), 'Sandbox allow some functions');
     }
-    
+
     public function testSandboxAllowFunctionsCaseInsensitive()
     {
         foreach (array('getfoobar', 'getFoobar', 'getFooBar') as $name) {

--- a/test/Twig/Tests/Extension/SandboxTest.php
+++ b/test/Twig/Tests/Extension/SandboxTest.php
@@ -51,101 +51,146 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
     {
         $twig = $this->getEnvironment(false, array(), self::$templates);
         $this->assertEquals('FOO', $twig->loadTemplate('1_basic')->render(self::$params), 'Sandbox does nothing if it is disabled globally');
-
+    }
+    
+    public function testSandboxUnallowedMethodAccessor()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates);
         try {
             $twig->loadTemplate('1_basic1')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed method is called');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e);
-            $this->assertEquals('FooObject', $e->getClassName());
-            $this->assertEquals('foo', $e->getMethodName());
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedMethodError');
+            $this->assertEquals('FooObject', $e->getClassName(), 'Exception should be raised on the "FooObject" class');
+            $this->assertEquals('foo', $e->getMethodName(), 'Exception should be raised on the "foo" method');
         }
-
+    }
+    
+    public function testSandboxUnallowedFilter()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates);
         try {
             $twig->loadTemplate('1_basic2')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed filter is called');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedFilterError::class, $e);
-            $this->assertEquals('upper', $e->getFilterName());
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedFilterError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFilterError');
+            $this->assertEquals('upper', $e->getFilterName(), 'Exception should be raised on the "upper" filter');
         }
-
+    }
+    
+    public function testSandboxUnallowedTag()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates);
         try {
             $twig->loadTemplate('1_basic3')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed tag is used in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedTagError::class, $e);
-            $this->assertEquals('if', $e->getTagName());
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedTagError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedTagError');
+            $this->assertEquals('if', $e->getTagName(), 'Exception should be raised on the "if" tag');
         }
-
+    }
+    
+    public function testSandboxUnallowedProperty()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates);
         try {
             $twig->loadTemplate('1_basic4')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed property is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedPropertyError::class, $e);
-            $this->assertEquals('FooObject', $e->getClassName());
-            $this->assertEquals('bar', $e->getPropertyName());
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedPropertyError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedPropertyError');
+            $this->assertEquals('FooObject', $e->getClassName(), 'Exception should be raised on the "FooObject" class');
+            $this->assertEquals('bar', $e->getPropertyName(), 'Exception should be raised on the "bar" property');
         }
-
+    }
+    
+    public function testSandboxUnallowedToString()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates);
         try {
             $twig->loadTemplate('1_basic5')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed method (__toString()) is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e);
-            $this->assertEquals('FooObject', $e->getClassName());
-            $this->assertEquals('__tostring', $e->getMethodName());
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedMethodError');
+            $this->assertEquals('FooObject', $e->getClassName(), 'Exception should be raised on the "FooObject" class');
+            $this->assertEquals('__tostring', $e->getMethodName(), 'Exception should be raised on the "__toString" method');
         }
-
+    }
+    
+    public function testSandboxUnallowedToStringArray()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates);
         try {
             $twig->loadTemplate('1_basic6')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed method (__toString()) is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e);
-            $this->assertEquals('FooObject', $e->getClassName());
-            $this->assertEquals('__tostring', $e->getMethodName());
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedMethodError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedMethodError');
+            $this->assertEquals('FooObject', $e->getClassName(), 'Exception should be raised on the "FooObject" class');
+            $this->assertEquals('__tostring', $e->getMethodName(), 'Exception should be raised on the "__toString" method');
         }
-
+    }
+    
+    public function testSandboxUnallowedFunction()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates);
         try {
             $twig->loadTemplate('1_basic7')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed function is called in the template');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedFunctionError::class, $e);
-            $this->assertEquals('cycle', $e->getFunctionName());
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedFunctionError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFunctionError');
+            $this->assertEquals('cycle', $e->getFunctionName(), 'Exception should be raised on the "cycle" function');
         }
-
+    }
+    
+    public function testSandboxAllowMethodFoo()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates, array(), array(), array('FooObject' => 'foo'));
         FooObject::reset();
         $this->assertEquals('foo', $twig->loadTemplate('1_basic1')->render(self::$params), 'Sandbox allow some methods');
         $this->assertEquals(1, FooObject::$called['foo'], 'Sandbox only calls method once');
-
+    }
+    
+    public function testSandboxAllowMethodToString()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates, array(), array(), array('FooObject' => '__toString'));
         FooObject::reset();
         $this->assertEquals('foo', $twig->loadTemplate('1_basic5')->render(self::$params), 'Sandbox allow some methods');
         $this->assertEquals(1, FooObject::$called['__toString'], 'Sandbox only calls method once');
-
+    }
+    
+    public function testSandboxAllowMethodToStringDisabled()
+    {
         $twig = $this->getEnvironment(false, array(), self::$templates);
         FooObject::reset();
         $this->assertEquals('foo', $twig->loadTemplate('1_basic5')->render(self::$params), 'Sandbox allows __toString when sandbox disabled');
         $this->assertEquals(1, FooObject::$called['__toString'], 'Sandbox only calls method once');
-
+    }
+    
+    public function testSandboxAllowFilter()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates, array(), array('upper'));
         $this->assertEquals('FABIEN', $twig->loadTemplate('1_basic2')->render(self::$params), 'Sandbox allow some filters');
-
+    }
+    
+    public function testSandboxAllowTag()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates, array('if'));
         $this->assertEquals('foo', $twig->loadTemplate('1_basic3')->render(self::$params), 'Sandbox allow some tags');
-
+    }
+    
+    public function testSandboxAllowProperty()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates, array(), array(), array(), array('FooObject' => 'bar'));
         $this->assertEquals('bar', $twig->loadTemplate('1_basic4')->render(self::$params), 'Sandbox allow some properties');
-
+    }
+    
+    public function testSandboxAllowFunction()
+    {
         $twig = $this->getEnvironment(true, array(), self::$templates, array(), array(), array(), array(), array('cycle'));
         $this->assertEquals('bar', $twig->loadTemplate('1_basic7')->render(self::$params), 'Sandbox allow some functions');
-
+    }
+    
+    public function testSandboxAllowFunctionsCaseInsensitive()
+    {
         foreach (array('getfoobar', 'getFoobar', 'getFooBar') as $name) {
             $twig = $this->getEnvironment(true, array(), self::$templates, array(), array(), array('FooObject' => $name));
             FooObject::reset();
@@ -176,7 +221,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             $twig->loadTemplate('3_basic')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception when the included file is sandboxed');
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedTagError::class, $e);
+            $this->assertInstanceOf(Twig_Sandbox_SecurityNotAllowedTagError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedTagError');
             $this->assertEquals('sandbox', $e->getTagName());
         }
     }


### PR DESCRIPTION
On the model of the SecurityNotAllowedFilterError, SecurityNotAllowedFunctionError and SecurityNotAllowedTagError, I added SecurityNotAllowedMethodError and SecurityNotAllowedPropertyError to allow the user to retrieve both the $className and $methodName/$propertyName from the exception.