### PR TITLE
Remove optimization as it's not compatible with Symfony cache system

### DIFF
--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -10,10 +10,6 @@
  * file that was distributed with this source code.
  */
 
-if (PHP_VERSION_ID >= 50600) {
-    require_once __DIR__.'/twig_call_method.php';
-}
-
 /**
  * Default base class for compiled templates.
  *
@@ -635,8 +631,6 @@ abstract class Twig_Template implements Twig_TemplateInterface
         try {
             if (!$arguments) {
                 $ret = $object->$method();
-            } elseif (PHP_VERSION_ID >= 50600) {
-                $ret = twig_call_method($object, $method, $arguments);
             } else {
                 $ret = call_user_func_array(array($object, $method), $arguments);
             }

--- a/lib/Twig/twig_call_method.php
+++ b/lib/Twig/twig_call_method.php
@@ -1,9 +1,0 @@
-<?php
-
-/**
- * @internal
- */
-function twig_call_method($object, $method, $arguments)
-{
-    return $object->$method(...$arguments);
-}


### PR DESCRIPTION
fixes #2243

@nicolas-grekas Instead of fixing Symfony cache system (which will only happen in a new patch release), I propose to revert these changes. It means no optimization for Twig 1.x, but the optimization is the default in Twig 2.0. So, I don't think this is a big deal.
