### PR TITLE
#1802 left/right trim

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * 2.2.0 (2017-XX-XX)
 
  * added a PSR-11 compatible runtime loader
+ * added `type` argument to `trim` to allow left or right trimming only.
 
 * 2.1.0 (2017-01-11)
 
@@ -31,6 +32,7 @@
 * 1.32.0 (2017-XX-XX)
 
  * added a PSR-11 compatible runtime loader
+ * added `type` argument to `trim` to allow left or right trimming only.
 
 * 1.31.0 (2017-01-11)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 * 2.2.0 (2017-XX-XX)
 
  * added a PSR-11 compatible runtime loader
- * added `type` argument to `trim` to allow left or right trimming only.
+ * added `side` argument to `trim` to allow left or right trimming only.
 
 * 2.1.0 (2017-01-11)
 
@@ -32,7 +32,7 @@
 * 1.32.0 (2017-XX-XX)
 
  * added a PSR-11 compatible runtime loader
- * added `type` argument to `trim` to allow left or right trimming only.
+ * added `side` argument to `trim` to allow left or right trimming only.
 
 * 1.31.0 (2017-01-11)
 

--- a/doc/filters/trim.rst
+++ b/doc/filters/trim.rst
@@ -28,6 +28,6 @@ Arguments
 * ``character_mask``: The characters to strip
 
 * ``type``: The default is to strip from the start and the end (`both`), but `left`
-and `right` will strip from either the left side or right side only.
+  and `right` will strip from either the left side or right side only.
 
 .. _`trim`: http://php.net/trim

--- a/doc/filters/trim.rst
+++ b/doc/filters/trim.rst
@@ -1,5 +1,8 @@
 ``trim``
 ========
+.. versionadded:: 1.32
+
+    The ``type`` argument was added in Twig 1.32.
 
 The ``trim`` filter strips whitespace (or other characters) from the beginning
 and end of a string:
@@ -24,7 +27,7 @@ and end of a string:
 
 .. note::
 
-    Internally, Twig uses the PHP `trim`_, `ltrim`_ and `rtrim`_ functions.
+    Internally, Twig uses the PHP `trim`_, `ltrim`_, and `rtrim`_ functions.
 
 Arguments
 ---------
@@ -32,7 +35,7 @@ Arguments
 * ``character_mask``: The characters to strip
 
 * ``type``: The default is to strip from the start and the end (`both`), but `left`
-  and `right` will strip from either the left side or right side only.
+  and `right` will strip from either the left side or right side only
 
 .. _`trim`: http://php.net/trim
 .. _`ltrim`: http://php.net/ltrim

--- a/doc/filters/trim.rst
+++ b/doc/filters/trim.rst
@@ -26,6 +26,8 @@ Arguments
 ---------
 
 * ``character_mask``: The characters to strip
-* ``mode``: The default is to strip from the start and the end ('both'), but 'left'
-and 'right' will strip from either the left side or right side only.
+
+* ``mode``: The default is to strip from the start and the end (`both`), but `left`
+and `right` will strip from either the left side or right side only.
+
 .. _`trim`: http://php.net/trim

--- a/doc/filters/trim.rst
+++ b/doc/filters/trim.rst
@@ -35,3 +35,5 @@ Arguments
   and `right` will strip from either the left side or right side only.
 
 .. _`trim`: http://php.net/trim
+.. _`ltrim`: http://php.net/ltrim
+.. _`rtrim`: http://php.net/rtrim

