### PR TITLE
optionally specify array keys

### DIFF
--- a/lib/Twig/ExpressionParser.php
+++ b/lib/Twig/ExpressionParser.php
@@ -240,7 +240,13 @@ class Twig_ExpressionParser
             }
             $first = false;
 
-            $node->addElement($this->parseExpression());
+            $value = $this->parseExpression();
+            if ($stream->test(Twig_Token::PUNCTUATION_TYPE, ':')) {
+                $stream->expect(Twig_Token::PUNCTUATION_TYPE, ':');
+                $node->addElement($this->parseExpression(), $value);
+            } else {
+                $node->addElement($value);
+            }
         }
         $stream->expect(Twig_Token::PUNCTUATION_TYPE, ']', 'An opened array is not properly closed');
 

--- a/test/Twig/Tests/ExpressionParserTest.php
+++ b/test/Twig/Tests/ExpressionParserTest.php
@@ -53,26 +53,6 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $parser->parse($stream)->getNode('body')->getNode(0)->getNode('expr'));
     }
 
-    /**
-     * @expectedException Twig_Error_Syntax
-     * @dataProvider getFailingTestsForArray
-     */
-    public function testArraySyntaxError($template)
-    {
-        $env = new Twig_Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock(), array('cache' => false, 'autoescape' => false));
-        $parser = new Twig_Parser($env);
-
-        $parser->parse($env->tokenize(new Twig_Source($template, 'index')));
-    }
-
-    public function getFailingTestsForArray()
-    {
-        return array(
-            array('{{ [1, "a": "b"] }}'),
-            array('{{ {"a": "b", 2} }}'),
-        );
-    }
-
     public function getTestsForArray()
     {
         return array(
@@ -88,6 +68,19 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
 
             // array with trailing ,
             array('{{ [1, 2, ] }}', new Twig_Node_Expression_Array(array(
+                  new Twig_Node_Expression_Constant(0, 1),
+                  new Twig_Node_Expression_Constant(1, 1),
+
+                  new Twig_Node_Expression_Constant(1, 1),
+                  new Twig_Node_Expression_Constant(2, 1),
+                ), 1),
+            ),
+
+            // array keys
+            array('{{ ["a": "b", 1, 2] }}', new Twig_Node_Expression_Array(array(
+                  new Twig_Node_Expression_Constant('a', 1),
+                  new Twig_Node_Expression_Constant('b', 1),
+
                   new Twig_Node_Expression_Constant(0, 1),
                   new Twig_Node_Expression_Constant(1, 1),
 

--- a/test/Twig/Tests/ExpressionParserTest.php
+++ b/test/Twig/Tests/ExpressionParserTest.php
@@ -88,6 +88,17 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
                   new Twig_Node_Expression_Constant(2, 1),
                 ), 1),
             ),
+            array('{{ [1: "one", "two": 2, "three"] }}', new Twig_Node_Expression_Array(array(
+                  new Twig_Node_Expression_Constant(1, 1),
+                  new Twig_Node_Expression_Constant('one', 1),
+
+                  new Twig_Node_Expression_Constant('two', 1),
+                  new Twig_Node_Expression_Constant(2, 1),
+
+                  new Twig_Node_Expression_Constant(0, 1),
+                  new Twig_Node_Expression_Constant('three', 1),
+                ), 1),
+            ), 
 
             // simple hash
             array('{{ {"a": "b", "b": "c"} }}', new Twig_Node_Expression_Array(array(

--- a/test/Twig/Tests/ExpressionParserTest.php
+++ b/test/Twig/Tests/ExpressionParserTest.php
@@ -88,15 +88,15 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
                   new Twig_Node_Expression_Constant(2, 1),
                 ), 1),
             ),
-            array('{{ [1: "one", "two": 2, "three"] }}', new Twig_Node_Expression_Array(array(
+            array('{{ [1: "a", "b": 2, "c"] }}', new Twig_Node_Expression_Array(array(
                   new Twig_Node_Expression_Constant(1, 1),
-                  new Twig_Node_Expression_Constant('one', 1),
+                  new Twig_Node_Expression_Constant('a', 1),
 
-                  new Twig_Node_Expression_Constant('two', 1),
+                  new Twig_Node_Expression_Constant('b', 1),
                   new Twig_Node_Expression_Constant(2, 1),
 
                   new Twig_Node_Expression_Constant(0, 1),
-                  new Twig_Node_Expression_Constant('three', 1),
+                  new Twig_Node_Expression_Constant('c', 1),
                 ), 1),
             ), 
 

--- a/test/Twig/Tests/ExpressionParserTest.php
+++ b/test/Twig/Tests/ExpressionParserTest.php
@@ -88,17 +88,6 @@ class Twig_Tests_ExpressionParserTest extends PHPUnit_Framework_TestCase
                   new Twig_Node_Expression_Constant(2, 1),
                 ), 1),
             ),
-            array('{{ [1: "a", "b": 2, "c"] }}', new Twig_Node_Expression_Array(array(
-                  new Twig_Node_Expression_Constant(1, 1),
-                  new Twig_Node_Expression_Constant('a', 1),
-
-                  new Twig_Node_Expression_Constant('b', 1),
-                  new Twig_Node_Expression_Constant(2, 1),
-
-                  new Twig_Node_Expression_Constant(0, 1),
-                  new Twig_Node_Expression_Constant('c', 1),
-                ), 1),
-            ), 
 
             // simple hash
             array('{{ {"a": "b", "b": "c"} }}', new Twig_Node_Expression_Array(array(


### PR DESCRIPTION
This pull request enables Twig arrays to more closely resemble the syntax and functionality of PHP arrays, by allowing the keys to be optionally specified via a colon (:) similar to hashes eg. ``[1: 'one', 'two': 2, 'three']``.