### PR TITLE
Add ability to set safety for custom escapers

### DIFF
--- a/doc/filters/escape.rst
+++ b/doc/filters/escape.rst
@@ -107,11 +107,6 @@ and the fourth is an array of escapers that are safe for this escaper:
 When called by Twig, the callable receives the Twig environment instance, the
 string to escape, and the charset.
 
-.. note::
-
-    Built-in escapers cannot be overridden mainly they should be considered as
-    the final implementation and also for better performance.
-
 Arguments
 ---------
 

--- a/doc/filters/escape.rst
+++ b/doc/filters/escape.rst
@@ -85,12 +85,24 @@ Custom Escapers
 
 You can define custom escapers by calling the ``setEscaper()`` method on the
 ``core`` extension instance. The first argument is the escaper name (to be
-used in the ``escape`` call) and the second one must be a valid PHP callable:
+used in the ``escape`` call), the second one must be a valid PHP callable,
+the third one is an array of escapers this escaper is safe for,
+and the fourth is an array of escapers that are safe for this escaper:
 
 .. code-block:: php
 
     $twig = new Twig_Environment($loader);
-    $twig->getExtension('Twig_Extension_Core')->setEscaper('csv', 'csv_escaper');
+    $core = $twig->getExtension('Twig_Extension_Core');
+
+    // Either:
+    $core->setEscaper('url_query', 'esc_url_query');
+    $core->setEscaper('url_query_key', 'esc_url_query_key', array('url_query'));
+    $core->setEscaper('url_query_value', 'esc_url_query_value', array('url_query'));
+
+    // Or:
+    $core->setEscaper('url_query_key', 'esc_url_query_key');
+    $core->setEscaper('url_query_value', 'esc_url_query_value');
+    $core->setEscaper('url_query', 'esc_url_query', array(), array('url_query_key', 'url_query_value'));
 
 When called by Twig, the callable receives the Twig environment instance, the
 string to escape, and the charset.
@@ -105,5 +117,7 @@ Arguments
 
 * ``strategy``: The escaping strategy
 * ``charset``:  The string charset
+* ``is_safe_for``: Array of escapers that this escaper is safe for
+* ``is_safe``: Array of escapers that safe for escaper
 
 .. _`htmlspecialchars`: http://php.net/htmlspecialchars

--- a/doc/filters/escape.rst
+++ b/doc/filters/escape.rst
@@ -92,17 +92,17 @@ and the fourth is an array of escapers that are safe for this escaper:
 .. code-block:: php
 
     $twig = new Twig_Environment($loader);
-    $core = $twig->getExtension('Twig_Extension_Core');
+    $escaper = $twig->getExtension('Twig_Extension_Escaper');
 
     // Either:
-    $core->setEscaper('url_query', 'esc_url_query');
-    $core->setEscaper('url_query_key', 'esc_url_query_key', array('url_query'));
-    $core->setEscaper('url_query_value', 'esc_url_query_value', array('url_query'));
+    $escaper->setEscaper('url_query', 'esc_url_query');
+    $escaper->setEscaper('url_query_key', 'esc_url_query_key', array('url_query'));
+    $escaper->setEscaper('url_query_value', 'esc_url_query_value', array('url_query'));
 
     // Or:
-    $core->setEscaper('url_query_key', 'esc_url_query_key');
-    $core->setEscaper('url_query_value', 'esc_url_query_value');
-    $core->setEscaper('url_query', 'esc_url_query', array(), array('url_query_key', 'url_query_value'));
+    $escaper->setEscaper('url_query_key', 'esc_url_query_key');
+    $escaper->setEscaper('url_query_value', 'esc_url_query_value');
+    $escaper->setEscaper('url_query', 'esc_url_query', array(), array('url_query_key', 'url_query_value'));
 
 When called by Twig, the callable receives the Twig environment instance, the
 string to escape, and the charset.

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -42,6 +42,7 @@ class Twig_Environment
     private $runtimeLoaders = array();
     private $runtimes = array();
     private $optionsHash;
