### PR TITLE
Move tests handling in Twig_ParserExpression instead of Twig_Extension_Core

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.27.0 (2016-XX-XX)
 
+ * deprecated Twig_Parser::getEnvironment()
  * deprecated Twig_Parser::addHandler() and Twig_Parser::addNodeVisitor()
  * deprecated Twig_Compiler::addIndentation()
  * fixed regression when registering two extensions having the same class name

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -23,6 +23,8 @@ Token Parsers
 * As of Twig 1.27, ``Twig_Parser::getFilename()`` is deprecated. From a token
   parser, use ``$this->parser->getStream()->getSourceContext()->getPath()`` instead.
 
+* As of Twig 1.27, ``Twig_Parser::getEnvironment()`` is deprecated.
+
 Extensions
 ----------
 

--- a/lib/Twig/ExpressionParser.php
+++ b/lib/Twig/ExpressionParser.php
@@ -44,7 +44,11 @@ class Twig_ExpressionParser
             $op = $this->binaryOperators[$token->getValue()];
             $this->parser->getStream()->next();
 
-            if (isset($op['callable'])) {
+            if ('is not' === $token->getValue()) {
+                $expr = $this->parseNotTestExpression($expr);
+            } elseif ('is' === $token->getValue()) {
+                $expr = $this->parseTestExpression($expr);
+            } elseif (isset($op['callable'])) {
                 $expr = call_user_func($op['callable'], $this->parser, $expr);
             } else {
                 $expr1 = $this->parseExpression(self::OPERATOR_LEFT === $op['associativity'] ? $op['precedence'] + 1 : $op['precedence']);
@@ -565,6 +569,74 @@ class Twig_ExpressionParser
         }
 
         return new Twig_Node($targets);
+    }
+
+    private function parseNotTestExpression(Twig_NodeInterface $node)
+    {
+        return new Twig_Node_Expression_Unary_Not($this->parseTestExpression($node), $this->parser->getCurrentToken()->getLine());
+    }
+
+    private function parseTestExpression(Twig_NodeInterface $node)
+    {
+        $stream = $this->parser->getStream();
+        list($name, $test) = $this->getTest($node->getTemplateLine());
+
+        $class = $this->getTestNodeClass($test);
+        $arguments = null;
+        if ($stream->test(Twig_Token::PUNCTUATION_TYPE, '(')) {
+            $arguments = $this->parser->getExpressionParser()->parseArguments(true);
+        }
+
+        return new $class($node, $name, $arguments, $this->parser->getCurrentToken()->getLine());
+    }
+
+    private function getTest($line)
+    {
+        $stream = $this->parser->getStream();
+        $name = $stream->expect(Twig_Token::NAME_TYPE)->getValue();
+        $env = $this->parser->getEnvironment();
+
+        if ($test = $env->getTest($name)) {
+            return array($name, $test);
+        }
+
+        if ($stream->test(Twig_Token::NAME_TYPE)) {
+            // try 2-words tests
+            $name = $name.' '.$this->parser->getCurrentToken()->getValue();
+
+            if ($test = $env->getTest($name)) {
+                $stream->next();
+
+                return array($name, $test);
+            }
+        }
+
+        $e = new Twig_Error_Syntax(sprintf('Unknown "%s" test.', $name), $line, $stream->getSourceContext()->getName());
+        $e->addSuggestions($name, array_keys($env->getTests()));
+
+        throw $e;
+    }
+
+    private function getTestNodeClass($test)
+    {
+        if ($test instanceof Twig_SimpleTest && $test->isDeprecated()) {
+            $message = sprintf('Twig Test "%s" is deprecated', $name);
+            if (!is_bool($test->getDeprecatedVersion())) {
+                $message .= sprintf(' since version %s', $test->getDeprecatedVersion());
+            }
+            if ($test->getAlternative()) {
+                $message .= sprintf('. Use "%s" instead', $test->getAlternative());
+            }
+            $message .= sprintf(' in %s at line %d.', $stream->getSourceContext()->getName(), $stream->getCurrent()->getLine());
+
+            @trigger_error($message, E_USER_DEPRECATED);
+        }
+
+        if ($test instanceof Twig_SimpleTest) {
+            return $test->getNodeClass();
+        }
+
+        return $test instanceof Twig_Test_Node ? $test->getClass() : 'Twig_Node_Expression_Test';
     }
 
     protected function getFunctionNodeClass($name, $line)

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -258,80 +258,12 @@ class Twig_Extension_Core extends Twig_Extension
                 '/' => array('precedence' => 60, 'class' => 'Twig_Node_Expression_Binary_Div', 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
                 '//' => array('precedence' => 60, 'class' => 'Twig_Node_Expression_Binary_FloorDiv', 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
                 '%' => array('precedence' => 60, 'class' => 'Twig_Node_Expression_Binary_Mod', 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
-                'is' => array('precedence' => 100, 'callable' => array($this, 'parseTestExpression'), 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
-                'is not' => array('precedence' => 100, 'callable' => array($this, 'parseNotTestExpression'), 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
+                'is' => array('precedence' => 100, 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
+                'is not' => array('precedence' => 100, 'associativity' => Twig_ExpressionParser::OPERATOR_LEFT),
                 '**' => array('precedence' => 200, 'class' => 'Twig_Node_Expression_Binary_Power', 'associativity' => Twig_ExpressionParser::OPERATOR_RIGHT),
                 '??' => array('precedence' => 300, 'class' => 'Twig_Node_Expression_NullCoalesce', 'associativity' => Twig_ExpressionParser::OPERATOR_RIGHT),
             ),
         );
-    }
-
-    public function parseNotTestExpression(Twig_Parser $parser, Twig_NodeInterface $node)
-    {
-        return new Twig_Node_Expression_Unary_Not($this->parseTestExpression($parser, $node), $parser->getCurrentToken()->getLine());
-    }
-
-    public function parseTestExpression(Twig_Parser $parser, Twig_NodeInterface $node)
-    {
-        $stream = $parser->getStream();
-        list($name, $test) = $this->getTest($parser, $node->getTemplateLine());
-
-        if ($test instanceof Twig_SimpleTest && $test->isDeprecated()) {
-            $message = sprintf('Twig Test "%s" is deprecated', $name);
-            if (!is_bool($test->getDeprecatedVersion())) {
-                $message .= sprintf(' since version %s', $test->getDeprecatedVersion());
-            }
-            if ($test->getAlternative()) {
-                $message .= sprintf('. Use "%s" instead', $test->getAlternative());
-            }
-            $message .= sprintf(' in %s at line %d.', $stream->getSourceContext()->getName(), $stream->getCurrent()->getLine());
-
-            @trigger_error($message, E_USER_DEPRECATED);
-        }
-
-        $class = $this->getTestNodeClass($parser, $test);
-        $arguments = null;
-        if ($stream->test(Twig_Token::PUNCTUATION_TYPE, '(')) {
-            $arguments = $parser->getExpressionParser()->parseArguments(true);
-        }
-
-        return new $class($node, $name, $arguments, $parser->getCurrentToken()->getLine());
-    }
-
-    protected function getTest(Twig_Parser $parser, $line)
-    {
-        $stream = $parser->getStream();
-        $name = $stream->expect(Twig_Token::NAME_TYPE)->getValue();
-        $env = $parser->getEnvironment();
-
-        if ($test = $env->getTest($name)) {
-            return array($name, $test);
-        }
-
-        if ($stream->test(Twig_Token::NAME_TYPE)) {
-            // try 2-words tests
-            $name = $name.' '.$parser->getCurrentToken()->getValue();
-
-            if ($test = $env->getTest($name)) {
-                $parser->getStream()->next();
-
-                return array($name, $test);
-            }
-        }
-
-        $e = new Twig_Error_Syntax(sprintf('Unknown "%s" test.', $name), $line, $stream->getSourceContext()->getName());
-        $e->addSuggestions($name, array_keys($env->getTests()));
-
-        throw $e;
-    }
-
-    protected function getTestNodeClass(Twig_Parser $parser, $test)
-    {
-        if ($test instanceof Twig_SimpleTest) {
-            return $test->getNodeClass();
-        }
-
-        return $test instanceof Twig_Test_Node ? $test->getClass() : 'Twig_Node_Expression_Test';
     }
 
     public function getName()

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -42,8 +42,13 @@ class Twig_Parser implements Twig_ParserInterface
         $this->env = $env;
     }
 
+    /**
+     * @deprecated since 1.27 (to be removed in 2.0)
+     */
     public function getEnvironment()
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.27 and will be removed in 2.0.', E_USER_DEPRECATED);
+
         return $this->env;
     }
 
@@ -90,7 +95,7 @@ class Twig_Parser implements Twig_ParserInterface
         }
 
         if (null === $this->expressionParser) {
-            $this->expressionParser = new Twig_ExpressionParser($this, $this->env->getUnaryOperators(), $this->env->getBinaryOperators());
+            $this->expressionParser = new Twig_ExpressionParser($this, $this->env);
         }
 
         $this->stream = $stream;


### PR DESCRIPTION
In my quest to better organize the layers in Twig, I've always find the way we deal with test a bit awkward. This PR moves the code from the Core extension to the Parser, where it belongs, even if if makes hardcoding 'is' and 'is not' twice, but I think SOC is more important here. Especially as I want to remove the `getEnvironment()` from the Parser class at some point. Having everything centralized helps a lot.
