### PR TITLE
Cleanup

### DIFF
--- a/lib/Twig/Error/Loader.php
+++ b/lib/Twig/Error/Loader.php
@@ -24,18 +24,15 @@
  */
 class Twig_Error_Loader extends Twig_Error
 {
-    private $guess = false;
-
     public function __construct($message, $lineno = -1, $source = null, Exception $previous = null)
     {
-        parent::__construct($message, false, null, $previous);
-        $this->guess = true;
-    }
-
-    protected function guessTemplateInfo()
-    {
-        if ($this->guess) {
-            parent::guessTemplateInfo();
+        if (PHP_VERSION_ID < 50300) {
+            $this->previous = $previous;
+            Exception::__construct('');
+        } else {
+            Exception::__construct('', 0, $previous);
         }
+        $this->appendMessage($message);
+        $this->setTemplateLine(false);
     }
 }

--- a/lib/Twig/Test/IntegrationTestCase.php
+++ b/lib/Twig/Test/IntegrationTestCase.php
@@ -173,12 +173,6 @@ abstract class Twig_Test_IntegrationTestCase extends PHPUnit_Framework_TestCase
                     return;
                 }
 
-                if ($e instanceof Twig_Error_Syntax) {
-                    $e->setTemplateName($file);
-
-                    throw $e;
-                }
-
                 throw new Twig_Error(sprintf('%s: %s', get_class($e), $e->getMessage()), -1, $file, $e);
             }
 
@@ -191,11 +185,7 @@ abstract class Twig_Test_IntegrationTestCase extends PHPUnit_Framework_TestCase
                     return;
                 }
 
-                if ($e instanceof Twig_Error_Syntax) {
-                    $e->setTemplateName($file);
-                } else {
-                    $e = new Twig_Error(sprintf('%s: %s', get_class($e), $e->getMessage()), -1, $file, $e);
-                }
+                $e = new Twig_Error(sprintf('%s: %s', get_class($e), $e->getMessage()), -1, $file, $e);
 
                 $output = trim(sprintf('%s: %s', get_class($e), $e->getMessage()));
             }


### PR DESCRIPTION
Two things here:

guessTemplateInfo is private in 2.x
this PR will fix tests on 2.x

setTemplateName is deprecated, and the removed code paths are never run