+    private $optionsHashNeedsUpdate = true;
 
     /**
      * Constructor.
@@ -126,7 +127,7 @@ class Twig_Environment
     public function setBaseTemplateClass($class)
     {
         $this->baseTemplateClass = $class;
-        $this->updateOptionsHash();
+        $this->flagOptionsHashForUpdate();
     }
 
     /**
@@ -135,7 +136,7 @@ class Twig_Environment
     public function enableDebug()
     {
         $this->debug = true;
-        $this->updateOptionsHash();
+        $this->flagOptionsHashForUpdate();
     }
 
     /**
@@ -144,7 +145,7 @@ class Twig_Environment
     public function disableDebug()
     {
         $this->debug = false;
-        $this->updateOptionsHash();
+        $this->flagOptionsHashForUpdate();
     }
 
     /**
@@ -189,7 +190,7 @@ class Twig_Environment
     public function enableStrictVariables()
     {
         $this->strictVariables = true;
-        $this->updateOptionsHash();
+        $this->flagOptionsHashForUpdate();
     }
 
     /**
@@ -198,7 +199,7 @@ class Twig_Environment
     public function disableStrictVariables()
     {
         $this->strictVariables = false;
-        $this->updateOptionsHash();
+        $this->flagOptionsHashForUpdate();
     }
 
     /**
@@ -266,7 +267,7 @@ class Twig_Environment
      */
     public function getTemplateClass($name, $index = null)
     {
-        $key = $this->getLoader()->getCacheKey($name).$this->optionsHash;
+        $key = $this->getLoader()->getCacheKey($name).$this->getOptionsHash();
 
         return $this->templateClassPrefix.hash('sha256', $key).(null === $index ? '' : '_'.$index);
     }
@@ -649,7 +650,7 @@ class Twig_Environment
     public function addExtension(Twig_ExtensionInterface $extension)
     {
         $this->extensionSet->addExtension($extension);
-        $this->updateOptionsHash();
+        $this->flagOptionsHashForUpdate();
     }
 
     /**
@@ -931,6 +932,20 @@ class Twig_Environment
         return $this->extensionSet->getBinaryOperators();
     }
 
+    private function getOptionsHash()
+    {
+        if ($this->optionsHashNeedsUpdate) {
+            $this->updateOptionsHash();
+        }
+
+        return $this->optionsHash;
+    }
+
+    public function flagOptionsHashForUpdate()
+    {
+        $this->optionsHashNeedsUpdate = true;
+    }
+
     private function updateOptionsHash()
     {
         $this->optionsHash = implode(':', array(
@@ -942,5 +957,6 @@ class Twig_Environment
             $this->baseTemplateClass,
             (int) $this->strictVariables,
         ));
+        $this->optionsHashNeedsUpdate = false;
     }
 }

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -934,14 +934,19 @@ class Twig_Environment
 
     private function getOptionsHash()
     {
-        if ($this->optionsHashNeedsUpdate) {
+        if ($this->optionsHashNeedsUpdate()) {
             $this->updateOptionsHash();
         }
 
         return $this->optionsHash;
     }
 
-    public function flagOptionsHashForUpdate()
+    private function optionsHashNeedsUpdate()
+    {
+        return $this->optionsHashNeedsUpdate || $this->extensionSet->signatureNeedsUpdate();
+    }
+
+    private function flagOptionsHashForUpdate()
     {
         $this->optionsHashNeedsUpdate = true;
     }

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -104,7 +104,7 @@ class Twig_Environment
         $this->extensionSet = new Twig_ExtensionSet();
 
         $this->addExtension(new Twig_Extension_Core());
-        $this->addExtension(new Twig_Extension_Escaper($options['autoescape']));
+        $this->addExtension(new Twig_Extension_Escaper($options['autoescape'], $this));
         $this->addExtension(new Twig_Extension_Optimizer($options['optimizations']));
     }
 

--- a/lib/Twig/Extension.php
+++ b/lib/Twig/Extension.php
@@ -39,4 +39,9 @@ abstract class Twig_Extension implements Twig_ExtensionInterface
     {
         return array();
     }
+
+    public function getSignature()
+    {
+        return '';
+    }
 }

--- a/lib/Twig/Extension.php
+++ b/lib/Twig/Extension.php
@@ -10,6 +10,9 @@
  */
 abstract class Twig_Extension implements Twig_ExtensionInterface
 {
+    protected $signature = '';
+    private $signatureNeedsUpdate = true;
+
     public function getTokenParsers()
     {
         return array();
@@ -40,8 +43,28 @@ abstract class Twig_Extension implements Twig_ExtensionInterface
         return array();
     }
 
-    public function getSignature()
+    final public function getSignature()
     {
-        return '';
+        if ($this->signatureNeedsUpdate()) {
+            $this->updateSignature();
+        }
+
+        return $this->signature;
+    }
+
+    final public function signatureNeedsUpdate()
+    {
+        return (bool) $this->signatureNeedsUpdate;
+    }
+
+    final protected function flagSignatureForUpdate()
+    {
+        $this->signatureNeedsUpdate = true;
+    }
+
+    protected function updateSignature()
+    {
+        $this->signature = '';
+        $this->signatureNeedsUpdate = false;
     }
 }

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -21,13 +21,6 @@ final class Twig_Extension_Core extends Twig_Extension
         'html_attr' => 'twig_escape_html_attr',
         'url' => 'twig_escape_url',
     );
