### PR TITLE
Consider __toString() implementations in "empty" test [Twig 1.x]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* 1.33.0 (2017-XX-XX)
+
+ * "empty" test will now consider the return value of the __toString() method for objects implement __toString() but not \Countable
+
 * 1.32.1 (2017-XX-XX)
 
  * n/a

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 1.33.0 (2017-XX-XX)
 
- * "empty" test will now consider the return value of the __toString() method for objects implement __toString() but not \Countable
+ * "empty" test will now consider the return value of the __toString() method for objects implementing __toString() but not \Countable
 
 * 1.32.1 (2017-XX-XX)
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1400,8 +1400,16 @@ function twig_ensure_traversable($seq)
  */
 function twig_test_empty($value)
 {
-    if ($value instanceof Countable) {
-        return 0 == count($value);
+    if (is_object($value)) {
+
+        if ($value instanceof Countable) {
+            return 0 == count($value);
+        }
+
+        if (is_callable(array($value, '__toString'))) {
+            return '' === (string) $value;
+        }
+
     }
 
     return '' === $value || false === $value || null === $value || array() === $value;

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1401,7 +1401,6 @@ function twig_ensure_traversable($seq)
 function twig_test_empty($value)
 {
     if (is_object($value)) {
-
         if ($value instanceof Countable) {
             return 0 == count($value);
         }
@@ -1409,7 +1408,6 @@ function twig_test_empty($value)
         if (is_callable(array($value, '__toString'))) {
             return '' === (string) $value;
         }
-
     }
 
     return '' === $value || false === $value || null === $value || array() === $value;

--- a/test/Twig/Tests/Fixtures/tests/empty.test
+++ b/test/Twig/Tests/Fixtures/tests/empty.test
@@ -11,6 +11,9 @@
 {{ countable_not_empty is empty ? 'ok' : 'ko' }}
 {{ markup_empty is empty ? 'ok' : 'ko' }}
 {{ markup_not_empty is empty ? 'ok' : 'ko' }}
+{{ string_convertible_empty is empty ? 'ok' : 'ko' }}
+{{ string_convertible_not_empty is empty ? 'k' : 'ok' }}
+
 --DATA--
 
 class CountableStub implements Countable
@@ -26,10 +29,32 @@ class CountableStub implements Countable
     {
         return count($this->items);
     }
+
+    public function __toString()
+    {
+        return 'this method does not matter';
+    }
 }
+
+class ToStringConvertible
+{
+    private $string;
+
+    public function __construct($string)
+    {
+        $this->string = $string;
+    }
+
+    public function __toString()
+    {
+        return $this->string;
+    }
+}
+
 return array(
     'foo' => '', 'bar' => null, 'foobar' => false, 'array' => array(), 'zero' => 0, 'string' => '0',
     'countable_empty' => new CountableStub(array()), 'countable_not_empty' => new CountableStub(array(1, 2)),
+    'string_convertible_empty' => new ToStringConvertible(''), 'string_convertible_not_empty' => new ToStringConvertible('foo'),
     'markup_empty' => new Twig_Markup('', 'UTF-8'), 'markup_not_empty' => new Twig_Markup('test', 'UTF-8'),
 );
 --EXPECT--
@@ -43,3 +68,5 @@ ok
 ko
 ok
 ko
+ok
+ok


### PR DESCRIPTION
This follows up on #2420:

When you have variables in your views that are actually objects but implement `__toString`, they feel like strings: For example, `{{ something }}` will make use of that to-string-conversion.

What does *not* work is `{% if something is empty %}`, because

> empty checks if a variable is an empty string, an empty array, an empty hash, exactly false, or exactly null  `[http://twig.sensiolabs.org/doc/2.x/tests/empty.html]`

... and obviously `something !== null` in this case.

For template designers, this may be surprising if they don't actually care about the object-or-string difference, they just "use" the variable.

This PR changes the test to consider the return value of the `__toString` method when the value under test is an object, *not* `\Countable` *and* implements `__toString`.

*Yes*, it's a BC break in the edge case of testing (defined) variables that are objects implementing  `__toString` but return the empty string `''`.