### PR TITLE
Remove $env argument type from ExpressionParser constructor

### DIFF
--- a/lib/Twig/ExpressionParser.php
+++ b/lib/Twig/ExpressionParser.php
@@ -33,7 +33,7 @@ class Twig_ExpressionParser
 
     private $env;
 
-    public function __construct(Twig_Parser $parser, Twig_Environment $env = null)
+    public function __construct(Twig_Parser $parser, $env = null)
     {
         $this->parser = $parser;
 


### PR DESCRIPTION
Either the argument type should be removed, or the whole "else" block and the deprecation warning is useless.