### PR TITLE
remove condition on PHP version

### DIFF
--- a/lib/Twig/Node/Expression/Name.php
+++ b/lib/Twig/Node/Expression/Name.php
@@ -44,22 +44,11 @@ class Twig_Node_Expression_Name extends Twig_Node_Expression
             ;
         } else {
             if ($this->getAttribute('ignore_strict_check') || !$compiler->getEnvironment()->isStrictVariables()) {
-                if (PHP_VERSION_ID >= 70000) {
-                    // use PHP 7 null coalescing operator
-                    $compiler
-                        ->raw('($context[')
-                        ->string($name)
-                        ->raw('] ?? null)')
-                    ;
-                } else {
-                    $compiler
-                        ->raw('(isset($context[')
-                        ->string($name)
-                        ->raw(']) ? $context[')
-                        ->string($name)
-                        ->raw('] : null)')
-                    ;
-                }
+                $compiler
+                    ->raw('($context[')
+                    ->string($name)
+                    ->raw('] ?? null)')
+                ;
             } else {
                 $compiler
                     ->raw('(isset($context[')


### PR DESCRIPTION
Twig now requires PHP >= 7 so there is no need to check for prior version.