### PR TITLE
Allow "length" filter to work on objects with a __toString method that are not \Countable

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1139,7 +1139,15 @@ function twig_convert_encoding($string, $to, $from)
  */
 function twig_length_filter(Twig_Environment $env, $thing)
 {
-    return is_scalar($thing) ? mb_strlen($thing, $env->getCharset()) : count($thing);
+    if (is_scalar($thing)) {
+        return mb_strlen($thing, $env->getCharset());
+    }
+    
+    if (is_object($thing) && !($thing instanceof \Countable) && is_callable([$thing, '__toString'])) {
+        return mb_strlen((string) $thing, $env->getCharset());
+    }
+    
+    return count($thing);
 }
 
 /**

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1143,7 +1143,7 @@ function twig_length_filter(Twig_Environment $env, $thing)
         return mb_strlen($thing, $env->getCharset());
     }
     
-    if (is_object($thing) && !($thing instanceof \Countable) && is_callable(array($thing, '__toString'))) {
+    if (is_object($thing) && !$thing instanceof \Countable && is_callable(array($thing, '__toString'))) {
         return mb_strlen((string) $thing, $env->getCharset());
     }
     

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1143,7 +1143,7 @@ function twig_length_filter(Twig_Environment $env, $thing)
         return mb_strlen($thing, $env->getCharset());
     }
     
-    if (is_object($thing) && !($thing instanceof \Countable) && is_callable([$thing, '__toString'])) {
+    if (is_object($thing) && !($thing instanceof \Countable) && is_callable(array($thing, '__toString'))) {
         return mb_strlen((string) $thing, $env->getCharset());
     }
     


### PR DESCRIPTION
**The Twig 1.x version of this PR is at #2420, feel free to close either one.**

Use case: When you have variables in your views that are actually objects but implement `__toString`, they feel like strings: For example, `{{ something }}` will make use of that to-string-conversion.

What does *not* work is `{{ something | length }}`, because that will only have a meaningful return value for objects implementing `\Countable`. This interface, however, may have a totally different semantic/purpose for the object in question.

For template designers, this may be surprising if they don't actually care about the object-or-string difference, they just "use" the variable.

This change tries to address this as it changes the behavior for  such objects that have a `__toString` method and are *not* `\Countable`.

*Yes*, it's a BC break in an edge case: Objects that implement a `__toString` but not `\Countable` would previously yield `1` for `{{ object | length }}`, and now would return the length of the string returned by `__toString`.