### PR TITLE
renamed blockExists to hasBlock

### DIFF
--- a/lib/Twig/Node/Expression/BlockReference.php
+++ b/lib/Twig/Node/Expression/BlockReference.php
@@ -40,7 +40,7 @@ class Twig_Node_Expression_BlockReference extends Twig_Node_Expression
     {
         if ($this->getAttribute('is_defined_test')) {
             $compiler
-                ->raw('$this->blockExists(')
+                ->raw('$this->hasBlock(')
                 ->subcompile($this->getNode('name'))
                 ->raw(', $context, $blocks)')
             ;

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -270,29 +270,40 @@ abstract class Twig_Template implements Twig_TemplateInterface
     }
 
     /**
-     * Returns whether a block exists or not.
+     * Returns whether a block exists or not in the current context of the template.
      *
-     * This method is for internal use only and should never be called
-     * directly.
+     * This method checks blocks defined in the current template
+     * or defined in "used" traits or defined in parent templates.
      *
-     * This method does only return blocks defined in the current template
-     * or defined in "used" traits.
-     *
-     * It does not return blocks from parent templates as the parent
-     * template name can be dynamic, which is only known based on the
-     * current context.
-     *
-     * @param string $name The block name
+     * @param string $name    The block name
+     * @param array  $context The context
+     * @param array  $blocks  The current set of blocks
      *
      * @return bool true if the block exists, false otherwise
      *
-     * @see blockExists
-     *
      * @internal
      */
-    public function hasBlock($name)
+    public function hasBlock($name, array $context = null, array $blocks = array())
     {
-        return isset($this->blocks[(string) $name]);
+        if (null === $context) {
+            @trigger_error('The '.__METHOD__.' method is internal and should never be called; calling it directly is deprecated since version 1.28 and won\'t be possible anymore in 2.0.', E_USER_DEPRECATED);
+
+            return isset($this->blocks[(string) $name]);
+        }
+
+        if (isset($blocks[$name])) {
+            return $blocks[$name][0] instanceof self;
+        }
+
+        if (isset($this->blocks[$name])) {
+            return true;
+        }
+
+        if (false !== $parent = $this->getParent($context)) {
+            return $parent->hasBlock($name, $context);
+        }
+
+        return false;
     }
 
     /**
@@ -302,8 +313,6 @@ abstract class Twig_Template implements Twig_TemplateInterface
      * directly.
      *
      * @return array An array of block names
-     *
-     * @see hasBlock
      *
      * @internal
      */
@@ -350,8 +359,6 @@ abstract class Twig_Template implements Twig_TemplateInterface
      * directly.
      *
      * @return array An array of blocks
-     *
-     * @see hasBlock
      *
      * @internal
      */
@@ -654,38 +661,5 @@ abstract class Twig_Template implements Twig_TemplateInterface
         }
 
         return $ret;
-    }
-
-    /**
-     * Returns whether a block exists or not in the current context of the template.
-     *
-     * This method checks blocks defined in the current template
-     * or defined in "used" traits or defined in parent templates.
-     *
-     * @param string $name    The block name
-     * @param array  $context The context
-     * @param array  $blocks  The current set of blocks
-     *
-     * @return bool true if the block exists, false otherwise
-     *
-     * @see hasBlock
-     *
-     * @internal
-     */
-    protected function blockExists($name, array $context, array $blocks = array())
-    {
-        if (isset($blocks[$name])) {
-            return $blocks[$name][0] instanceof self;
-        }
-
-        if (isset($this->blocks[$name])) {
-            return true;
-        }
-
-        if (false !== $parent = $this->getParent($context)) {
-            return $parent->blockExists($name, $context);
-        }
-
-        return false;
     }
 }


### PR DESCRIPTION
As `hasBlock()` is marked as internal and because it's not even used anywhere in Twig, I've replaced its implementation with the one of `blockExists()`, and I also kept BC with a deprecation notice just in case someone is using it.

