### PR TITLE
Strict blocks

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -122,6 +122,12 @@ The following options are available:
   replace them with a ``null`` value. When set to ``true``, Twig throws an
   exception instead (default to ``false``).
 
+* ``strict_blocks`` *boolean*
+
+  If set to ``false``, Twig will silently ignore usage of undefined
+  blocks with the ``block()`` function. When set to ``true``, Twig throws an
+  exception instead (default to ``false``).
+
 * ``autoescape`` *string* or *boolean*
 
   If set to ``true``, HTML auto-escaping will be enabled by

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -43,6 +43,7 @@ class Twig_Environment
     protected $extensionInitialized = false;
     protected $loadedTemplates;
     protected $strictVariables;
+    protected $strictBlocks;
     protected $unaryOperators;
     protected $binaryOperators;
     protected $templateClassPrefix = '__TwigTemplate_';
@@ -83,6 +84,9 @@ class Twig_Environment
      *  * strict_variables: Whether to ignore invalid variables in templates
      *                      (default to false).
      *
+     *  * strict_blocks: Whether to ignore undefined blocks usage.
+     *                   (default to false).
+     *
      *  * autoescape: Whether to enable auto-escaping (default to html):
      *                  * false: disable auto-escaping
      *                  * true: equivalent to html
@@ -110,6 +114,7 @@ class Twig_Environment
             'charset' => 'UTF-8',
             'base_template_class' => 'Twig_Template',
             'strict_variables' => false,
+            'strict_blocks' => false,
             'autoescape' => 'html',
             'cache' => false,
             'auto_reload' => null,
@@ -121,6 +126,7 @@ class Twig_Environment
         $this->baseTemplateClass = $options['base_template_class'];
         $this->autoReload = null === $options['auto_reload'] ? $this->debug : (bool) $options['auto_reload'];
         $this->strictVariables = (bool) $options['strict_variables'];
+        $this->strictBlocks = (bool) $options['strict_blocks'];
         $this->setCache($options['cache']);
 
         $this->addExtension(new Twig_Extension_Core());
@@ -247,6 +253,34 @@ class Twig_Environment
     public function isStrictVariables()
     {
         return $this->strictVariables;
+    }
+
+    /**
+     * Enables the strict_blocks option.
+     */
+    public function enableStrictBlocks()
+    {
+        $this->strictBlocks = true;
+        $this->updateOptionsHash();
+    }
+
+    /**
+     * Disables the strict_blocks option.
+     */
+    public function disableStrictBlocks()
+    {
+        $this->strictBlocks = false;
+        $this->updateOptionsHash();
+    }
+
+    /**
+     * Checks if the strict_blocks option is enabled.
+     *
+     * @return bool true if strict_blocks is enabled, false otherwise
+     */
+    public function isStrictBlocks()
+    {
+        return $this->strictBlocks;
     }
 
     /**
@@ -1541,6 +1575,7 @@ class Twig_Environment
                 (int) $this->debug,
                 $this->baseTemplateClass,
                 (int) $this->strictVariables,
+                (int) $this->strictBlocks,
             )
         );
         $this->optionsHash = implode(':', $hashParts);

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -180,6 +180,8 @@ abstract class Twig_Template implements Twig_TemplateInterface
      * @param array  $blocks    The current set of blocks
      * @param bool   $useBlocks Whether to use the current set of blocks
      *
+     * @throws Twig_Error_Runtime if the block is not defined and Twig is running in strict blocks mode
+     *
      * @internal
      */
     public function displayBlock($name, array $context, array $blocks = array(), $useBlocks = true)