-    private $escapers_safe = array(
-        'html' => array('html'),
-        'js' => array('js'),
-        'css' => array('css'),
-        'html_attr' => array('html', 'html_attr'),
-        'url' => array('url'),
-    );
 
     /**
      * Defines a new escaper to be used via the escape filter.

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -28,9 +28,9 @@ final class Twig_Extension_Core extends Twig_Extension
      * @param string   $strategy The strategy name that should be used as a strategy in the escape call
      * @param callable $callable A valid PHP callable
      */
-    public function setEscaper($strategy, callable $callable, $ignore_deprecation = false)
+    public function setEscaper($strategy, callable $callable, $ignoreDeprecation = false)
     {
-        if (!$ignore_deprecation) {
+        if (!$ignoreDeprecation) {
             @trigger_error("Twig_Extension_Core::setEscaper() is deprecated. Used Twig_Extension_Escaper::setEscaper() instead", E_USER_DEPRECATED);
         }
 
@@ -42,9 +42,9 @@ final class Twig_Extension_Core extends Twig_Extension
      *
      * @return callable[] An array of escapers
      */
-    public function getEscapers($ignore_deprecation = false)
+    public function getEscapers($ignoreDeprecation = false)
     {
-        if (!$ignore_deprecation) {
+        if (!$ignoreDeprecation) {
             @trigger_error("Twig_Extension_Core::getEscapers() is deprecated. Used Twig_Extension_Escaper::getEscapers() instead", E_USER_DEPRECATED);
         }
 

--- a/lib/Twig/Extension/Escaper.php
+++ b/lib/Twig/Extension/Escaper.php
@@ -11,16 +11,90 @@
 
 final class Twig_Extension_Escaper extends Twig_Extension
 {
+    private $core;
     private $defaultStrategy;
+    private $escapers = array(
+        'html' => 'twig_escape_html',
+        'js' => 'twig_escape_js',
+        'css' => 'twig_escape_css',
+        'html_attr' => 'twig_escape_html_attr',
+        'url' => 'twig_escape_url',
+    );
+    private $escapers_safe = array(
+        'html' => array('html'),
+        'js' => array('js'),
+        'css' => array('css'),
+        'html_attr' => array('html', 'html_attr'),
+        'url' => array('url'),
+    );
 
     /**
      * @param string|false|callable $defaultStrategy An escaping strategy
+     * @param Twig_Environment      $env             Environment this extension is added to. Used temporarily to deprecate Twig_Extension_Core::setEscaper()/getEscapers() instead of removing them without notice.
      *
      * @see setDefaultStrategy()
      */
-    public function __construct($defaultStrategy = 'html')
+    public function __construct($defaultStrategy = 'html', Twig_Environment $env = null)
     {
         $this->setDefaultStrategy($defaultStrategy);
+        $this->core = $env ? $env->getExtension('Twig_Extension_Core') : null;
+    }
+
+    /**
+     * Defines a new escaper to be used via the escape filter.
+     *
+     * @param string   $strategy    The strategy name that should be used as a strategy in the escape call
+     * @param callable $callable    A valid PHP callable
+     * @param array    $is_safe_for Strategies this strategy should be marked safe for. For example, 'html_attr' lists 'html' as being safe since 'html_attr' escapes everything 'html' does, plus more.
+     * @param array    $is_safe     Strategies that should be marked safe for this strategy. Useful for adding strategies compatible to existing strategies. For example, an extension that adds a competing html escaper that escapes fewer characters could list 'html' and 'html_attr' as being safe.
+     */
+    public function setEscaper($strategy, callable $callable, array $is_safe_for = array(), array $is_safe = array())
+    {
+        if (!isset($this->core)) {
+            throw new Twig_Error_Runtime(
+                "Environment must be provided to Twig_Extension_Escaper as the second argument to call this method on this object. If this isn't possible, you can temporarily use Twig_Extension_Core->setEscaper() instead"
+            );
+        }
+
+        if (!empty($is_safe_for)) {
+            $is_safe_for = array();
+        }
+        foreach ($is_safe_for as $safe_strategy) {
+            $this->escapers_safe[$safe_strategy][] = $strategy;
+        }
+
+        if (!empty($is_safe)) {
+            $is_safe = array();
+        }
+        $this->escapers_safe[$strategy] = array_merge(array($strategy), $is_safe);
+
+        return $this->core->setEscaper($strategy, $callable, true);
+    }
+
+    /**
+     * Gets all defined escapers.
+     *
+     * @return callable[] An array of escapers
+     */
+    public function getEscapers()
+    {
+        if (!isset($this->core)) {
+            throw new Twig_Error_Runtime(
+                "Environment must be provided to Twig_Extension_Escaper as the second argument to call this method on this object. If this isn't possible, you can temporarily use Twig_Extension_Core->getEscapers() instead"
+            );
+        }
+
+        return $this->core->getEscapers(true);
+    }
+
+    /**
+     * Gets safe escapers for all escapers.
+     *
+     * @return callable[] An array of escapers safe for each escaper
+     */
+    public function getEscapersSafe()
+    {
+        return $this->escapers_safe;
     }
 
     public function getTokenParsers()
@@ -36,6 +110,8 @@ final class Twig_Extension_Escaper extends Twig_Extension
     public function getFilters()
     {
         return array(
+            new Twig_Filter('escape', 'twig_escape_filter', array('needs_environment' => true, 'is_safe_callback' => 'twig_escape_filter_is_safe')),
+            new Twig_Filter('e', 'twig_escape_filter', array('needs_environment' => true, 'is_safe_callback' => 'twig_escape_filter_is_safe')),
             new Twig_Filter('raw', 'twig_raw_filter', array('is_safe' => array('all'))),
         );
     }
@@ -76,6 +152,11 @@ final class Twig_Extension_Escaper extends Twig_Extension
     }
 }
 
+function twig_convert_encoding($string, $to, $from)
+{
+    return iconv($from, $to, $string);
+}
+
 /**
  * Marks a variable as being safe.
  *
@@ -86,4 +167,278 @@ final class Twig_Extension_Escaper extends Twig_Extension
 function twig_raw_filter($string)
 {
     return $string;
+}
+
+/**
+ * Escapes a string.
+ *
+ * @param Twig_Environment $env
+ * @param mixed            $string     The value to be escaped
+ * @param string           $strategy   The escaping strategy
+ * @param string           $charset    The charset
+ * @param bool             $autoescape Whether the function is called by the auto-escaping feature (true) or by the developer (false)
+ *
+ * @return string
+ */
+function twig_escape_filter(Twig_Environment $env, $string, $strategy = 'html', $charset = null, $autoescape = false)
+{
+    if ($autoescape && $string instanceof Twig_Markup) {
+        return $string;
+    }
+
+    if (!is_string($string)) {
+        if (is_object($string) && method_exists($string, '__toString')) {
+            $string = (string) $string;
+        } elseif (in_array($strategy, array('html', 'js', 'css', 'html_attr', 'url'))) {
+            return $string;
+        }
+    }
+
+    if (null === $charset) {
+        $charset = $env->getCharset();
+    }
+
+    $escapers = $env->getExtension('Twig_Extension_Escaper')->getEscapers();
+
+    if (isset($escapers[$strategy])) {
+        return $escapers[$strategy]($env, $string, $charset);
+    }
+
+    $validStrategies = implode(', ', array_keys($escapers));
+
+    throw new Twig_Error_Runtime(sprintf('Invalid escaping strategy "%s" (valid ones: %s).', $strategy, $validStrategies));
+}
+
+/**
+ * @internal
+ */
+function twig_escape_html(Twig_Environment $env, $string, $charset)
+{
+    // see http://php.net/htmlspecialchars
+
+    // Using a static variable to avoid initializing the array
+    // each time the function is called. Moving the declaration on the
+    // top of the function slow downs other escaping strategies.
+    static $htmlspecialcharsCharsets;
+
+    if (null === $htmlspecialcharsCharsets) {
+        if (defined('HHVM_VERSION')) {
+            $htmlspecialcharsCharsets = array('utf-8' => true, 'UTF-8' => true);
+        } else {
+            $htmlspecialcharsCharsets = array(
+                'ISO-8859-1' => true, 'ISO8859-1' => true,
+                'ISO-8859-15' => true, 'ISO8859-15' => true,
+                'utf-8' => true, 'UTF-8' => true,
+                'CP866' => true, 'IBM866' => true, '866' => true,
+                'CP1251' => true, 'WINDOWS-1251' => true, 'WIN-1251' => true,
+                '1251' => true,
+                'CP1252' => true, 'WINDOWS-1252' => true, '1252' => true,
+                'KOI8-R' => true, 'KOI8-RU' => true, 'KOI8R' => true,
+                'BIG5' => true, '950' => true,
+                'GB2312' => true, '936' => true,
+                'BIG5-HKSCS' => true,
+                'SHIFT_JIS' => true, 'SJIS' => true, '932' => true,
+                'EUC-JP' => true, 'EUCJP' => true,
+                'ISO8859-5' => true, 'ISO-8859-5' => true, 'MACROMAN' => true,
+            );
+        }
+    }
+
+    if (isset($htmlspecialcharsCharsets[$charset])) {
+        return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
+    }
+
+    if (isset($htmlspecialcharsCharsets[strtoupper($charset)])) {
+        // cache the lowercase variant for future iterations
+        $htmlspecialcharsCharsets[$charset] = true;
+
+        return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
+    }
+
+    $string = iconv($charset, 'UTF-8', $string);
+    $string = htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+    return iconv('UTF-8', $charset, $string);
+}
+
+/**
+ * @internal
+ */
+function twig_escape_js(Twig_Environment $env, $string, $charset)
+{
+    // escape all non-alphanumeric characters
+    // into their \xHH or \uHHHH representations
+    if ('UTF-8' !== $charset) {
+        $string = iconv($charset, 'UTF-8', $string);
+    }
+
+    if (0 == strlen($string) ? false : 1 !== preg_match('/^./su', $string)) {
+        throw new Twig_Error_Runtime('The string to escape is not a valid UTF-8 string.');
+    }
+
+    $string = preg_replace_callback('#[^a-zA-Z0-9,\._]#Su', function ($matches) {
+        $char = $matches[0];
+
+        // \xHH
+        if (!isset($char[1])) {
+            return '\\x'.strtoupper(substr('00'.bin2hex($char), -2));
+        }
+
+        // \uHHHH
+        $char = twig_convert_encoding($char, 'UTF-16BE', 'UTF-8');
+        $char = strtoupper(bin2hex($char));
+
+        if (4 >= strlen($char)) {
+            return sprintf('\u%04s', $char);
+        }
+
+        return sprintf('\u%04s\u%04s', substr($char, 0, -4), substr($char, -4));
+    }, $string);
+
+    if ('UTF-8' !== $charset) {
+        $string = iconv('UTF-8', $charset, $string);
+    }
+
+    return $string;
+}
+
+/**
+ * @internal
+ */
+function twig_escape_css(Twig_Environment $env, $string, $charset)
+{
+    if ('UTF-8' !== $charset) {
+        $string = iconv($charset, 'UTF-8', $string);
+    }
+
+    if (0 == strlen($string) ? false : 1 !== preg_match('/^./su', $string)) {
+        throw new Twig_Error_Runtime('The string to escape is not a valid UTF-8 string.');
+    }
+
+    $string = preg_replace_callback('#[^a-zA-Z0-9]#Su', function ($matches) {
+        $char = $matches[0];
+
+        // \xHH
+        if (!isset($char[1])) {
+            $hex = ltrim(strtoupper(bin2hex($char)), '0');
+            if (0 === strlen($hex)) {
+                $hex = '0';
+            }
+
+            return '\\'.$hex.' ';
+        }
+
+        // \uHHHH
+        $char = twig_convert_encoding($char, 'UTF-16BE', 'UTF-8');
+
+        return '\\'.ltrim(strtoupper(bin2hex($char)), '0').' ';
+    }, $string);
+
+    if ('UTF-8' !== $charset) {
+        $string = iconv('UTF-8', $charset, $string);
+    }
+
+    return $string;
+}
+
+/**
+ * @internal
+ */
+function twig_escape_html_attr(Twig_Environment $env, $string, $charset)
+{
+    if ('UTF-8' !== $charset) {
+        $string = iconv($charset, 'UTF-8', $string);
+    }
+
+    if (0 == strlen($string) ? false : 1 !== preg_match('/^./su', $string)) {
+        throw new Twig_Error_Runtime('The string to escape is not a valid UTF-8 string.');
+    }
+
+    $string = preg_replace_callback('#[^a-zA-Z0-9,\.\-_]#Su', function ($matches) {
+        /**
+         * This function is adapted from code coming from Zend Framework.
+         *
+         * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+         * @license   http://framework.zend.com/license/new-bsd New BSD License
+         */
+        /*
+         * While HTML supports far more named entities, the lowest common denominator
+         * has become HTML5's XML Serialisation which is restricted to the those named
+         * entities that XML supports. Using HTML entities would result in this error:
+         *     XML Parsing Error: undefined entity
+         */
+        static $entityMap = array(
+            34 => 'quot', /* quotation mark */
+            38 => 'amp',  /* ampersand */
+            60 => 'lt',   /* less-than sign */
+            62 => 'gt',   /* greater-than sign */
+        );
+
+        $chr = $matches[0];
+        $ord = ord($chr);
+
+        /*
+         * The following replaces characters undefined in HTML with the
+         * hex entity for the Unicode replacement character.
+         */
+        if (($ord <= 0x1f && $chr != "\t" && $chr != "\n" && $chr != "\r") || ($ord >= 0x7f && $ord <= 0x9f)) {
+            return '&#xFFFD;';
+        }
+
+        /*
+         * Check if the current character to escape has a name entity we should
+         * replace it with while grabbing the hex value of the character.
+         */
+        if (strlen($chr) == 1) {
+            $hex = strtoupper(substr('00'.bin2hex($chr), -2));
+        } else {
+            $chr = twig_convert_encoding($chr, 'UTF-16BE', 'UTF-8');
+            $hex = strtoupper(substr('0000'.bin2hex($chr), -4));
+        }
+
+        $int = hexdec($hex);
+        if (array_key_exists($int, $entityMap)) {
+            return sprintf('&%s;', $entityMap[$int]);
+        }
+
+        /*
+         * Per OWASP recommendations, we'll use hex entities for any other
+         * characters where a named entity does not exist.
+         */
+        return sprintf('&#x%s;', $hex);
+    }, $string);
+
+    if ('UTF-8' !== $charset) {
+        $string = iconv('UTF-8', $charset, $string);
+    }
+
+    return $string;
+}
+
+/**
+ * @internal
+ */
+function twig_escape_url(Twig_Environment $env, string $string, string $charset)
+{
+    return rawurlencode($string);
+}
+
+/**
+ * @internal
+ */
+function twig_escape_filter_is_safe(Twig_Node $filterArgs, Twig_Environment $env = null)
+{
+    foreach ($filterArgs as $arg) {
+        if ($arg instanceof Twig_Node_Expression_Constant) {
+            if ($env) {
+                $env->getExtension('Twig_Extension_Escaper')->getEscapersSafe();
+            }
+
+            return array($arg->getAttribute('value'));
+        }
+
+        return array();
+    }
+
+    return array('html');
 }

--- a/lib/Twig/Extension/Escaper.php
+++ b/lib/Twig/Extension/Escaper.php
@@ -11,7 +11,6 @@
 
 final class Twig_Extension_Escaper extends Twig_Extension
 {
-    private $environment;
     private $core;
     private $defaultStrategy;
     private $escaperSafety = array(
@@ -31,7 +30,6 @@ final class Twig_Extension_Escaper extends Twig_Extension
     public function __construct($defaultStrategy = 'html', Twig_Environment $env = null)
     {
         $this->setDefaultStrategy($defaultStrategy);
-        $this->environment = $env;
         $this->core = $env ? $env->getExtension('Twig_Extension_Core') : null;
     }
 
@@ -73,7 +71,7 @@ final class Twig_Extension_Escaper extends Twig_Extension
 
         $this->core->setEscaper($strategy, $callable, true);
 
-        $this->environment->flagOptionsHashForUpdate();
+        $this->flagSignatureForUpdate();
     }
 
     /**
@@ -156,13 +154,14 @@ final class Twig_Extension_Escaper extends Twig_Extension
         return $this->defaultStrategy;
     }
 
-    public function getSignature()
+    public function updateSignature()
     {
-        return hash('sha256', json_encode(array(
+        $this->signature = hash('sha256', json_encode(array(
             $this->getStrategySignature($this->defaultStrategy),
             $this->escaperSafety,
             $this->getEscapers(),
         )));
+        $this->signatureNeedsUpdate = false;
     }
 
     private function getStrategySignature($strategy)

--- a/lib/Twig/ExtensionSet.php
+++ b/lib/Twig/ExtensionSet.php
@@ -111,10 +111,21 @@ final class Twig_ExtensionSet
     {
         $signatures = array();
         foreach ($this->extensions as $class => $extension) {
-            $signatures[$class] = $extension->getSignature();
+            $signatures[$class] = $extension instanceof Twig_Extension ? $extension->getSignature() : null;
         }
 
         return json_encode($signatures);
+    }
+
+    public function signatureNeedsUpdate()
+    {
+        foreach ($this->extensions as $extension) {
+            if ($extension instanceof Twig_Extension && $extension->signatureNeedsUpdate()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function isInitialized()

--- a/lib/Twig/ExtensionSet.php
+++ b/lib/Twig/ExtensionSet.php
@@ -109,7 +109,12 @@ final class Twig_ExtensionSet
 
     public function getSignature()
     {
-        return json_encode(array_keys($this->extensions));
+        $signatures = array();
+        foreach ($this->extensions as $class => $extension) {
+            $signatures[$class] = $extension->getSignature();
+        }
+
+        return json_encode($signatures);
     }
 
     public function isInitialized()

--- a/lib/Twig/Filter.php
+++ b/lib/Twig/Filter.php
@@ -90,14 +90,14 @@ class Twig_Filter
         return $this->options['needs_context'];
     }
 
-    public function getSafe(Twig_Node $filterArgs)
+    public function getSafe(Twig_Node $filterArgs, Twig_Environment $env = null)
     {
         if (null !== $this->options['is_safe']) {
             return $this->options['is_safe'];
         }
 
         if (null !== $this->options['is_safe_callback']) {
-            return $this->options['is_safe_callback']($filterArgs);
+            return $this->options['is_safe_callback']($filterArgs, $env);
         }
     }
 

--- a/lib/Twig/Function.php
+++ b/lib/Twig/Function.php
@@ -88,14 +88,14 @@ class Twig_Function
         return $this->options['needs_context'];
     }
 
-    public function getSafe(Twig_Node $functionArgs)
+    public function getSafe(Twig_Node $functionArgs, Twig_Environment $env = null)
     {
         if (null !== $this->options['is_safe']) {
             return $this->options['is_safe'];
         }
 
         if (null !== $this->options['is_safe_callback']) {
-            return $this->options['is_safe_callback']($functionArgs);
+            return $this->options['is_safe_callback']($functionArgs, $env);
         }
 
         return array();

--- a/lib/Twig/NodeVisitor/SafeAnalysis.php
+++ b/lib/Twig/NodeVisitor/SafeAnalysis.php
@@ -31,10 +31,6 @@ final class Twig_NodeVisitor_SafeAnalysis extends Twig_BaseNodeVisitor
                 continue;
             }
 
-            if (in_array('html_attr', $bucket['value'])) {
-                $bucket['value'][] = 'html';
-            }
-
             return $bucket['value'];
         }
     }

--- a/lib/Twig/NodeVisitor/SafeAnalysis.php
+++ b/lib/Twig/NodeVisitor/SafeAnalysis.php
@@ -82,7 +82,7 @@ final class Twig_NodeVisitor_SafeAnalysis extends Twig_BaseNodeVisitor
             $name = $node->getNode('filter')->getAttribute('value');
             $args = $node->getNode('arguments');
             if (false !== $filter = $env->getFilter($name)) {
-                $safe = $filter->getSafe($args);
+                $safe = $filter->getSafe($args, $env);
                 if (null === $safe) {
                     $safe = $this->intersectSafe($this->getSafe($node->getNode('node')), $filter->getPreservesSafety());
                 }
@@ -96,7 +96,7 @@ final class Twig_NodeVisitor_SafeAnalysis extends Twig_BaseNodeVisitor
             $args = $node->getNode('arguments');
             $function = $env->getFunction($name);
             if (false !== $function) {
-                $this->setSafe($node, $function->getSafe($args));
+                $this->setSafe($node, $function->getSafe($args, $env));
             } else {
                 $this->setSafe($node, array());
             }

--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -107,21 +107,41 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($output, 'éÄ');
     }
 
+    public function testCustomEscaperOverwriting()
+    {
+        $string = 'foo';
+
+        $twig = new Twig_Environment(new Twig_Loader_Array(array(
+            'index.html' => '{{ string|e("html") }}',
+        )));
+        $escaper = $twig->getExtension('Twig_Extension_Escaper');
+
+        $escaper->setEscaper('foo', 'foo_escaper_for_test', array(), array('html'));
+        $escaper->setEscaper('foo', 'foo_escaper_for_test');
+        $escaper->setDefaultStrategy('foo');
+
+        $this->assertSame('fooUTF-8', $twig->load('index.html')->render(array('string' => $string)));
+    }
+
     /**
      * @dataProvider provideCustomEscaperCases
      */
-    public function testCustomEscaper($expected, $string, $strategy)
+    public function testCustomEscaper($expected, $string, $strategy, $is_safe_for = array())
     {
-        $twig = new Twig_Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock());
-        $twig->getExtension('Twig_Extension_Escaper')->setEscaper('foo', 'foo_escaper_for_test');
+        $twig = new Twig_Environment(new Twig_Loader_Array(array(
+            'index.html' => '{{ string|e("foo") }}',
+        )));
+        $twig->getExtension('Twig_Extension_Escaper')->setEscaper('foo', 'foo_escaper_for_test', $is_safe_for);
 
-        $this->assertSame($expected, twig_escape_filter($twig, $string, $strategy));
+        $this->assertSame($expected, $twig->load('index.html')->render(array('string' => $string)));
     }
 
     public function provideCustomEscaperCases()
     {
         return array(
             array('fooUTF-8', 'foo', 'foo'),
+            array('&lt;foo bar=&quot;baz&quot;&gt;UTF-8', '<foo bar="baz">', 'foo'),
+            array('<foo bar="baz">UTF-8', '<foo bar="baz">', 'foo', array('html')),
             array('UTF-8', null, 'foo'),
             array('42UTF-8', 42, 'foo'),
         );
@@ -256,7 +276,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
             array(array(), new CoreTestIterator($i, $keys, true), count($keys) + 10),
             array('de', 'abcdef', 3, 2),
             array(array(), new SimpleXMLElement('<items><item>1</item><item>2</item></items>'), 3),
-            array(array(), new ArrayIterator(array(1, 2)), 3),
+            array(array(), new ArrayIterator(array(1, 2)), 3)
         );
     }
 }
@@ -336,7 +356,7 @@ final class CoreTestIterator implements Iterator
     {
         ++$this->position;
         if ($this->position === $this->maxPosition) {
-            throw new LogicException(sprintf('Code should not iterate beyond %d.', $this->maxPosition));
+             throw new LogicException(sprintf('Code should not iterate beyond %d.', $this->maxPosition));
         }
     }
 

--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -113,7 +113,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
     public function testCustomEscaper($expected, $string, $strategy)
     {
         $twig = new Twig_Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock());
-        $twig->getExtension('Twig_Extension_Core')->setEscaper('foo', 'foo_escaper_for_test');
+        $twig->getExtension('Twig_Extension_Escaper')->setEscaper('foo', 'foo_escaper_for_test');
 
         $this->assertSame($expected, twig_escape_filter($twig, $string, $strategy));
     }
