### PR TITLE
Improve Twig Error Messages

### DIFF
--- a/lib/Twig/Error.php
+++ b/lib/Twig/Error.php
@@ -250,8 +250,6 @@ class Twig_Error extends Exception
         if ($this->sourcePath && $this->lineno > 0) {
             $this->file = $this->sourcePath;
             $this->line = $this->lineno;
-
-            return;
         }
 
         $dot = false;

--- a/test/Twig/Tests/ErrorTest.php
+++ b/test/Twig/Tests/ErrorTest.php
@@ -94,7 +94,7 @@ EOHTML
 
             $this->fail();
         } catch (Twig_Error_Runtime $e) {
-            $this->assertEquals('Variable "foo" does not exist.', $e->getMessage());
+            $this->assertEquals('Variable "foo" does not exist in "index.html" at line 3.', $e->getMessage());
             $this->assertEquals(3, $e->getTemplateLine());
             $this->assertEquals('index.html', $e->getSourceContext()->getName());
             $this->assertEquals(3, $e->getLine());
@@ -113,7 +113,7 @@ EOHTML
 
             $this->fail();
         } catch (Twig_Error_Runtime $e) {
-            $this->assertEquals('An exception has been thrown during the rendering of a template ("Runtime error...").', $e->getMessage());
+            $this->assertEquals('An exception has been thrown during the rendering of a template ("Runtime error...") in "index.html" at line 3.', $e->getMessage());
             $this->assertEquals(3, $e->getTemplateLine());
             $this->assertEquals('index.html', $e->getSourceContext()->getName());
             $this->assertEquals(3, $e->getLine());


### PR DESCRIPTION
Removes an early exit from the `updateRepr` method, which allows for more informative error messages.