### PR TITLE
Fix Travis Build Matrix to Support 7.x and HHVM Only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,36 +3,37 @@ language: php
 sudo: false
 
 cache:
-    directories:
-        - vendor
-        - $HOME/.composer/cache/files
+  directories:
+    - vendor
+    - $HOME/.composer/cache/files
 
-php:
-    - 5.6
-    - 7.0
-    - 7.1
-    - hhvm
-
-env:
-    - TWIG_EXT=no
-    - TWIG_EXT=yes
+matrix:
+  include:
+    - php: hhvm-stable
+      sudo: required
+      dist: trusty
+      group: edge
+      env: TWIG_EXT=no
+    - php: 7.0
+      env: TWIG_EXT=no
+    - php: 7.1
+      env: TWIG_EXT=no
+  allow_failures:
+    - php: hhvm-stable
+      sudo: required
+      dist: trusty
+      group: edge
+      env: TWIG_EXT=no
+  fast_finish: true
 
 before_install:
-    - if [[ ! $TRAVIS_PHP_VERSION = hhvm* ]]; then phpenv config-rm xdebug.ini || echo "xdebug not available"; fi
+  - if [[ ! $TRAVIS_PHP_VERSION = hhvm* ]]; then phpenv config-rm xdebug.ini || echo "xdebug not available"; fi
+  - if [[ $TRAVIS_PHP_VERSION = hhvm* ]]; then echo hhvm.php7.all=1 >> /etc/hhvm/php.ini; fi
 
 install:
   - travis_retry composer install
 
 before_script:
-    - if [ "$TWIG_EXT" == "yes" ]; then sh -c "cd ext/twig && phpize && ./configure --enable-twig && make && make install"; fi
-    - if [ "$TWIG_EXT" == "yes" ]; then echo "extension=twig.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
+  - if [ "$TWIG_EXT" == "yes" ]; then sh -c "cd ext/twig && phpize && ./configure --enable-twig && make && make install"; fi
+  - if [ "$TWIG_EXT" == "yes" ]; then echo "extension=twig.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
 
-matrix:
-    fast_finish: true
-    exclude:
-        - php: hhvm
-          env: TWIG_EXT=yes
-        - php: 7.0
-          env: TWIG_EXT=yes
-        - php: 7.1
-          env: TWIG_EXT=yes

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "forum": "https://groups.google.com/forum/#!forum/twig-users"
     },
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^7.0",
         "symfony/polyfill-mbstring": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
As a follow-up to #2302 (with HHVM set as an allowed failure until Composer sorts out its inability to parse the `7.0.99-hhvm` version string, ticket for this here: composer/composer#5978).