### PR TITLE
Fixed JS escaping for unicode characters with higher code points

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * 2.2.1 (2017-XX-XX)
 
  * added error message when calling `parent()` in a block that doesn't exist in the parent template
+ * fixed JS escaping for unicode characters with higher code points
 
 * 2.2.0 (2017-02-26)
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -975,13 +975,13 @@ function twig_escape_filter(Twig_Environment $env, $string, $strategy = 'html', 
 
                 // \uHHHH
                 $char = twig_convert_encoding($char, 'UTF-16BE', 'UTF-8');
+                $char = strtoupper(bin2hex($char));
 
-                return implode('', array_map(
-                    function ($surrogate) {
-                        return '\\u'.strtoupper(substr('0000'.$surrogate, -4));
-                    },
-                    str_split(bin2hex($char), 4)
-                ));
+                if (4 >= strlen($char)) {
+                    return sprintf('\u%04s', $char);
+                }
+
+                return sprintf('\u%04s\u%04s', substr($char, 0, -4), substr($char, -4));
             }, $string);
 
             if ('UTF-8' !== $charset) {

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -976,7 +976,12 @@ function twig_escape_filter(Twig_Environment $env, $string, $strategy = 'html', 
                 // \uHHHH
                 $char = twig_convert_encoding($char, 'UTF-16BE', 'UTF-8');
 
-                return '\\u'.strtoupper(substr('0000'.bin2hex($char), -4));
+                return implode('', array_map(
+                    function ($surrogate) {
+                        return '\\u'.strtoupper(substr('0000'.$surrogate, -4));
+                    },
+                    str_split(bin2hex($char), 4)
+                ));
             }, $string);
 
             if ('UTF-8' !== $charset) {

--- a/test/Twig/Tests/Fixtures/filters/escape_javascript.test
+++ b/test/Twig/Tests/Fixtures/filters/escape_javascript.test
@@ -1,8 +1,8 @@
 --TEST--
 "escape" filter
 --TEMPLATE--
-{{ "𝌆"|e('js') }}
+{{ "é ♜ 𝌆"|e('js') }}
 --DATA--
 return array()
 --EXPECT--
-\uD834\uDF06
+\u00E9\x20\u265C\x20\uD834\uDF06

--- a/test/Twig/Tests/Fixtures/filters/escape_javascript.test
+++ b/test/Twig/Tests/Fixtures/filters/escape_javascript.test
@@ -1,0 +1,8 @@
+--TEST--
+"escape" filter
+--TEMPLATE--
+{{ "𝌆"|e('js') }}
+--DATA--
+return array()
+--EXPECT--
+\uD834\uDF06


### PR DESCRIPTION
Unicode characters with higher code points were being escaped incorrectly. When these characters are escaped, they should maintain their surrogate halves. Previously, Twig was dropping the first surrogate half. 

https://mathiasbynens.be/notes/javascript-escapes#unicode-code-point
> The tetragram for centre symbol (𝌆) has code point U+1D306, so you could write it as \u{1D306}. For comparison, if you were to use simple Unicode escapes to represent this symbol, you’d have to write out the surrogate halves separately: '\uD834\uDF06'.