### PR TITLE
Deprecate warnings and upgrade path.

### DIFF
--- a/lib/Twig/SimpleFilter.php
+++ b/lib/Twig/SimpleFilter.php
@@ -12,6 +12,15 @@
 /**
  * Empty class for Twig 1.x compatibility.
  */
-final class Twig_SimpleFilter extends Twig_Filter
+class Twig_SimpleFilter extends Twig_Filter
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(string $name, $callable = null, array $options = array())
+    {
+        @trigger_error('"Twig_SimpleFilter" is deprecated in favor of "Twig_Filter" and will be removed in Twig 3.0.', E_USER_DEPRECATED);
+
+        parent::__construct($name, $callable, $options);
+    }
 }

--- a/lib/Twig/SimpleFunction.php
+++ b/lib/Twig/SimpleFunction.php
@@ -12,6 +12,15 @@
 /**
  * Empty class for Twig 1.x compatibility.
  */
-final class Twig_SimpleFunction extends Twig_Function
+class Twig_SimpleFunction extends Twig_Function
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(string $name, $callable = null, array $options = array())
+    {
+        @trigger_error('"Twig_SimpleFunction" is deprecated in favor of "Twig_Function" and will be removed in Twig 3.0.', E_USER_DEPRECATED);
+
+        parent::__construct($name, $callable, $options);
+    }
 }

--- a/lib/Twig/SimpleTest.php
+++ b/lib/Twig/SimpleTest.php
@@ -12,6 +12,15 @@
 /**
  * Empty class for Twig 1.x compatibility.
  */
-final class Twig_SimpleTest extends Twig_Test
+class Twig_SimpleTest extends Twig_Test
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(string $name, $callable = null, array $options = array())
+    {
+        @trigger_error('"Twig_SimpleTest" is deprecated in favor of "Twig_Test" and will be removed in Twig 3.0.', E_USER_DEPRECATED);
+
+        parent::__construct($name, $callable, $options);
+    }
 }


### PR DESCRIPTION
The classes
- Twig_SimpleFilter
- Twig_SimpleFunction
 -Twig_SimpleTest

were left in the 2.x release `for Twig 1.x compatibility`. However since the classes are now declared as `final` it won't help for projects extending those classes ([example](https://github.com/GeckoPackages/GeckoTwig/blob/v1.3/src/Twig/Filters/BytesFilter.php#L53)).