### PR TITLE
fix C89 compat

### DIFF
--- a/ext/twig/twig.c
+++ b/ext/twig/twig.c
@@ -1124,6 +1124,8 @@ PHP_FUNCTION(twig_template_get_attributes)
 		// ret can be null, if e.g. the called method throws an exception
 		if (ret) {
 			if (TWIG_INSTANCE_OF_USERLAND(object, "Twig_TemplateInterface" TSRMLS_CC)) {
+				int self;
+				int old_error_reporting;
 				zval *object_filename;
 				zval *this_filename;
 				zval *filename_func;
@@ -1140,7 +1142,7 @@ PHP_FUNCTION(twig_template_get_attributes)
 				ZVAL_STRINGL(filename_func, "getTemplateName", sizeof("getTemplateName")-1, 1);
 				call_user_function(EG(function_table), &template, filename_func, this_filename, 0, 0 TSRMLS_CC);
 
-				int self = (strcmp(Z_STRVAL_P(object_filename), Z_STRVAL_P(this_filename)) == 0);
+				self = (strcmp(Z_STRVAL_P(object_filename), Z_STRVAL_P(this_filename)) == 0);
 
 				if (strcmp(methodForDeprecation, "renderBlock") == 0 || strcmp(methodForDeprecation, "displayBlock") == 0) {
 					zval **arg0;
@@ -1179,7 +1181,7 @@ PHP_FUNCTION(twig_template_get_attributes)
 					deprecation_message_complement
 				);
 
-				int old_error_reporting = EG(error_reporting);
+				old_error_reporting = EG(error_reporting);
 				EG(error_reporting) = 0;
 				zend_error(E_USER_DEPRECATED, "%s", deprecation_message);
 				EG(error_reporting) = old_error_reporting;


### PR DESCRIPTION
@tucksaun @fabpot The extension did not compile anymore with old MSVC compilers. This PR contains the fix.