### PR TITLE
Turned fatal error into exception when a previously generated cache prevents loading its newly compiled version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@
  * added Twig_NodeCaptureInterface for nodes that capture all output
  * fixed marking the environment as initialized too early
  * fixed C89 compat for the C extension
+ * turned fatal error into exception when a previously generated cache is corrupted
+ * fixed offline cache warm-ups for embedded templates
 
 * 1.30.0 (2016-12-23)
 


### PR DESCRIPTION
Not sure if this is testable, yet this should save some hours to people that end up in the same trap we did on our project.
It turned out we generated some twig template cache in two separate commands, in a situation where "index" tracking for embeds where lost.

This PR detects the situation and invites to clear the cache properly, because that's the only way to fix the issue.

It also fixes a mistake in the cache $key generation, that should not take $index into account.
Doing so were making offline cache warmup useless in some situations.