### PR TITLE
Remove mention of Twig_Autoloader() [deprecated]

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -22,8 +22,7 @@ The simplest way to configure Twig to load templates for your application
 looks roughly like this::
 
     require_once '/path/to/lib/Twig/Autoloader.php';
-    Twig_Autoloader::register();
-
+    
     $loader = new Twig_Loader_Filesystem('/path/to/templates');
     $twig = new Twig_Environment($loader, array(
         'cache' => '/path/to/compilation_cache',


### PR DESCRIPTION
I could be wrong, but just started learning Symfony, and PHPStorm 9.0 says `Twig_Autoloader` in `Twig_Autoloader::register();` is deprecated!. if that is the case, might as well remove it. I didn't have issues removing it, since I installed twig via composer.