### PR TITLE
deprecated Twig_Parser::addHandler() and Twig_Parser::addNodeVisitor()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.27.0 (2016-XX-XX)
 
+ * deprecated Twig_Parser::addHandler() and Twig_Parser::addNodeVisitor()
  * fixed regression when registering two extensions having the same class name
  * deprecated Twig_LoaderInterface::getSource() (implement Twig_SourceContextLoaderInterface instead)
  * fixed the filesystem loader with relative paths

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -200,3 +200,6 @@ Miscellaneous
 
 * As of Twig 1.27, ``Twig_Template::getSource()`` is deprecated. Use
   ``Twig_Template::getSourceContext()`` instead.
+
+* As of Twig 1.27, ``Twig_Parser::addHandler()`` and
+  ``Twig_Parser::addNodeVisitor()`` are deprecated and will be removed in 2.0.

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -207,13 +207,23 @@ class Twig_Parser implements Twig_ParserInterface
         return new Twig_Node($rv, array(), $lineno);
     }
 
+    /**
+     * @deprecated since 1.27 (to be removed in 2.0)
+     */
     public function addHandler($name, $class)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.27 and will be removed in 2.0.', E_USER_DEPRECATED);
+
         $this->handlers[$name] = $class;
     }
 
+    /**
+     * @deprecated since 1.27 (to be removed in 2.0)
+     */
     public function addNodeVisitor(Twig_NodeVisitorInterface $visitor)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.27 and will be removed in 2.0.', E_USER_DEPRECATED);
+
         $this->visitors[] = $visitor;
     }
 


### PR DESCRIPTION
I don't even understand why these methods are here. It looks like they never had any usage in the core.
