### PR TITLE
Autoescape test addition; collision fix in Array Loader.

### DIFF
--- a/lib/Twig/Loader/Array.php
+++ b/lib/Twig/Loader/Array.php
@@ -80,7 +80,7 @@ class Twig_Loader_Array implements Twig_LoaderInterface, Twig_ExistsLoaderInterf
             throw new Twig_Error_Loader(sprintf('Template "%s" is not defined.', $name));
         }
 
-        return $this->templates[$name];
+        return $name . $this->templates[$name];
     }
 
     public function isFresh($name, $time)

--- a/lib/Twig/Loader/Array.php
+++ b/lib/Twig/Loader/Array.php
@@ -80,7 +80,7 @@ class Twig_Loader_Array implements Twig_LoaderInterface, Twig_ExistsLoaderInterf
             throw new Twig_Error_Loader(sprintf('Template "%s" is not defined.', $name));
         }
 
-        return $name . $this->templates[$name];
+        return $name.$this->templates[$name];
     }
 
     public function isFresh($name, $time)

--- a/lib/Twig/Loader/Array.php
+++ b/lib/Twig/Loader/Array.php
@@ -80,7 +80,7 @@ class Twig_Loader_Array implements Twig_LoaderInterface, Twig_ExistsLoaderInterf
             throw new Twig_Error_Loader(sprintf('Template "%s" is not defined.', $name));
         }
 
-        return $name.$this->templates[$name];
+        return $name.':'.$this->templates[$name];
     }
 
     public function isFresh($name, $time)

--- a/lib/Twig/Profiler/Dumper/Blackfire.php
+++ b/lib/Twig/Profiler/Dumper/Blackfire.php
@@ -22,7 +22,7 @@ class Twig_Profiler_Dumper_Blackfire
         $this->dumpProfile('main()', $profile, $data);
         $this->dumpChildren('main()', $profile, $data);
 
-        $start = microtime(true);
+        $start = sprintf('%f', microtime(true));
         $str = <<<EOF
 file-format: BlackfireProbe
 cost-dimensions: wt mu pmu

--- a/test/Twig/Tests/Fixtures/autoescape/name.test
+++ b/test/Twig/Tests/Fixtures/autoescape/name.test
@@ -2,8 +2,11 @@
 "name" autoescape strategy
 --TEMPLATE--
 {{ br -}}
+{{ include('index.js.twig') -}}
 {{ include('index.html.twig') -}}
 {{ include('index.txt.twig') -}}
+--TEMPLATE(index.js.twig)--
+{{ br -}}
 --TEMPLATE(index.html.twig)--
 {{ br -}}
 --TEMPLATE(index.txt.twig)--
@@ -14,5 +17,6 @@ return array('br' => '<br />')
 return array('autoescape' => 'name')
 --EXPECT--
 &lt;br /&gt;
+\x3Cbr\x20\x2F\x3E
 &lt;br /&gt;
 <br />

