### PR TITLE
Compiler - setlocale must be a string

### DIFF
--- a/lib/Twig/Compiler.php
+++ b/lib/Twig/Compiler.php
@@ -169,7 +169,7 @@ class Twig_Compiler implements Twig_CompilerInterface
     public function repr($value)
     {
         if (is_int($value) || is_float($value)) {
-            if (false !== $locale = setlocale(LC_NUMERIC, 0)) {
+            if (false !== $locale = setlocale(LC_NUMERIC, '0')) {
                 setlocale(LC_NUMERIC, 'C');
             }
 


### PR DESCRIPTION
Following the docs of [setlocale](http://php.net/manual/en/function.setlocale.php) the second argument must be a `string`, `null` or an `array`. Special note about "0" is there as well.

closes https://github.com/twigphp/Twig/issues/2416