### PR TITLE
Added Twig_Simple* methods to deprecated doc

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -5,4 +5,24 @@ This document lists deprecated features in Twig 2.x. Deprecated features are
 kept for backward compatibility and removed in the next major release (a
 feature that was deprecated in Twig 2.x is removed in Twig 3.0).
 
-There are no deprecated features for Twig 2.x.
+Filters
+-------
+
+* As of Twig 2.x, the ``Twig_SimpleFilter`` class is deprecated and will be
+  removed in Twig 3.x (use ``Twig_Filter`` instead). In Twig 2.x,
+  ``Twig_SimpleFilter`` is just an alias for ``Twig_Filter``.
+
+Functions
+---------
+
+* As of Twig 2.x, the ``Twig_SimpleFunction`` class is deprecated and will be
+  removed in Twig 3.x (use ``Twig_Function`` instead). In Twig 2.x,
+  ``Twig_SimpleFunction`` is just an alias for ``Twig_Function``.
+
+Tests
+-----
+
+* As of Twig 2.x, the ``Twig_SimpleTest`` class is deprecated and will be
+  removed in Twig 3.x (use ``Twig_Test`` instead). In Twig 2.x,
+  ``Twig_SimpleTest`` is just an alias for ``Twig_Test``.
+  


### PR DESCRIPTION
The documentation of these deprecations was available in the 1.0 branch and is still useful in 2.0.