--- a/test/Twig/Tests/Loader/ArrayTest.php
+++ b/test/Twig/Tests/Loader/ArrayTest.php
@@ -46,7 +46,18 @@ class Twig_Tests_Loader_ArrayTest extends PHPUnit_Framework_TestCase
     {
         $loader = new Twig_Loader_Array(array('foo' => 'bar'));
 
-        $this->assertEquals('bar', $loader->getCacheKey('foo'));
+        $this->assertEquals('foobar', $loader->getCacheKey('foo'));
+    }
+
+    public function testGetCacheKeyWhenTemplateHasDuplicateContent()
+    {
+        $loader = new Twig_Loader_Array(array(
+            'foo' => 'bar',
+            'baz' => 'bar'
+        ));
+
+        $this->assertEquals('foobar', $loader->getCacheKey('foo'));
+        $this->assertEquals('bazbar', $loader->getCacheKey('baz'));
     }
 
     /**

--- a/test/Twig/Tests/Loader/ArrayTest.php
+++ b/test/Twig/Tests/Loader/ArrayTest.php
@@ -46,7 +46,7 @@ class Twig_Tests_Loader_ArrayTest extends PHPUnit_Framework_TestCase
     {
         $loader = new Twig_Loader_Array(array('foo' => 'bar'));
 
-        $this->assertEquals('foobar', $loader->getCacheKey('foo'));
+        $this->assertEquals('foo:bar', $loader->getCacheKey('foo'));
     }
 
     public function testGetCacheKeyWhenTemplateHasDuplicateContent()
@@ -56,8 +56,19 @@ class Twig_Tests_Loader_ArrayTest extends PHPUnit_Framework_TestCase
             'baz' => 'bar',
         ));
 
-        $this->assertEquals('foobar', $loader->getCacheKey('foo'));
-        $this->assertEquals('bazbar', $loader->getCacheKey('baz'));
+        $this->assertEquals('foo:bar', $loader->getCacheKey('foo'));
+        $this->assertEquals('baz:bar', $loader->getCacheKey('baz'));
+    }
+
+    public function testGetCacheKeyIsProtectedFromEdgeCollisions()
+    {
+        $loader = new Twig_Loader_Array(array(
+            'foo__' => 'bar',
+            'foo' => '__bar',
+        ));
+
+        $this->assertEquals('foo__:bar', $loader->getCacheKey('foo__'));
+        $this->assertEquals('foo:__bar', $loader->getCacheKey('foo'));
     }
 
     /**
@@ -102,7 +113,7 @@ class Twig_Tests_Loader_ArrayTest extends PHPUnit_Framework_TestCase
         $loader->getCacheKey($name);
         $loader->getSourceContext($name);
         $loader->isFresh($name, time());
-        $loader->setTemplate($name, 'foobar');
+        $loader->setTemplate($name, 'foo:bar');
 
         // add a dummy assertion here to satisfy PHPUnit, the only thing we want to test is that the code above
         // can be executed without crashing PHP

--- a/test/Twig/Tests/Loader/ArrayTest.php
+++ b/test/Twig/Tests/Loader/ArrayTest.php
@@ -53,7 +53,7 @@ class Twig_Tests_Loader_ArrayTest extends PHPUnit_Framework_TestCase
     {
         $loader = new Twig_Loader_Array(array(
             'foo' => 'bar',
-            'baz' => 'bar'
+            'baz' => 'bar',
         ));
 
         $this->assertEquals('foobar', $loader->getCacheKey('foo'));

--- a/test/Twig/Tests/Loader/ChainTest.php
+++ b/test/Twig/Tests/Loader/ChainTest.php
@@ -74,8 +74,8 @@ class Twig_Tests_Loader_ChainTest extends PHPUnit_Framework_TestCase
             new Twig_Loader_Array(array('foo' => 'foobar', 'bar' => 'foo')),
         ));
 
-        $this->assertEquals('bar', $loader->getCacheKey('foo'));
-        $this->assertEquals('foo', $loader->getCacheKey('bar'));
+        $this->assertEquals('foobar', $loader->getCacheKey('foo'));
+        $this->assertEquals('barfoo', $loader->getCacheKey('bar'));
     }
 
     /**

--- a/test/Twig/Tests/Loader/ChainTest.php
+++ b/test/Twig/Tests/Loader/ChainTest.php
@@ -74,8 +74,8 @@ class Twig_Tests_Loader_ChainTest extends PHPUnit_Framework_TestCase
             new Twig_Loader_Array(array('foo' => 'foobar', 'bar' => 'foo')),
         ));
 
-        $this->assertEquals('foobar', $loader->getCacheKey('foo'));
-        $this->assertEquals('barfoo', $loader->getCacheKey('bar'));
+        $this->assertEquals('foo:bar', $loader->getCacheKey('foo'));
+        $this->assertEquals('bar:foo', $loader->getCacheKey('bar'));
     }
 
     /**


### PR DESCRIPTION
This PR makes two changes. It was created while testing a third issue that was discovered to be fixed in the latest version.

## Added JS to Autoescape: name test

This adds "index.js.html" to the autoescape:name test, proving the functionality of the JS escape system and the name guessing strategy.

## Fixed collision in Array Loader

While trying to run the above test, it was discovered that the Array Loader uses the content of the template file as the "key" for determining which compiled template to load.
As the above test uses identical content for both HTML and JS templates this led to the compiled HTML template always being loaded.

This change prepends the content with the filename, which vaguely follows the same mechanism as the "options" (which are appended after `getCacheKey` is called).

**This change might be a backwards-incompatible change** depending on your interpretation of how `Loader/Array` is intended to be used.
The class itself states:
> This loader should only be used for unit testing.

The assumption is it's OK for this to occur.

Test cases have been updated to take this key change into account, and an additional test has been added to confirm `Loader/Array` specifically has the capability to resolve two files with the same content to different keys.