### PR TITLE
undeprecate interface for a smooth upgrade path

### DIFF
--- a/lib/Twig/ExistsLoaderInterface.php
+++ b/lib/Twig/ExistsLoaderInterface.php
@@ -11,8 +11,6 @@
 
 /**
  * Empty interface for Twig 1.x compatibility.
- *
- * @deprecated to be removed in 3.0
  */
 interface Twig_ExistsLoaderInterface extends Twig_LoaderInterface
 {

--- a/lib/Twig/Extension/InitRuntimeInterface.php
+++ b/lib/Twig/Extension/InitRuntimeInterface.php
@@ -16,8 +16,6 @@
  * deprecated initRuntime() method in your extensions.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @deprecated to be removed in 3.0
  */
 interface Twig_Extension_InitRuntimeInterface
 {

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -259,14 +259,8 @@ class Twig_Parser
     {
         $this->macros[$name] = $node;
     }
-
-    /**
-     * @deprecated since 2.0. Will be removed in 3.0. There is no reserved macro names anymore
-     */
     public function isReservedMacroName($name)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.0 and will be removed in 3.0.', E_USER_DEPRECATED);
-
         return false;
     }
 

--- a/lib/Twig/SimpleFilter.php
+++ b/lib/Twig/SimpleFilter.php
@@ -11,8 +11,6 @@
 
 /**
  * Empty class for Twig 1.x compatibility.
- *
- * @deprecated to be removed in 3.0
  */
 class Twig_SimpleFilter extends Twig_Filter
 {

--- a/lib/Twig/SimpleFunction.php
+++ b/lib/Twig/SimpleFunction.php
@@ -11,8 +11,6 @@
 
 /**
  * Empty class for Twig 1.x compatibility.
- *
- * @deprecated to be removed in 3.0
  */
 class Twig_SimpleFunction extends Twig_Function
 {

--- a/lib/Twig/SimpleTest.php
+++ b/lib/Twig/SimpleTest.php
@@ -11,8 +11,6 @@
 
 /**
  * Empty class for Twig 1.x compatibility.
- *
- * @deprecated to be removed in 3.0
  */
 class Twig_SimpleTest extends Twig_Test
 {


### PR DESCRIPTION
The interface should then become deprecated in Twig 2.1 (see https://github.com/symfony/symfony/issues/18427#issuecomment-253293223).