### PR TITLE
Fix twig_test_empty and twig_length_filter to not trigger autoloading

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1148,7 +1148,7 @@ function twig_length_filter(Twig_Environment $env, $thing)
         return mb_strlen($thing, $env->getCharset());
     }
 
-    if (method_exists($thing, '__toString') && !$thing instanceof \Countable) {
+    if (is_object($thing) && method_exists($thing, '__toString') && !$thing instanceof \Countable) {
         return mb_strlen((string) $thing, $env->getCharset());
     }
 
@@ -1241,7 +1241,7 @@ function twig_test_empty($value)
         return 0 == count($value);
     }
 
-    if (method_exists($value, '__toString')) {
+    if (is_object($value) && method_exists($value, '__toString')) {
         return '' === (string) $value;
     }
 


### PR DESCRIPTION
Introduced in #2420, partially fixed in #2433.

cc @mpdude

Also because of this I found another bug in both Symfony and Composer - autoloading fails for an empty string. I'll send pull requests to both shortly.