### PR TITLE
Call clearstatcache() before calling is_dir().

### DIFF
--- a/lib/Twig/Cache/Filesystem.php
+++ b/lib/Twig/Cache/Filesystem.php
@@ -58,8 +58,11 @@ class Twig_Cache_Filesystem implements Twig_CacheInterface
     {
         $dir = dirname($key);
         if (!is_dir($dir)) {
-            if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
-                throw new RuntimeException(sprintf('Unable to create the cache directory (%s).', $dir));
+            if (false === @mkdir($dir, 0777, true)) {
+                clearstatcache(false, $dir);
+                if (!is_dir($dir)) {
+                    throw new RuntimeException(sprintf('Unable to create the cache directory (%s).', $dir));
+                }
             }
         } elseif (!is_writable($dir)) {
             throw new RuntimeException(sprintf('Unable to write in the cache directory (%s).', $dir));

--- a/lib/Twig/Cache/Filesystem.php
+++ b/lib/Twig/Cache/Filesystem.php
@@ -59,7 +59,7 @@ class Twig_Cache_Filesystem implements Twig_CacheInterface
         $dir = dirname($key);
         if (!is_dir($dir)) {
             if (false === @mkdir($dir, 0777, true)) {
-                clearstatcache(false, $dir);
+                clearstatcache(true, $dir);
                 if (!is_dir($dir)) {
                     throw new RuntimeException(sprintf('Unable to create the cache directory (%s).', $dir));
                 }


### PR DESCRIPTION
The result of is_dir() is cached.
So call clearstatcache() before calling 2nd is_dir().
