### PR TITLE
Add error message when calling parent() in a block that doesn't exist

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 2.2.1 (2017-XX-XX)
 
- * n/a
+ * added error message when calling `parent()` in a block that doesn't exist in the parent template
 
 * 2.2.0 (2017-02-26)
 

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -204,12 +204,10 @@ abstract class Twig_Template
             }
         } elseif (false !== $parent = $this->getParent($context)) {
             $parent->displayBlock($name, $context, array_merge($this->blocks, $blocks), false);
+        } elseif (isset($blocks[$name])) {
+            throw new Twig_Error_Runtime(sprintf('Block "%s" should not call parent() in %s as the block does not exist in the parent template %s.', $name, $blocks[$name][0]->getTemplateName(), $this->getTemplateName()), -1, $blocks[$name][0]->getTemplateName());
         } else {
-            if (isset($blocks[$name])) {
-                throw new Twig_Error_Runtime(sprintf('Block "%s" should not call parent() in %s as the block does not exist in the parent template %s.', $name, $blocks[$name][0]->getTemplateName(), $this->getTemplateName()), -1, $blocks[$name][0]->getTemplateName());
-            } else {
-                throw new Twig_Error_Runtime(sprintf('Block "%s" on template "%s" does not exist.', $name, $this->getTemplateName()), -1, $this->getTemplateName());
-            }
+            throw new Twig_Error_Runtime(sprintf('Block "%s" on template "%s" does not exist.', $name, $this->getTemplateName()), -1, $this->getTemplateName());
         }
     }
 

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -205,7 +205,7 @@ abstract class Twig_Template
         } elseif (false !== $parent = $this->getParent($context)) {
             $parent->displayBlock($name, $context, array_merge($this->blocks, $blocks), false);
         } elseif (isset($blocks[$name])) {
-            throw new Twig_Error_Runtime(sprintf('Block "%s" should not call parent() in %s as the block does not exist in the parent template %s.', $name, $blocks[$name][0]->getTemplateName(), $this->getTemplateName()), -1, $blocks[$name][0]->getTemplateName());
+            throw new Twig_Error_Runtime(sprintf('Block "%s" should not call parent() in "%s" as the block does not exist in the parent template "%s".', $name, $blocks[$name][0]->getTemplateName(), $this->getTemplateName()), -1, $blocks[$name][0]->getTemplateName());
         } else {
             throw new Twig_Error_Runtime(sprintf('Block "%s" on template "%s" does not exist.', $name, $this->getTemplateName()), -1, $this->getTemplateName());
         }

--- a/lib/Twig/Template.php
+++ b/lib/Twig/Template.php
@@ -205,7 +205,11 @@ abstract class Twig_Template
         } elseif (false !== $parent = $this->getParent($context)) {
             $parent->displayBlock($name, $context, array_merge($this->blocks, $blocks), false);
         } else {
-            throw new Twig_Error_Runtime(sprintf('Block "%s" on template "%s" does not exist.', $name, $this->getTemplateName()), -1, $this->getTemplateName());
+            if (isset($blocks[$name])) {
+                throw new Twig_Error_Runtime(sprintf('Block "%s" should not call parent() in %s as the block does not exist in the parent template %s.', $name, $blocks[$name][0]->getTemplateName(), $this->getTemplateName()), -1, $blocks[$name][0]->getTemplateName());
+            } else {
+                throw new Twig_Error_Runtime(sprintf('Block "%s" on template "%s" does not exist.', $name, $this->getTemplateName()), -1, $this->getTemplateName());
+            }
         }
     }
 

--- a/test/Twig/Tests/Fixtures/functions/block_without_parent.test
+++ b/test/Twig/Tests/Fixtures/functions/block_without_parent.test
@@ -1,0 +1,11 @@
+--TEST--
+"block" calling parent() with no definition in parent template
+--TEMPLATE--
+{% extends "parent.twig" %}
+{% block label %}{{ parent() }}{% endblock %}
+--TEMPLATE(parent.twig)--
+{{ block('label') }}
+--DATA--
+return array()
+--EXCEPTION--
+Twig_Error_Runtime: Block "label" should not call parent() in "index.twig" as the block does not exist in the parent template "parent.twig" in "index.twig" at line 3.

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -131,6 +131,17 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
         $template->displayBlock('unknown', array());
     }
 
+    /**
+     * @expectedException Twig_Error_Runtime
+     * @expectedExceptionMessage Block "foo" should not call parent() in index.twig as the block does not exist in the parent template parent.twig
+     */
+    public function testDisplayBlockWithUndefinedParentBlock()
+    {
+        $twig = new Twig_Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock());
+        $template = new Twig_TemplateTest($twig, 'parent.twig');
+        $template->displayBlock('foo', array(), array('foo' => array(new Twig_TemplateTest($twig, 'index.twig'), 'block_foo')), false);
+    }
+
     public function testGetAttributeOnArrayWithConfusableKey()
     {
         $twig = new Twig_Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock());

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -133,7 +133,7 @@ class Twig_Tests_TemplateTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Twig_Error_Runtime
-     * @expectedExceptionMessage Block "foo" should not call parent() in index.twig as the block does not exist in the parent template parent.twig
+     * @expectedExceptionMessage Block "foo" should not call parent() in "index.twig" as the block does not exist in the parent template "parent.twig"
      */
     public function testDisplayBlockWithUndefinedParentBlock()
     {


### PR DESCRIPTION
Related: #2309

When calling `parent()` in a block that isn't defined in the parent template, you get an error message that states `Block "%s" on template "%s" does not exist`, even if the block is wrapped in an `is defined` check, which is confusing and makes debugging hard.

This fix adds a better error message indicating that you should not call `parent()` when the parent block is not defined.

Before:
![screen shot 2017-03-08 at 08 08 38](https://cloud.githubusercontent.com/assets/144858/23693410/0e476242-03dd-11e7-9621-4442bdc6bf05.png)

After:
![screen shot 2017-03-08 at 08 56 18](https://cloud.githubusercontent.com/assets/144858/23693424/234d9c2e-03dd-11e7-8d07-4e277d80f7e4.png)
