### PR TITLE
Support PHPUnit 6 for testing extensions

### DIFF
--- a/lib/Twig/Test/IntegrationTestCase.php
+++ b/lib/Twig/Test/IntegrationTestCase.php
@@ -9,13 +9,16 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Constraint\Exception as ExceptionConstraint;
+
 /**
  * Integration test helper.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Karma Dordrak <drak@zikula.org>
  */
-abstract class Twig_Test_IntegrationTestCase extends PHPUnit_Framework_TestCase
+abstract class Twig_Test_IntegrationTestCase extends TestCase
 {
     /**
      * @return string
@@ -196,7 +199,8 @@ abstract class Twig_Test_IntegrationTestCase extends PHPUnit_Framework_TestCase
 
             if (false !== $exception) {
                 list($class) = explode(':', $exception);
-                $this->assertThat(null, new PHPUnit_Framework_Constraint_Exception($class));
+                $constraintClass = class_exists(ExceptionConstraint::class) ? ExceptionConstraint::class : \PHPUnit_Framework_Constraint_Exception::class;
+                $this->assertThat(null, new $constraintClass($class));
             }
 
             $expected = trim($match[3], "\n ");

--- a/lib/Twig/Test/NodeTestCase.php
+++ b/lib/Twig/Test/NodeTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 /*
  * This file is part of Twig.
  *
@@ -8,7 +10,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-abstract class Twig_Test_NodeTestCase extends PHPUnit_Framework_TestCase
+abstract class Twig_Test_NodeTestCase extends TestCase
 {
     abstract public function getTests();
 


### PR DESCRIPTION
When testing a Twig extension via the provided test cases [according to the documentation](https://twig.sensiolabs.org/doc/2.x/advanced.html#testing-an-extension), PHPUnit 6 is not supported.

I think we should force people who haven't upgraded to upgrade to PHPUnit 6 instead of limiting the ones who did.

Also, Twig 2.x runs only on PHP 7. People using Twig 2.x would most likely also test their code on PHP 7. Even though PHPUnit 5 supports PHP 7, I think most people who have updated PHP could update or would have already updated PHPUnit.