@@ -256,7 +256,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
             array(array(), new CoreTestIterator($i, $keys, true), count($keys) + 10),
             array('de', 'abcdef', 3, 2),
             array(array(), new SimpleXMLElement('<items><item>1</item><item>2</item></items>'), 3),
-            array(array(), new ArrayIterator(array(1, 2)), 3)
+            array(array(), new ArrayIterator(array(1, 2)), 3),
         );
     }
 }
@@ -336,7 +336,7 @@ final class CoreTestIterator implements Iterator
     {
         ++$this->position;
         if ($this->position === $this->maxPosition) {
-             throw new LogicException(sprintf('Code should not iterate beyond %d.', $this->maxPosition));
+            throw new LogicException(sprintf('Code should not iterate beyond %d.', $this->maxPosition));
         }
     }
 

--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -276,7 +276,7 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
             array(array(), new CoreTestIterator($i, $keys, true), count($keys) + 10),
             array('de', 'abcdef', 3, 2),
             array(array(), new SimpleXMLElement('<items><item>1</item><item>2</item></items>'), 3),
-            array(array(), new ArrayIterator(array(1, 2)), 3)
+            array(array(), new ArrayIterator(array(1, 2)), 3),
         );
     }
 }
@@ -356,7 +356,7 @@ final class CoreTestIterator implements Iterator
     {
         ++$this->position;
         if ($this->position === $this->maxPosition) {
-             throw new LogicException(sprintf('Code should not iterate beyond %d.', $this->maxPosition));
+            throw new LogicException(sprintf('Code should not iterate beyond %d.', $this->maxPosition));
         }
     }
 


