### PR TITLE
Removing @internal tag from Twig_TokenStream::getSourceContext

### DIFF
--- a/lib/Twig/TokenStream.php
+++ b/lib/Twig/TokenStream.php
@@ -147,8 +147,6 @@ class Twig_TokenStream
      * Gets the source associated with this stream.
      *
      * @return Twig_Source
-     *
-     * @internal
      */
     public function getSourceContext()
     {


### PR DESCRIPTION
To resolve #2210
