### PR TITLE
Add support for PHP 7 null coalescing operator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.28.0 (2016-XX-XX)
 
+ * added support for the PHP 7 null coalescing operator for the ?? Twig implementation
  * exposed a way to access template data and methods in a portable way
  * changed context access to use the PHP 7 null coalescing operator when available
  * added the "with" tag

--- a/lib/Twig/Node/Expression/NullCoalesce.php
+++ b/lib/Twig/Node/Expression/NullCoalesce.php
@@ -20,4 +20,27 @@ class Twig_Node_Expression_NullCoalesce extends Twig_Node_Expression_Conditional
 
         parent::__construct($test, $left, $right, $lineno);
     }
+
+    public function compile(Twig_Compiler $compiler)
+    {
+        /*
+         * This optimizes only one case. PHP 7 also supports more complex expressions
+         * that can return null. So, for instance, if log is defined, log("foo") ?? "..." works,
+         * but log($a["foo"]) ?? "..." does not if $a["foo"] is not defined. More advanced
+         * cases might be implemented as an optimizer node visitor, but has not been done
+         * as benefits are probably not worth the added complexity.
+         */
+        if (PHP_VERSION_ID >= 70000 && $this->getNode('expr2') instanceof Twig_Node_Expression_Name) {
+            $this->getNode('expr2')->setAttribute('always_defined', true);
+            $compiler
+                ->raw('((')
+                ->subcompile($this->getNode('expr2'))
+                ->raw(') ?? (')
+                ->subcompile($this->getNode('expr3'))
+                ->raw('))')
+            ;
+        } else {
+            parent::compile($compiler);
+        }
+    }
 }

--- a/test/Twig/Tests/Node/Expression/NullCoalesceTest.php
+++ b/test/Twig/Tests/Node/Expression/NullCoalesceTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Twig_Tests_Node_Expression_NullCoalesceTest extends Twig_Test_NodeTestCase
+{
+    public function getTests()
+    {
+        $tests = array();
+
+        $left = new Twig_Node_Expression_Name('foo', 1);
+        $right = new Twig_Node_Expression_Constant(2, 1);
+        $node = new Twig_Node_Expression_NullCoalesce($left, $right, 1);
+        if (PHP_VERSION_ID >= 70000) {
+            $tests[] = array($node, "((// line 1\n\$context[\"foo\"]) ?? (2))");
+        } elseif (PHP_VERSION_ID >= 50400) {
+            $tests[] = array($node, "(((// line 1\narray_key_exists(\"foo\", \$context) &&  !(null === (isset(\$context[\"foo\"]) ? \$context[\"foo\"] : null)))) ? ((isset(\$context[\"foo\"]) ? \$context[\"foo\"] : null)) : (2))");
+        } else {
+            $tests[] = array($node, "(((// line 1\narray_key_exists(\"foo\", \$context) &&  !(null === \$this->getContext(\$context, \"foo\")))) ? (\$this->getContext(\$context, \"foo\")) : (2))");
+        }
+
+        return $tests;
+    }
+}


### PR DESCRIPTION
This is just one case where we can "optimize" the ternary operator. PHP 7 also supports more complex expressions that can return `null`. The rule here seems to be that you cannot have more than one level of undefinedness.

So, for instance, if `log` is defined, `log("foo") ?? "NOPE"` works, but `log($a["foo"]) ?? "NOPE"` does not if `$a["foo"]` is not defined. If we want to convert the code to always use `??` when possible, this should probably be implemented in the Optimizer node visitor, not here. But the question is: is it worth it in terms of performance? It cleans up the generated code quite a bit though.

closes #1979