### PR TITLE
Bugfix: When rendering blocks of other templates, don't pass the local blocks array

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 1.28.1 (2016-XX-XX)
 
- * n/a
+ * fixed block() function when used with a template argument
 
 * 1.28.0 (2016-11-17)
 

--- a/lib/Twig/Node/Expression/BlockReference.php
+++ b/lib/Twig/Node/Expression/BlockReference.php
@@ -50,17 +50,17 @@ class Twig_Node_Expression_BlockReference extends Twig_Node_Expression
 
                 $this
                     ->compileTemplateCall($compiler)
-                    ->raw('->displayBlock(')
-                    ->subcompile($this->getNode('name'))
-                    ->raw(", \$context, \$blocks);\n")
+                    ->raw('->displayBlock')
                 ;
+                $this
+                    ->compileBlockArguments($compiler)
+                    ->raw(";\n");
             } else {
                 $this
                     ->compileTemplateCall($compiler)
-                    ->raw('->renderBlock(')
-                    ->subcompile($this->getNode('name'))
-                    ->raw(', $context, $blocks)')
+                    ->raw('->renderBlock')
                 ;
+                $this->compileBlockArguments($compiler);
             }
         }
     }
@@ -80,5 +80,19 @@ class Twig_Node_Expression_BlockReference extends Twig_Node_Expression
             ->repr($this->getTemplateLine())
             ->raw(')')
         ;
+    }
+
+    private function compileBlockArguments(Twig_Compiler $compiler)
+    {
+        $compiler
+            ->raw('(')
+            ->subcompile($this->getNode('name'))
+            ->raw(', $context');
+
+        if (!$this->hasNode('template')) {
+            $compiler->raw(', $blocks');
+        }
+
+        return $compiler->raw(')');
     }
 }

--- a/lib/Twig/Node/Expression/BlockReference.php
+++ b/lib/Twig/Node/Expression/BlockReference.php
@@ -39,23 +39,16 @@ class Twig_Node_Expression_BlockReference extends Twig_Node_Expression
     public function compile(Twig_Compiler $compiler)
     {
         if ($this->getAttribute('is_defined_test')) {
-            $this
-                ->compileTemplateCall($compiler, 'hasBlock')
-                ->compileBlockArguments($compiler)
-            ;
+            $this->compileTemplateCall($compiler, 'hasBlock');
         } else {
             if ($this->getAttribute('output')) {
                 $compiler->addDebugInfo($this);
 
                 $this
                     ->compileTemplateCall($compiler, 'displayBlock')
-                    ->compileBlockArguments($compiler)
                     ->raw(";\n");
             } else {
-                $this
-                    ->compileTemplateCall($compiler, 'renderBlock')
-                    ->compileBlockArguments($compiler)
-                ;
+                $this->compileTemplateCall($compiler, 'renderBlock');
             }
         }
     }
@@ -77,8 +70,9 @@ class Twig_Node_Expression_BlockReference extends Twig_Node_Expression
         }
 
         $compiler->raw(sprintf('->%s', $method));
+        $this->compileBlockArguments($compiler);
 
-        return $this;
+        return $compiler;
     }
 
     private function compileBlockArguments(Twig_Compiler $compiler)

--- a/lib/Twig/Node/Expression/BlockReference.php
+++ b/lib/Twig/Node/Expression/BlockReference.php
@@ -39,47 +39,46 @@ class Twig_Node_Expression_BlockReference extends Twig_Node_Expression
     public function compile(Twig_Compiler $compiler)
     {
         if ($this->getAttribute('is_defined_test')) {
-            $compiler
-                ->raw('$this->hasBlock(')
-                ->subcompile($this->getNode('name'))
-                ->raw(', $context, $blocks)')
+            $this
+                ->compileTemplateCall($compiler, 'hasBlock')
+                ->compileBlockArguments($compiler)
             ;
         } else {
             if ($this->getAttribute('output')) {
                 $compiler->addDebugInfo($this);
 
                 $this
-                    ->compileTemplateCall($compiler)
-                    ->raw('->displayBlock')
-                ;
-                $this
+                    ->compileTemplateCall($compiler, 'displayBlock')
                     ->compileBlockArguments($compiler)
                     ->raw(";\n");
             } else {
                 $this
-                    ->compileTemplateCall($compiler)
-                    ->raw('->renderBlock')
+                    ->compileTemplateCall($compiler, 'renderBlock')
+                    ->compileBlockArguments($compiler)
                 ;
-                $this->compileBlockArguments($compiler);
             }
         }
     }
 
-    private function compileTemplateCall(Twig_Compiler $compiler)
+    private function compileTemplateCall(Twig_Compiler $compiler, $method)
     {
         if (!$this->hasNode('template')) {
-            return $compiler->write('$this');
+            $compiler->write('$this');
+        } else {
+            $compiler
+                ->write('$this->loadTemplate(')
+                ->subcompile($this->getNode('template'))
+                ->raw(', ')
+                ->repr($this->getTemplateName())
+                ->raw(', ')
+                ->repr($this->getTemplateLine())
+                ->raw(')')
+            ;
         }
 
-        return $compiler
-            ->write('$this->loadTemplate(')
-            ->subcompile($this->getNode('template'))
-            ->raw(', ')
-            ->repr($this->getTemplateName())
-            ->raw(', ')
-            ->repr($this->getTemplateLine())
-            ->raw(')')
-        ;
+        $compiler->raw(sprintf('->%s', $method));
+
+        return $this;
     }
 
     private function compileBlockArguments(Twig_Compiler $compiler)

--- a/test/Twig/Tests/Fixtures/functions/block_with_template.test
+++ b/test/Twig/Tests/Fixtures/functions/block_with_template.test
@@ -1,0 +1,22 @@
+--TEST--
+"block" function with a template argument
+--TEMPLATE--
+{{ block('foo', 'included.twig') }}
+{{ block('foo', included_loaded) }}
+{{ block('foo', included_loaded_internal) }}
+{% set output = block('foo', 'included.twig') %}
+{{ output }}
+{% block foo %}NOT FOO{% endblock %}
+--TEMPLATE(included.twig)--
+{% block foo %}FOO{% endblock %}
+--DATA--
+return array(
+    'included_loaded' => $twig->load('included.twig'),
+    'included_loaded_internal' => $twig->loadTemplate('included.twig'),
+)
+--EXPECT--
+FOO
+FOO
+FOO
+FOO
+NOT FOO

--- a/test/Twig/Tests/Fixtures/tests/defined_for_blocks_with_template.test
+++ b/test/Twig/Tests/Fixtures/tests/defined_for_blocks_with_template.test
@@ -1,0 +1,17 @@
+--TEST--
+"defined" support for blocks with a template argument
+--TEMPLATE--
+{{ block('foo', 'included.twig') is defined ? 'ok' : 'ko' }}
+{{ block('foo', included_loaded) is defined ? 'ok' : 'ko' }}
+{{ block('foo', included_loaded_internal) is defined ? 'ok' : 'ko' }}
+--TEMPLATE(included.twig)--
+{% block foo %}FOO{% endblock %}
+--DATA--
+return array(
+    'included_loaded' => $twig->load('included.twig'),
+    'included_loaded_internal' => $twig->loadTemplate('included.twig'),
+)
+--EXPECT--
+ok
+ok
+ok


### PR DESCRIPTION
This PR fixes symfony/symfony#20556.

When referring to a block of another template from within a template that also has a block with the same name, Twig renders the wrong block.