--- a/doc/filters/trim.rst
+++ b/doc/filters/trim.rst
@@ -14,6 +14,10 @@ and end of a string:
 
     {# outputs '  I like Twig' #}
 
+    {{ '  I like Twig.  '|rtrim('', 'left') }}
+
+    {# outputs '  I like Twig. #}
+
 .. note::
 
     Internally, Twig uses the PHP `trim`_ function.
@@ -22,5 +26,6 @@ Arguments
 ---------
 
 * ``character_mask``: The characters to strip
-
+* ``mode``: The default is to strip from the start and the end ('both'), but 'left'
+and 'right' will strip from either the left side or right side only.
 .. _`trim`: http://php.net/trim

--- a/doc/filters/trim.rst
+++ b/doc/filters/trim.rst
@@ -14,7 +14,7 @@ and end of a string:
 
     {# outputs '  I like Twig' #}
 
-    {{ '  I like Twig.  '|rtrim('', 'left') }}
+    {{ '  I like Twig.  '|trim('', 'left') }}
 
     {# outputs '  I like Twig. #}
 

--- a/doc/filters/trim.rst
+++ b/doc/filters/trim.rst
@@ -14,7 +14,7 @@ and end of a string:
 
     {# outputs '  I like Twig' #}
 
-    {{ '  I like Twig.  '|trim('', 'left') }}
+    {{ '  I like Twig.  '|trim(type='left') }}
 
     {# outputs '  I like Twig. #}
 
@@ -27,7 +27,7 @@ Arguments
 
 * ``character_mask``: The characters to strip
 
-* ``mode``: The default is to strip from the start and the end (`both`), but `left`
+* ``type``: The default is to strip from the start and the end (`both`), but `left`
 and `right` will strip from either the left side or right side only.
 
 .. _`trim`: http://php.net/trim

--- a/doc/filters/trim.rst
+++ b/doc/filters/trim.rst
@@ -16,7 +16,7 @@ and end of a string:
 
     {{ '  I like Twig.  '|trim(type='left') }}
 
-    {# outputs '  I like Twig. #}
+    {# outputs 'I like Twig.  ' #}
 
 .. note::
 

--- a/doc/filters/trim.rst
+++ b/doc/filters/trim.rst
@@ -2,7 +2,7 @@
 ========
 .. versionadded:: 1.32
 
-    The ``type`` argument was added in Twig 1.32.
+    The ``side`` argument was added in Twig 1.32.
 
 The ``trim`` filter strips whitespace (or other characters) from the beginning
 and end of a string:
@@ -17,7 +17,7 @@ and end of a string:
 
     {# outputs '  I like Twig' #}
 
-    {{ '  I like Twig.  '|trim(type='left') }}
+    {{ '  I like Twig.  '|trim(side='left') }}
 
     {# outputs 'I like Twig.  ' #}
 
@@ -34,7 +34,7 @@ Arguments
 
 * ``character_mask``: The characters to strip
 
-* ``type``: The default is to strip from the start and the end (`both`), but `left`
+* ``side``: The default is to strip from the left and the right (`both`) sides, but `left`
   and `right` will strip from either the left side or right side only
 
 .. _`trim`: http://php.net/trim

--- a/doc/filters/trim.rst
+++ b/doc/filters/trim.rst
@@ -18,9 +18,13 @@ and end of a string:
 
     {# outputs 'I like Twig.  ' #}
 
+    {{ '  I like Twig.  '|trim(' ', 'right') }}
+
+    {# outputs '  I like Twig.' #}
+
 .. note::
 
-    Internally, Twig uses the PHP `trim`_ function.
+    Internally, Twig uses the PHP `trim`_, `ltrim`_ and `rtrim`_ functions.
 
 Arguments
 ---------

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -860,6 +860,8 @@ function twig_in_filter($value, $compare)
  * @param string $mode
  *
  * @return string
+ *
+ * @throws Twig_Error_Runtime When an invalid type is used (not 'left', 'right' or 'both')
  */
 function twig_trim_filter($string, $characterMask = null, $type = 'both')
 {
@@ -872,8 +874,9 @@ function twig_trim_filter($string, $characterMask = null, $type = 'both')
         case 'right':
             return rtrim($string, $characterMask);
         case 'both':
-        default:
             return trim($string, $characterMask);
+        default:
+            throw new Twig_Error_Runtime(sprintf('trim type must be "left", "right" or "both". Got %s.', $type));
     }          
 }
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -860,8 +860,11 @@ function twig_in_filter($value, $compare)
  * @param string $mode
  * @return string
  */
-function twig_trim_filter($string, $characterMask = " \t\n\r\0\x0B", $mode = 'both')
+function twig_trim_filter($string, $characterMask = null, $mode = 'both')
 {
+    if (empty($characterMask)) {
+        $characterMask = " \t\n\r\0\x0B";
+    }
     switch ($mode) {
         case 'left':
             $trimmed = ltrim($string, $characterMask);

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -860,19 +860,19 @@ function twig_in_filter($value, $compare)
  * @param string $mode
  * @return string
  */
-function twig_trim_filter($string, $character_mask = null, $type = 'both')
+function twig_trim_filter($string, $characterMask = null, $type = 'both')
 {
-    if (null === $character_mask) {
-        $character_mask = " \t\n\r\0\x0B";
+    if (null === $characterMask) {
+        $characterMask = " \t\n\r\0\x0B";
     }
     switch ($type) {
         case 'left':
-            return ltrim($string, $character_mask);
+            return ltrim($string, $characterMask);
         case 'right':
-            return rtrim($string, $character_mask);
+            return rtrim($string, $characterMask);
         case 'both':
         default:
-            return trim($string, $character_mask);
+            return trim($string, $characterMask);
     }          
 }
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -873,10 +873,8 @@ function twig_trim_filter($string, $characterMask = null, $side = 'both')
         case 'right':
             return rtrim($string, $characterMask);
         default:
-            if (!is_string($side) || !in_array($side, ['both', 'left', 'right'])) {
-                throw new Twig_Error_Runtime('Trimming side must be "left", "right" or "both".');
-            }
-    }          
+            throw new Twig_Error_Runtime('Trimming side must be "left", "right" or "both".');
+    }
 }
 
 /**

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -862,7 +862,7 @@ function twig_in_filter($value, $compare)
  */
 function twig_trim_filter($string, $character_mask = null, $type = 'both')
 {
-    if (is_null($character_mask)) {
+    if (null === $character_mask) {
         $character_mask = " \t\n\r\0\x0B";
     }
     switch ($type) {

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -857,15 +857,15 @@ function twig_in_filter($value, $compare)
  *
  * @return string
  *
- * @throws Twig_Error_Runtime When an invalid trimming type is used (not a string or not 'left', 'right' or 'both')
+ * @throws Twig_Error_Runtime When an invalid trimming side is used (not a string or not 'left', 'right' or 'both')
  */
-function twig_trim_filter($string, $characterMask = null, $type = 'both')
+function twig_trim_filter($string, $characterMask = null, $side = 'both')
 {
     if (null === $characterMask) {
         $characterMask = " \t\n\r\0\x0B";
     }
 
-    switch ($type) {
+    switch ($side) {
         case 'both':
             return trim($string, $characterMask);
         case 'left':
@@ -873,7 +873,7 @@ function twig_trim_filter($string, $characterMask = null, $type = 'both')
         case 'right':
             return rtrim($string, $characterMask);
         default:
-            if (!is_string($type) || !in_array($type, ['both', 'left', 'right'])) {
+            if (!is_string($side) || !in_array($side, ['both', 'left', 'right'])) {
                 throw new Twig_Error_Runtime('Trimming type must be "left", "right" or "both".');
             }
     }          

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -861,22 +861,27 @@ function twig_in_filter($value, $compare)
  *
  * @return string
  *
+ * @throws Twig_Error_Runtime When an type is not a string.
  * @throws Twig_Error_Runtime When an invalid type is used (not 'left', 'right' or 'both')
  */
 function twig_trim_filter($string, $characterMask = null, $type = 'both')
 {
+    if (!is_string($type)) {
+        throw new Twig_Error_Runtime(sprintf('Trimming type must be a string but got %s.', gettype($type)));
+    }
+    if (!in_array($type, ['both', 'left', 'right'])) {
+        throw new Twig_Error_Runtime(sprintf('Trimming type must be "left", "right" or "both" but got %s.', $type));
+    }
     if (null === $characterMask) {
         $characterMask = " \t\n\r\0\x0B";
     }
     switch ($type) {
+        case 'both':
+            return trim($string, $characterMask);
         case 'left':
             return ltrim($string, $characterMask);
         case 'right':
             return rtrim($string, $characterMask);
-        case 'both':
-            return trim($string, $characterMask);
-        default:
-            throw new Twig_Error_Runtime(sprintf('trim type must be "left", "right" or "both". Got %s.', $type));
     }          
 }
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -856,28 +856,27 @@ function twig_in_filter($value, $compare)
  * Returns a trimmed string.
  * 
  * @param string $string
- * @param string $characterMask
+ * @param string $character_mask
  * @param string $mode
  * @return string
  */
-function twig_trim_filter($string, $characterMask = null, $mode = 'both')
+function twig_trim_filter($string, $character_mask = null, $type = 'both')
 {
-    if (empty($characterMask)) {
-        $characterMask = " \t\n\r\0\x0B";
+    if (is_null($character_mask)) {
+        $character_mask = " \t\n\r\0\x0B";
     }
-    switch ($mode) {
+    switch ($type) {
         case 'left':
-            $trimmed = ltrim($string, $characterMask);
+            return ltrim($string, $character_mask);
             break;
         case 'right':
-            $trimmed = rtrim($string, $characterMask);
+            return rtrim($string, $character_mask);
             break;
         case 'both':
         default:
-            $trimmed = trim($string, $characterMask);
+            return trim($string, $character_mask);
             break;
-    }
-    return $trimmed;            
+    }          
 }
 
 /**

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -874,7 +874,7 @@ function twig_trim_filter($string, $characterMask = null, $side = 'both')
             return rtrim($string, $characterMask);
         default:
             if (!is_string($side) || !in_array($side, ['both', 'left', 'right'])) {
-                throw new Twig_Error_Runtime('Trimming type must be "left", "right" or "both".');
+                throw new Twig_Error_Runtime('Trimming side must be "left", "right" or "both".');
             }
     }          
 }

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -860,11 +860,8 @@ function twig_in_filter($value, $compare)
  * @param string $mode
  * @return string
  */
-function twig_trim_filter($string, $characterMask = null, $mode = 'both')
+function twig_trim_filter($string, $characterMask = " \t\n\r\0\x0B", $mode = 'both')
 {
-    if (empty($characterMask)) {
-        $characterMask = " \t\n\r\0\x0B";
-    }
     switch ($mode) {
         case 'left':
             $trimmed = ltrim($string, $characterMask);

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -857,11 +857,11 @@ function twig_in_filter($value, $compare)
  * 
  * @param string $string
  * @param string $characterMask
- * @param string $mode
+ * @param string $type
  *
  * @return string
  *
- * @throws Twig_Error_Runtime When an type is not a string or when an invalid trimming type is used (not 'left', 'right' or 'both')
+ * @throws Twig_Error_Runtime When an invalid trimming type is used (not a string or not 'left', 'right' or 'both')
  */
 function twig_trim_filter($string, $characterMask = null, $type = 'both')
 {

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -861,20 +861,14 @@ function twig_in_filter($value, $compare)
  *
  * @return string
  *
- * @throws Twig_Error_Runtime When an type is not a string.
- * @throws Twig_Error_Runtime When an invalid type is used (not 'left', 'right' or 'both')
+ * @throws Twig_Error_Runtime When an type is not a string or when an invalid trimming type is used (not 'left', 'right' or 'both')
  */
 function twig_trim_filter($string, $characterMask = null, $type = 'both')
 {
-    if (!is_string($type)) {
-        throw new Twig_Error_Runtime(sprintf('Trimming type must be a string but got %s.', gettype($type)));
-    }
-    if (!in_array($type, ['both', 'left', 'right'])) {
-        throw new Twig_Error_Runtime(sprintf('Trimming type must be "left", "right" or "both" but got %s.', $type));
-    }
     if (null === $characterMask) {
         $characterMask = " \t\n\r\0\x0B";
     }
+
     switch ($type) {
         case 'both':
             return trim($string, $characterMask);
@@ -882,6 +876,14 @@ function twig_trim_filter($string, $characterMask = null, $type = 'both')
             return ltrim($string, $characterMask);
         case 'right':
             return rtrim($string, $characterMask);
+        default:
+            if (!is_string($type)) {
+                throw new Twig_Error_Runtime(sprintf('Trimming type must be a string but got %s.', gettype($type)));
+            }
+
+            if (!in_array($type, ['both', 'left', 'right'])) {
+                throw new Twig_Error_Runtime(sprintf('Trimming type must be "left", "right" or "both" but got %s.', $type));
+            }
     }          
 }
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -868,14 +868,11 @@ function twig_trim_filter($string, $character_mask = null, $type = 'both')
     switch ($type) {
         case 'left':
             return ltrim($string, $character_mask);
-            break;
         case 'right':
             return rtrim($string, $character_mask);
-            break;
         case 'both':
         default:
             return trim($string, $character_mask);
-            break;
     }          
 }
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -856,8 +856,9 @@ function twig_in_filter($value, $compare)
  * Returns a trimmed string.
  * 
  * @param string $string
- * @param string $character_mask
+ * @param string $characterMask
  * @param string $mode
+ *
  * @return string
  */
 function twig_trim_filter($string, $characterMask = null, $type = 'both')

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -155,7 +155,7 @@ final class Twig_Extension_Core extends Twig_Extension
             new Twig_Filter('upper', 'twig_upper_filter', array('needs_environment' => true)),
             new Twig_Filter('lower', 'twig_lower_filter', array('needs_environment' => true)),
             new Twig_Filter('striptags', 'strip_tags'),
-            new Twig_Filter('trim', 'trim'),
+            new Twig_Filter('trim', 'twig_trim_filter'),
             new Twig_Filter('nl2br', 'nl2br', array('pre_escape' => 'html', 'is_safe' => array('html'))),
 
             // array helpers
@@ -850,6 +850,34 @@ function twig_in_filter($value, $compare)
     }
 
     return false;
+}
+
+/** 
+ * Returns a trimmed string.
+ * 
+ * @param string $string
+ * @param string $characterMask
+ * @param string $mode
+ * @return string
+ */
+function twig_trim_filter($string, $characterMask = null, $mode = 'both')
+{
+    if (empty($characterMask)) {
+        $characterMask = " \t\n\r\0\x0B";
+    }
+    switch ($mode) {
+        case 'left':
+            $trimmed = ltrim($string, $characterMask);
+            break;
+        case 'right':
+            $trimmed = rtrim($string, $characterMask);
+            break;
+        case 'both':
+        default:
+            $trimmed = trim($string, $characterMask);
+            break;
+    }
+    return $trimmed;            
 }
 
 /**

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -854,10 +854,6 @@ function twig_in_filter($value, $compare)
 
 /** 
  * Returns a trimmed string.
- * 
- * @param string $string
- * @param string $characterMask
- * @param string $type
  *
  * @return string
  *
@@ -877,12 +873,8 @@ function twig_trim_filter($string, $characterMask = null, $type = 'both')
         case 'right':
             return rtrim($string, $characterMask);
         default:
-            if (!is_string($type)) {
-                throw new Twig_Error_Runtime(sprintf('Trimming type must be a string but got %s.', gettype($type)));
-            }
-
-            if (!in_array($type, ['both', 'left', 'right'])) {
-                throw new Twig_Error_Runtime(sprintf('Trimming type must be "left", "right" or "both" but got %s.', $type));
+            if (!is_string($type) || !in_array($type, ['both', 'left', 'right'])) {
+                throw new Twig_Error_Runtime('Trimming type must be "left", "right" or "both".');
             }
     }          
 }

--- a/test/Twig/Tests/Fixtures/filters/trim.test
+++ b/test/Twig/Tests/Fixtures/filters/trim.test
@@ -4,9 +4,15 @@
 {{ "  I like Twig.  "|trim }}
 {{ text|trim }}
 {{ "  foo/"|trim("/") }}
+{{ "  I like Twig.  "|trim("", "left") }}
+{{ "  I like Twig.  "|trim("", "right") }}
+{{ "/  foo/"|trim("/", "left" ) }}
 --DATA--
 return array('text' => "  If you have some <strong>HTML</strong> it will be escaped.  ")
 --EXPECT--
 I like Twig.
 If you have some &lt;strong&gt;HTML&lt;/strong&gt; it will be escaped.
   foo
+I like Twig.  
+  I like Twig.
+  foo/

--- a/test/Twig/Tests/Fixtures/filters/trim.test
+++ b/test/Twig/Tests/Fixtures/filters/trim.test
@@ -4,11 +4,11 @@
 {{ "  I like Twig.  "|trim }}
 {{ text|trim }}
 {{ "  foo/"|trim("/") }}
-{{ "  I like Twig.  "|trim(type="left") }}
-{{ "  I like Twig.  "|trim(type="right") }}
+{{ "  I like Twig.  "|trim(side="left") }}
+{{ "  I like Twig.  "|trim(side="right") }}
 {{ "  I like Twig.  "|trim(null, "right") }}
 {{ "/  foo/"|trim("/", "left") }}
-{{ "/  foo/"|trim(character_mask="/", type="left") }}
+{{ "/  foo/"|trim(character_mask="/", side="left") }}
 {{ "  do nothing.  "|trim("", "right") }}
 --DATA--
 return array('text' => "  If you have some <strong>HTML</strong> it will be escaped.  ")

--- a/test/Twig/Tests/Fixtures/filters/trim.test
+++ b/test/Twig/Tests/Fixtures/filters/trim.test
@@ -4,9 +4,12 @@
 {{ "  I like Twig.  "|trim }}
 {{ text|trim }}
 {{ "  foo/"|trim("/") }}
-{{ "  I like Twig.  "|trim("", "left") }}
-{{ "  I like Twig.  "|trim("", "right") }}
-{{ "/  foo/"|trim("/", "left" ) }}
+{{ "  I like Twig.  "|trim(type="left") }}
+{{ "  I like Twig.  "|trim(type="right") }}
+{{ "  I like Twig.  "|trim(null, "right") }}
+{{ "/  foo/"|trim("/", "left") }}
+{{ "/  foo/"|trim(character_mask="/", type="left") }}
+{{ "  do nothing.  "|trim("", "right") }}
 --DATA--
 return array('text' => "  If you have some <strong>HTML</strong> it will be escaped.  ")
 --EXPECT--
@@ -15,4 +18,7 @@ If you have some &lt;strong&gt;HTML&lt;/strong&gt; it will be escaped.
   foo
 I like Twig.  
   I like Twig.
+  I like Twig.
   foo/
+  foo/
+  do nothing.  


### PR DESCRIPTION
It was said in this thread that there was a preference of adding parameters to the trim filter in order to implement this.

So this feature works like:

trim(character_mask, mode), where mode is either "both", "left" or "right". It is by default "both".

This is my first pull request of this project, so I apologise in advance if something is wrong.