### PR DESCRIPTION
Currently, there's no way to set "is_safe" for custom escapers, so it's necessary to use a filter instead (see #1689).

This adds the ability to specify "is_safe" for custom escapers:

```php
$core->setEscaper('url_query', 'esc_url_query');
$core->setEscaper('url_query_key', 'esc_url_query_key', ['url_query']);
$core->setEscaper('url_query_value', 'esc_url_query_value', ['url_query']);
```

I've also added a way to specify that an already specified escaper is safe for the new escaper (useful for adding missing escapers to existing groups of escapers without having to recreate those escapers):

```php
$core->setEscaper('url_query_key', 'esc_url_query_key');
$core->setEscaper('url_query_value', 'esc_url_query_value');

/* Later on, perhaps in a separate extension */
$core->setEscaper('url_query', 'esc_url_query', [], ['url_query_key', 'url_query_value']);
```

---

For the most part, the changes are rather straightforward:

### `SafeAnalysis.php`

- Pass `$env` to filter's and function's `getSafe()`

### `Filter.php` and `Function.php`

- Receive `$env` and pass to `is_safe_callback` as second (currently unused) argument

### `Core.php`

The diff is messy from static to dynamic change; mostly just moved static checks down to their own functions.

- Add default escapers to `Twig_Extension_Core::$escapers`
- Add `Twig_Extension_Core::$escapers_safe` to track escaper safety
- Add `$is_safe_for` and `$is_safe` parameters to `setEscaper()`

<!-- -->

- Remove `switch` check for default escapers (moved to own functions at bottom to be handled dynamically)
- Remove `static $escapers` and call `$core->getEscapers()` each time (otherwise different instantiations can affect eachother)
- Remove `array_merge($escapers, ['html', ...])`
- Remove hardcoded check for `html_attr` to add `html` as safe (handled by `$escapers_safe`)

### `escape.rst`
- Updated with an example marking escapers as safe

---

