### PR TITLE
Update umask before creating cache directory

### DIFF
--- a/lib/Twig/Cache/Filesystem.php
+++ b/lib/Twig/Cache/Filesystem.php
@@ -49,9 +49,12 @@ class Twig_Cache_Filesystem implements Twig_CacheInterface
     {
         $dir = dirname($key);
         if (!is_dir($dir)) {
+            $oldMask = umask(0);
             if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
+                umask($oldMask);
                 throw new RuntimeException(sprintf('Unable to create the cache directory (%s).', $dir));
             }
+            umask($oldMask);
         } elseif (!is_writable($dir)) {
             throw new RuntimeException(sprintf('Unable to write in the cache directory (%s).', $dir));
         }


### PR DESCRIPTION
The cache directory is not created with 0777 permissions because of the system umask. Therefore if the process is being triggered through different users (ex: web, CLI), it is unable to write to the directory and throws exception. This commit will ensure that cache directory is always created with 
0777 permissions irrespective of the system umask.