### PR TITLE
New method to get up-to-date template timestamp loaded

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -501,6 +501,7 @@ class Twig_Environment
     public function getTemplateLoaderFreshness()
     {
         $cache = $this->getCache(false);
+
         return $this->getLoader()->getTemplateFreshness($cache);
     }
 

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -494,6 +494,17 @@ class Twig_Environment
     }
 
     /**
+     * Returns up-to-date timestamp of all template loaded.
+     *
+     * @return string
+     */
+    public function getTemplateLoaderFreshness()
+    {
+        $cache = $this->getCache(false);
+        return $this->getLoader()->getTemplateFreshness($cache);
+    }
+
+    /**
      * Tries to load a template consecutively from an array.
      *
      * Similar to loadTemplate() but it also accepts Twig_TemplateInterface instances and an array

--- a/lib/Twig/Loader/Array.php
+++ b/lib/Twig/Loader/Array.php
@@ -107,4 +107,12 @@ class Twig_Loader_Array implements Twig_LoaderInterface, Twig_ExistsLoaderInterf
 
         return true;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplateFreshness(Twig_CacheInterface $cache)
+    {
+        return time();
+    }
 }

--- a/lib/Twig/Loader/Chain.php
+++ b/lib/Twig/Loader/Chain.php
@@ -166,4 +166,12 @@ class Twig_Loader_Chain implements Twig_LoaderInterface, Twig_ExistsLoaderInterf
 
         throw new Twig_Error_Loader(sprintf('Template "%s" is not defined%s.', $name, $exceptions ? ' ('.implode(', ', $exceptions).')' : ''));
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplateFreshness(Twig_CacheInterface $cache)
+    {
+        return time();
+    }
 }

--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -302,4 +302,35 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
             || null !== parse_url($file, PHP_URL_SCHEME)
         ;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplateFreshness(Twig_CacheInterface $cache)
+    {
+        $cacheKey = $cache->generateKey(
+            md5(serialize($this->cache)),
+            get_class()
+        );
+
+        ob_start();
+        $cache->load($cacheKey);
+        $lastDate = ob_get_contents();
+        ob_end_clean();
+
+        if(!$lastDate){
+            $lastModified = 0;
+            foreach($this->cache as $name=>$v){
+                $dateModified = filemtime($this->findTemplate($name));
+                if($dateModified > $lastModified) {
+                    $lastModified = $dateModified;
+                }
+            }
+
+            $cache->write($cacheKey, $lastDate);
+        }
+
+
+        return $lastDate;
+    }
 }

--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -318,18 +318,17 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
         $lastDate = ob_get_contents();
         ob_end_clean();
 
-        if(!$lastDate){
+        if (!$lastDate) {
             $lastModified = 0;
-            foreach($this->cache as $name=>$v){
+            foreach ($this->cache as $name => $v) {
                 $dateModified = filemtime($this->findTemplate($name));
-                if($dateModified > $lastModified) {
+                if ($dateModified > $lastModified) {
                     $lastModified = $dateModified;
                 }
             }
 
             $cache->write($cacheKey, $lastDate);
         }
-
 
         return $lastDate;
     }

--- a/lib/Twig/Loader/String.php
+++ b/lib/Twig/Loader/String.php
@@ -70,4 +70,12 @@ class Twig_Loader_String implements Twig_LoaderInterface, Twig_ExistsLoaderInter
     {
         return true;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplateFreshness(Twig_CacheInterface $cache)
+    {
+        return time();
+    }
 }

--- a/lib/Twig/LoaderInterface.php
+++ b/lib/Twig/LoaderInterface.php
@@ -52,4 +52,13 @@ interface Twig_LoaderInterface
      * @throws Twig_Error_Loader When $name is not found
      */
     public function isFresh($name, $time);
+
+    /**
+     * Returns up-to-date timestamp of all template loaded.
+     *
+     * @param Twig_CacheInterface $cache
+     * @return string
+     */
+    public function getTemplateFreshness(Twig_CacheInterface $cache);
+
 }

--- a/lib/Twig/LoaderInterface.php
+++ b/lib/Twig/LoaderInterface.php
@@ -57,8 +57,8 @@ interface Twig_LoaderInterface
      * Returns up-to-date timestamp of all template loaded.
      *
      * @param Twig_CacheInterface $cache
+     *
      * @return string
      */
     public function getTemplateFreshness(Twig_CacheInterface $cache);
-
 }


### PR DESCRIPTION
Since header last-modified is important to Google, we have to know when template rendered has last changed

In controller, you can get up-to-date template timestamp loader after render method

Here an example:

`$content           = $this->renderView($templateName);
$templateFreshness = $this->container->get('twig')->getTemplateLoaderFreshness(); 

if($templateFreshness && $templateFreshness > $articleDateModified) {
    $articleDateModified = $templateFreshness;
}

$lastModified = new \DateTime();
$lastModified->setTimestamp($articleDateModified);
    
$response = new Response();
$response->setLastModified($lastModified);
$response->setEtag($etag);

if ($response->isNotModified($request)) {
    return $response;
}

$response->setContent($content);

return $response;`
        