### PR TITLE
Allow construction without constructor arguments

### DIFF
--- a/lib/Twig/Loader/Array.php
+++ b/lib/Twig/Loader/Array.php
@@ -30,7 +30,7 @@ class Twig_Loader_Array implements Twig_LoaderInterface, Twig_ExistsLoaderInterf
      *
      * @param array $templates An array of templates (keys are the names, and values are the source code)
      */
-    public function __construct(array $templates)
+    public function __construct(array $templates = array())
     {
         $this->templates = $templates;
     }


### PR DESCRIPTION
Since we can dynamically add templates and its possible to not need to construct the loader without any initial templates. I've added the default argument to the constructor for simpler instantiation IE new Twig_Loader_Array();. This helps us on a project where we've extended the loader, and have no initial templates but need to add constructor parameters for no real reason.