### PR TITLE
Remove legacy exception catch blocks from 2.x

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1270,12 +1270,6 @@ function twig_include(Twig_Environment $env, $context, $template, $variables = a
         }
 
         throw $e;
-    } catch (Exception $e) {
-        if ($isSandboxed && !$alreadySandboxed) {
-            $sandbox->disableSandbox();
-        }
-
-        throw $e;
     }
 
     if ($isSandboxed && !$alreadySandboxed) {

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -370,12 +370,6 @@ abstract class Twig_Template
         ob_start();
         try {
             $this->display($context);
-        } catch (Exception $e) {
-            while (ob_get_level() > $level) {
-                ob_end_clean();
-            }
-
-            throw $e;
         } catch (Throwable $e) {
             while (ob_get_level() > $level) {
                 ob_end_clean();

--- a/lib/Twig/TemplateWrapper.php
+++ b/lib/Twig/TemplateWrapper.php
@@ -93,12 +93,6 @@ final class Twig_TemplateWrapper
         ob_start();
         try {
             $this->template->displayBlock($name, $context);
-        } catch (Exception $e) {
-            while (ob_get_level() > $level) {
-                ob_end_clean();
-            }
-
-            throw $e;
         } catch (Throwable $e) {
             while (ob_get_level() > $level) {
                 ob_end_clean();

--- a/test/Twig/Tests/Extension/SandboxTest.php
+++ b/test/Twig/Tests/Extension/SandboxTest.php
@@ -250,7 +250,6 @@ EOF
         try {
             $twig->loadTemplate('1_include')->render(self::$params);
         } catch (Throwable $e) {
-        } catch (Exception $e) {
         }
         if ($e === null) {
             $this->fail('An exception should be thrown for this test to be valid.');


### PR DESCRIPTION
These `catch` blocks were only useful for compatibility with PHP versions prior to 7.0.