### PR TITLE
Fix sandbox being left enabled if an exception is thrown while rendering

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1406,6 +1406,18 @@ function twig_include(Twig_Environment $env, $context, $template, $variables = a
 
             throw $e;
         }
+    } catch (Throwable $e) {
+        if ($isSandboxed && !$alreadySandboxed) {
+            $sandbox->disableSandbox();
+        }
+
+        throw $e;
+    } catch (Exception $e) {
+        if ($isSandboxed && !$alreadySandboxed) {
+            $sandbox->disableSandbox();
+        }
+
+        throw $e;
     }
 
     if ($isSandboxed && !$alreadySandboxed) {

--- a/test/Twig/Tests/Extension/SandboxTest.php
+++ b/test/Twig/Tests/Extension/SandboxTest.php
@@ -34,6 +34,7 @@ class Twig_Tests_Extension_SandboxTest extends PHPUnit_Framework_TestCase
             '1_basic' => '{% if obj.foo %}{{ obj.foo|upper }}{% endif %}',
             '1_layout' => '{% block content %}{% endblock %}',
             '1_child' => "{% extends \"1_layout\" %}\n{% block content %}\n{{ \"a\"|json_encode }}\n{% endblock %}",
+            '1_include' => '{{ include("1_basic1", sandboxed=true) }}',
         );
     }
 
@@ -238,6 +239,23 @@ EOF
         ), array('macro', 'import'), array('escape'));
 
         $this->assertEquals('<p>username</p>', $twig->loadTemplate('index')->render(array()));
+    }
+
+    public function testSandboxDisabledAfterIncludeFunctionError()
+    {
+        $twig = $this->getEnvironment(false, array(), self::$templates);
+
+        $e = null;
+        try {
+            $twig->loadTemplate('1_include')->render(self::$params);
+        } catch (Throwable $e) {
+        } catch (Exception $e) {
+        }
+        if ($e === null) {
+            $this->fail('An exception should be thrown for this test to be valid.');
+        }
+
+        $this->assertFalse($twig->getExtension('Twig_Extension_Sandbox')->isSandboxed(), 'Sandboxed include() function call should not leave Sandbox enabled when an error occurs.');
     }
 
     protected function getEnvironment($sandboxed, $options, $templates, $tags = array(), $filters = array(), $methods = array(), $properties = array(), $functions = array())


### PR DESCRIPTION
What's happening for me:
- An exception is thrown while rendering inside the sandbox
- Render exception response
- WebProfiler toolbar tries to include a file
- Sandbox is still enabled, so a SecurityException is thrown (which hides the real error)