@@ -192,9 +194,11 @@ abstract class Twig_Template implements Twig_TemplateInterface
         } elseif (isset($this->blocks[$name])) {
             $template = $this->blocks[$name][0];
             $block = $this->blocks[$name][1];
-        } else {
+        } elseif (!$this->env->isStrictBlocks()) {
             $template = null;
             $block = null;
+        } else {
+            throw new Twig_Error_Runtime(sprintf('Block "%s" is not defined.', $name), -1, $this->getTemplateName());
         }
 
         if (null !== $template) {
@@ -469,7 +473,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
      *
      * @return mixed The content of the context variable
      *
-     * @throws Twig_Error_Runtime if the variable does not exist and Twig is running in strict mode
+     * @throws Twig_Error_Runtime if the variable does not exist and Twig is running in strict variables mode
      *
      * @internal
      */
@@ -498,7 +502,7 @@ abstract class Twig_Template implements Twig_TemplateInterface
      *
      * @return mixed The attribute value, or a Boolean when $isDefinedTest is true, or null when the attribute is not set and $ignoreStrictCheck is true
      *
-     * @throws Twig_Error_Runtime if the attribute does not exist and Twig is running in strict mode and $isDefinedTest is false
+     * @throws Twig_Error_Runtime if the attribute does not exist and Twig is running in strict variables mode and $isDefinedTest is false
      *
      * @internal
      */

--- a/lib/Twig/Test/IntegrationTestCase.php
+++ b/lib/Twig/Test/IntegrationTestCase.php
@@ -87,21 +87,15 @@ abstract class Twig_Test_IntegrationTestCase extends PHPUnit_Framework_TestCase
 
             $test = file_get_contents($file->getRealpath());
 
-            if (preg_match('/--TEST--\s*(.*?)\s*(?:--CONDITION--\s*(.*))?\s*((?:--TEMPLATE(?:\(.*?\))?--(?:.*?))+)\s*(?:--DATA--\s*(.*))?\s*--EXCEPTION--\s*(.*)/sx', $test, $match)) {
-                $message = $match[1];
-                $condition = $match[2];
-                $templates = self::parseTemplates($match[3]);
-                $exception = $match[5];
-                $outputs = array(array(null, $match[4], null, ''));
-            } elseif (preg_match('/--TEST--\s*(.*?)\s*(?:--CONDITION--\s*(.*))?\s*((?:--TEMPLATE(?:\(.*?\))?--(?:.*?))+)--DATA--.*?--EXPECT--.*/s', $test, $match)) {
-                $message = $match[1];
-                $condition = $match[2];
-                $templates = self::parseTemplates($match[3]);
-                $exception = false;
-                preg_match_all('/--DATA--(.*?)(?:--CONFIG--(.*?))?--EXPECT--(.*?)(?=\-\-DATA\-\-|$)/s', $test, $outputs, PREG_SET_ORDER);
-            } else {
+            if (!preg_match('/--TEST--\s*(.*?)\s*(?:--CONDITION--\s*(.*))?\s*((?:--TEMPLATE(?:\(.*?\))?--(?:.*?))+)(?:--DATA--.*?)?--(EXPECT|EXCEPTION)--\s*(.*)/s', $test, $match)) {
                 throw new InvalidArgumentException(sprintf('Test "%s" is not valid.', str_replace($fixturesDir.'/', '', $file)));
             }
+
+            $message = $match[1];
+            $condition = $match[2];
+            $templates = self::parseTemplates($match[3]);
+            $exception = 'EXCEPTION' == $match[4] ? $match[5] : false;
+            preg_match_all('/(?:--DATA--(.*?))?(?:--CONFIG--(.*?))?--(?:EXPECT|EXCEPTION)--(.*?)(?=\-\-DATA\-\-|$)/s', $test, $outputs, PREG_SET_ORDER);
 
             $tests[] = array(str_replace($fixturesDir.'/', '', $file), $message, $condition, $templates, $exception, $outputs);
         }

--- a/test/Twig/Tests/Fixtures/functions/block_strict.test
+++ b/test/Twig/Tests/Fixtures/functions/block_strict.test
@@ -1,0 +1,14 @@
+--TEST--
+"block" function with strict_blocks option enabled
+--TEMPLATE--
+{% extends 'base.twig' %}
+{% block bar %}BAR{% endblock %}
+--TEMPLATE(base.twig)--
+{% block foo %}{{ block('bar') }}{% endblock %}
+{% block bar %}BAR_BASE{% endblock %}
+--DATA--
+return array()
+--CONFIG--
+return array('strict_blocks' => true)
+--EXPECT--
+BARBAR

--- a/test/Twig/Tests/Fixtures/functions/block_strict_unknown.test
+++ b/test/Twig/Tests/Fixtures/functions/block_strict_unknown.test
@@ -1,0 +1,14 @@
+--TEST--
+"block" function with strict_blocks option enabled
+--TEMPLATE--
+{% extends 'base.twig' %}
+{% block bar %}BAR{% endblock %}
+--TEMPLATE(base.twig)--
+{% block foo %}{{ block('unknown') }}{% endblock %}
+{% block bar %}BAR_BASE{% endblock %}
+--DATA--
+return array()
+--CONFIG--
+return array('strict_blocks' => true)
+--EXCEPTION--
+Twig_Error_Runtime: Block "unknown" is not defined in "base.twig" at line 2.

--- a/test/Twig/Tests/Fixtures/functions/block_strict_unknown_defined.test
+++ b/test/Twig/Tests/Fixtures/functions/block_strict_unknown_defined.test
@@ -1,0 +1,10 @@
+--TEST--
+"block" function defined test with strict_blocks option enabled
+--TEMPLATE--
+{{ block('unknown') is defined ? 'DEFINED' : 'UNDEFINED' }}
+--DATA--
+return array()
+--CONFIG--
+return array('strict_blocks' => true)
+--EXPECT--
+UNDEFINED


### PR DESCRIPTION
Not sure if this is a bug or a feature, but using `block('some_undefined_block')` silently fails. This PR introduces a new `strict_blocks` environment option to make Twig throw an exception in such case.

Also, I think this should be the default behavior in 2.x or 3.x by changing the option's default value to `true` or even removing it. WDYT?