### PR TITLE
Fix undef. source in exception.

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -359,7 +359,8 @@ class Twig_Environment
             }
 
             if (!class_exists($cls, false)) {
-                $content = $this->compileSource($this->getLoader()->getSourceContext($name));
+                $source = $this->getLoader()->getSourceContext($name);
+                $content = $this->compileSource($source);
                 $this->cache->write($key, $content);
                 $this->cache->load($key);
 
@@ -371,10 +372,10 @@ class Twig_Environment
                      */
                     eval('?>'.$content);
                 }
-            }
 
-            if (!class_exists($cls, false)) {
-                throw new Twig_Error_Runtime(sprintf('Failed to load Twig template "%s", index "%s": cache is corrupted.', $name, $index), -1, $source);
+                if (!class_exists($cls, false)) {
+                    throw new Twig_Error_Runtime(sprintf('Failed to load Twig template "%s", index "%s": cache is corrupted.', $name, $index), -1, $source);
+                }
             }
         }
 

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -334,6 +334,18 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $twig->render('func_string_named_args'));
     }
 
+    /**
+     * @expectedException Twig_Error_Runtime
+     * @expectedExceptionMessage Failed to load Twig template "testFailLoadTemplate.twig", index "abc": cache is corrupted in "testFailLoadTemplate.twig".
+     */
+    public function testFailLoadTemplate()
+    {
+        $template = 'testFailLoadTemplate.twig';
+        $twig = new Twig_Environment(new Twig_Loader_Array(array($template => false)));
+        //$twig->setCache(new CorruptCache());
+        $twig->loadTemplate($template, 'abc');
+    }
+
     protected function getMockLoader($templateName, $templateContent)
     {
         $loader = $this->getMockBuilder('Twig_LoaderInterface')->getMock();
@@ -347,6 +359,27 @@ class Twig_Tests_EnvironmentTest extends PHPUnit_Framework_TestCase
           ->will($this->returnValue($templateName));
 
         return $loader;
+    }
+}
+
+class CorruptCache implements Twig_CacheInterface
+{
+    public function generateKey($name, $className)
+    {
+        return $name.':'.$className;
+    }
+
+    public function write($key, $content)
+    {
+    }
+
+    public function load($key)
+    {
+    }
+
+    public function getTimestamp($key)
+    {
+        time();
     }
 }
 


### PR DESCRIPTION
closes https://github.com/twigphp/Twig/issues/2383

Two things:
- the tests fails without a corrupt cache, so maybe the message is of or the cache generation is off (i.e. not respecting the `$index`)
- passing the `$source` seems superfluous (but maybe that is only the case in the exception message)