### PR TITLE
Fix the argument name of filter replace

### DIFF
--- a/doc/filters/replace.rst
+++ b/doc/filters/replace.rst
@@ -14,6 +14,6 @@ The ``replace`` filter formats a given string by replacing the placeholders
 Arguments
 ---------
 
-* ``replace_pairs``: The placeholder values
+* ``from``: The placeholder values
 
 .. seealso:: :doc:`format<format>`


### PR DESCRIPTION
The argument name in the code is $from

See https://github.com/jean-pasqualini/Twig/blob/1.x/lib/Twig/Extension/Core.php#L475.

Issue : https://github.com/twigphp/Twig/issues/2329