### PR TITLE
Load templates from cache, even if they have just been compiled

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -420,7 +420,11 @@ class Twig_Environment
                 }
 
                 if (!class_exists($cls, false)) {
-                    // catch that either $this->bcWriteCacheFile was used or $this->cache is implemented as a no-op
+                    /* Last line of defense if either $this->bcWriteCacheFile was used,
+                     * $this->cache is implemented as a no-op or we have a race condition
+                     * where the cache was cleared between the above calls to write to and load from
+                     * the cache.
+                     */
                     eval('?>'.$content);
                 }
             }

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -414,11 +414,11 @@ class Twig_Environment
 
                 if ($this->bcWriteCacheFile) {
                     $this->writeCacheFile($key, $content);
+                    eval('?>'.$content);
                 } else {
                     $this->cache->write($key, $content);
+                    $this->cache->load($key);
                 }
-
-                eval('?>'.$content);
             }
         }
 

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -414,10 +414,14 @@ class Twig_Environment
 
                 if ($this->bcWriteCacheFile) {
                     $this->writeCacheFile($key, $content);
-                    eval('?>'.$content);
                 } else {
                     $this->cache->write($key, $content);
                     $this->cache->load($key);
+                }
+
+                if (!class_exists($cls, false)) {
+                    // catch that either $this->bcWriteCacheFile was used or $this->cache is implemented as a no-op
+                    eval('?>'.$content);
                 }
             }
         }

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -217,7 +217,9 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue(0));
         $loader->expects($this->never())
             ->method('isFresh');
-        $cache->expects($this->never())
+        $cache->expects($this->once())
+            ->method('write');
+        $cache->expects($this->once())
             ->method('load');
 
         $twig->loadTemplate($templateName);
@@ -245,7 +247,7 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $loader->expects($this->once())
             ->method('isFresh')
             ->will($this->returnValue(true));
-        $cache->expects($this->once())
+        $cache->expects($this->atLeastOnce())
             ->method('load');
 
         $twig->loadTemplate($templateName);
@@ -271,7 +273,9 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $loader->expects($this->once())
             ->method('isFresh')
             ->will($this->returnValue(false));
-        $cache->expects($this->never())
+        $cache->expects($this->once())
+            ->method('write');
+        $cache->expects($this->once())
             ->method('load');
 
         $twig->loadTemplate($templateName);


### PR DESCRIPTION
Previously, when the cache was empty, the compiled template would be written to it, but `eval()`d from `$content`. In that case, it is not possible to step through (read: debug) the compiled template because at least xDebug does not have a clue where the code comes from. 

With this change, PHP/xDebug can tell even on the first run (with an empty cache) where the code was loaded from.