### PR TITLE
Deprecate support for mbstring.func_overload != 0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
-* 1.28.3 (2016-XX-XX)
+* 1.29.0 (2016-XX-XX)
 
- * n/a
+ * deprecated support for mbstring.func_overload != 0
 
 * 1.28.2 (2016-11-23)
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.28-dev"
+            "dev-master": "1.29-dev"
         }
     }
 }

--- a/ext/twig/php_twig.h
+++ b/ext/twig/php_twig.h
@@ -15,7 +15,7 @@
 #ifndef PHP_TWIG_H
 #define PHP_TWIG_H
 
-#define PHP_TWIG_VERSION "1.28.3-DEV"
+#define PHP_TWIG_VERSION "1.29.0-DEV"
 
 #include "php.h"
 

--- a/lib/Twig/Compiler.php
+++ b/lib/Twig/Compiler.php
@@ -216,6 +216,8 @@ class Twig_Compiler implements Twig_CompilerInterface
             // mb_substr_count() replaces substr_count()
             // but they have different signatures!
             if (((int) ini_get('mbstring.func_overload')) & 2) {
+                @trigger_error('Support for having "mbstring.func_overload" different from 0 is deprecated version 1.29 and will be removed in 2.0.', E_USER_DEPRECATED);
+
                 // this is much slower than the "right" version
                 $this->sourceLine += mb_substr_count(mb_substr($this->source, $this->sourceOffset), "\n");
             } else {

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -16,11 +16,11 @@
  */
 class Twig_Environment
 {
-    const VERSION = '1.28.3';
-    const VERSION_ID = 12803;
+    const VERSION = '1.29.0-DEV';
+    const VERSION_ID = 12900;
     const MAJOR_VERSION = 1;
-    const MINOR_VERSION = 28;
-    const RELEASE_VERSION = 3;
+    const MINOR_VERSION = 20;
+    const RELEASE_VERSION = 0;
     const EXTRA_VERSION = 'DEV';
 
     protected $charset;

--- a/lib/Twig/Lexer.php
+++ b/lib/Twig/Lexer.php
@@ -85,6 +85,10 @@ class Twig_Lexer implements Twig_LexerInterface
             $source = $code;
         }
 
+        if (((int) ini_get('mbstring.func_overload')) & 2) {
+            @trigger_error('Support for having "mbstring.func_overload" different from 0 is deprecated version 1.29 and will be removed in 2.0.', E_USER_DEPRECATED);
+        }
+
         if (function_exists('mb_internal_encoding') && ((int) ini_get('mbstring.func_overload')) & 2) {
             $mbEncoding = mb_internal_encoding();
             mb_internal_encoding('ASCII');


### PR DESCRIPTION
see https://wiki.php.net/rfc/deprecations_php_7_2
