### PR TITLE
Typehint the function, filter and test names as string

### DIFF
--- a/lib/Twig/Filter.php
+++ b/lib/Twig/Filter.php
@@ -32,7 +32,7 @@ class Twig_Filter
      * @param callable|null $callable A callable implementing the filter. If null, you need to overwrite the "node_class" option to customize compilation.
      * @param array         $options  Options array
      */
-    public function __construct($name, $callable = null, array $options = array())
+    public function __construct(string $name, $callable = null, array $options = array())
     {
         $this->name = $name;
         $this->callable = $callable;

--- a/lib/Twig/Function.php
+++ b/lib/Twig/Function.php
@@ -32,7 +32,7 @@ class Twig_Function
      * @param callable|null $callable A callable implementing the function. If null, you need to overwrite the "node_class" option to customize compilation.
      * @param array         $options  Options array
      */
-    public function __construct($name, $callable = null, array $options = array())
+    public function __construct(string $name, $callable = null, array $options = array())
     {
         $this->name = $name;
         $this->callable = $callable;

--- a/lib/Twig/Test.php
+++ b/lib/Twig/Test.php
@@ -31,7 +31,7 @@ class Twig_Test
      * @param callable|null $callable A callable implementing the test. If null, you need to overwrite the "node_class" option to customize compilation.
      * @param array         $options  Options array
      */
-    public function __construct($name, $callable = null, array $options = array())
+    public function __construct(string $name, $callable = null, array $options = array())
     {
         $this->name = $name;
         $this->callable = $callable;


### PR DESCRIPTION
This gives faster feedback when using the class in a wrong way, instead of getting a ``Warning: Illegal offset type in ExtensionSet.php line 434`` during the function registration (see https://github.com/symfony/symfony/issues/21212 for a case getting this message)