### PR TITLE
Escapting of concatenation optimized

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,7 +47,11 @@
  * improved the performance of the filesystem loader
  * removed features that were deprecated in 1.x
 
-* 1.33.0 (2017-XX-XX)
+* 1.33.1 (2017-XX-XX)
+
+ * n/a
+
+* 1.33.0 (2017-03-22)
 
  * fixed a race condition handling when writing cache files
  * "length" filter now returns string length when applied to an object that does

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1191,7 +1191,11 @@ function twig_lower_filter(Twig_Environment $env, $string)
  */
 function twig_title_string_filter(Twig_Environment $env, $string)
 {
-    return mb_convert_case($string, MB_CASE_TITLE, $env->getCharset());
+    if (null !== $charset = $env->getCharset()) {
+        return mb_convert_case($string, MB_CASE_TITLE, $charset);
+    }
+
+    return ucwords(strtolower($string));
 }
 
 /**
@@ -1241,7 +1245,7 @@ function twig_test_empty($value)
         return 0 == count($value);
     }
 
-    if (method_exists($value, '__toString')) {
+    if (is_object($value) && method_exists($value, '__toString')) {
         return '' === (string) $value;
     }
 

--- a/lib/Twig/Loader/Array.php
+++ b/lib/Twig/Loader/Array.php
@@ -65,7 +65,7 @@ final class Twig_Loader_Array implements Twig_LoaderInterface, Twig_ExistsLoader
             throw new Twig_Error_Loader(sprintf('Template "%s" is not defined.', $name));
         }
 
-        return $this->templates[$name];
+        return $name.':'.$this->templates[$name];
     }
 
     public function isFresh($name, $time)

--- a/lib/Twig/NodeVisitor/Optimizer.php
+++ b/lib/Twig/NodeVisitor/Optimizer.php
@@ -25,6 +25,8 @@ final class Twig_NodeVisitor_Optimizer extends Twig_BaseNodeVisitor
     const OPTIMIZE_NONE = 0;
     const OPTIMIZE_FOR = 2;
     const OPTIMIZE_RAW_FILTER = 4;
+    const OPTIMIZE_CONCAT_CONST = 16;
+
     // obsolete, does not do anything
     const OPTIMIZE_VAR_ACCESS = 8;
 
@@ -37,7 +39,7 @@ final class Twig_NodeVisitor_Optimizer extends Twig_BaseNodeVisitor
      */
     public function __construct($optimizers = -1)
     {
-        if (!is_int($optimizers) || $optimizers > (self::OPTIMIZE_FOR | self::OPTIMIZE_RAW_FILTER | self::OPTIMIZE_VAR_ACCESS)) {
+        if (!is_int($optimizers) || $optimizers > (self::OPTIMIZE_FOR | self::OPTIMIZE_RAW_FILTER | self::OPTIMIZE_VAR_ACCESS | self::OPTIMIZE_CONCAT_CONST)) {
             throw new InvalidArgumentException(sprintf('Optimizer mode "%s" is not valid.', $optimizers));
         }
 
@@ -48,6 +50,10 @@ final class Twig_NodeVisitor_Optimizer extends Twig_BaseNodeVisitor
     {
         if (self::OPTIMIZE_FOR === (self::OPTIMIZE_FOR & $this->optimizers)) {
             $this->enterOptimizeFor($node, $env);
+        }
+
+        if (self::OPTIMIZE_CONCAT_CONST === (self::OPTIMIZE_CONCAT_CONST & $this->optimizers)) {
+            $node = $this->optimizeConcatOfTwoConsts($node, $env);
         }
 
         return $node;
@@ -91,6 +97,30 @@ final class Twig_NodeVisitor_Optimizer extends Twig_BaseNodeVisitor
             $exprNode->setAttribute('output', true);
 
             return $exprNode;
+        }
+
+        return $node;
+    }
+
+    /**
+     * Transforms a "Concat" node with two "Constant" nodes into one "Constant" node.
+     *
+     * @return Twig_Node
+     */
+    private function optimizeConcatOfTwoConsts(Twig_Node $node, Twig_Environment $env)
+    {
+        if ($node instanceof Twig_Node_Expression_Binary_Concat) {
+            $leftNode = $node->getNode('left');
+            $rightNode = $node->getNode('right');
+            if (
+                $leftNode instanceof Twig_Node_Expression_Constant
+                && $rightNode instanceof Twig_Node_Expression_Constant
+            ) {
+                return new Twig_Node_Expression_Constant(
+                    $leftNode->getAttribute('value').$rightNode->getAttribute('value'),
+                    $leftNode->getTemplateLine()
+                );
+            }
         }
 
         return $node;

--- a/lib/Twig/Profiler/Dumper/Blackfire.php
+++ b/lib/Twig/Profiler/Dumper/Blackfire.php
@@ -20,7 +20,7 @@ final class Twig_Profiler_Dumper_Blackfire
         $this->dumpProfile('main()', $profile, $data);
         $this->dumpChildren('main()', $profile, $data);
 
-        $start = microtime(true);
+        $start = sprintf('%f', microtime(true));
         $str = <<<EOF
 file-format: BlackfireProbe
 cost-dimensions: wt mu pmu

--- a/test/Twig/Tests/ContainerRuntimeLoaderTest.php
+++ b/test/Twig/Tests/ContainerRuntimeLoaderTest.php
@@ -17,7 +17,7 @@ class Twig_Tests_ContainerRuntimeLoaderTest extends PHPUnit_Framework_TestCase
     {
         $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $container->expects($this->once())->method('has')->with('stdClass')->willReturn(true);
-        $container->expects($this->once())->method('get')->with('stdClass')->willReturn(new \Stdclass());
+        $container->expects($this->once())->method('get')->with('stdClass')->willReturn(new \stdClass());
 
         $loader = new Twig_ContainerRuntimeLoader($container);
 

--- a/test/Twig/Tests/Fixtures/autoescape/name.test
+++ b/test/Twig/Tests/Fixtures/autoescape/name.test
@@ -2,8 +2,11 @@
 "name" autoescape strategy
 --TEMPLATE--
 {{ br -}}
+{{ include('index.js.twig') -}}
 {{ include('index.html.twig') -}}
 {{ include('index.txt.twig') -}}
+--TEMPLATE(index.js.twig)--
+{{ br -}}
 --TEMPLATE(index.html.twig)--
 {{ br -}}
 --TEMPLATE(index.txt.twig)--
@@ -14,5 +17,6 @@ return array('br' => '<br />')
 return array('autoescape' => 'name')
 --EXPECT--
 &lt;br /&gt;
+\x3Cbr\x20\x2F\x3E
 &lt;br /&gt;
 <br />

--- a/test/Twig/Tests/Loader/ArrayTest.php
+++ b/test/Twig/Tests/Loader/ArrayTest.php
@@ -25,7 +25,29 @@ class Twig_Tests_Loader_ArrayTest extends PHPUnit_Framework_TestCase
     {
         $loader = new Twig_Loader_Array(array('foo' => 'bar'));
 
-        $this->assertEquals('bar', $loader->getCacheKey('foo'));
+        $this->assertEquals('foo:bar', $loader->getCacheKey('foo'));
+    }
+
+    public function testGetCacheKeyWhenTemplateHasDuplicateContent()
+    {
+        $loader = new Twig_Loader_Array(array(
+            'foo' => 'bar',
+            'baz' => 'bar',
+        ));
+
+        $this->assertEquals('foo:bar', $loader->getCacheKey('foo'));
+        $this->assertEquals('baz:bar', $loader->getCacheKey('baz'));
+    }
+
+    public function testGetCacheKeyIsProtectedFromEdgeCollisions()
+    {
+        $loader = new Twig_Loader_Array(array(
+            'foo__' => 'bar',
+            'foo' => '__bar',
+        ));
+
+        $this->assertEquals('foo__:bar', $loader->getCacheKey('foo__'));
+        $this->assertEquals('foo:__bar', $loader->getCacheKey('foo'));
     }
 
     /**

--- a/test/Twig/Tests/Loader/ChainTest.php
+++ b/test/Twig/Tests/Loader/ChainTest.php
@@ -49,8 +49,8 @@ class Twig_Tests_Loader_ChainTest extends PHPUnit_Framework_TestCase
             new Twig_Loader_Array(array('foo' => 'foobar', 'bar' => 'foo')),
         ));
 
-        $this->assertEquals('bar', $loader->getCacheKey('foo'));
-        $this->assertEquals('foo', $loader->getCacheKey('bar'));
+        $this->assertEquals('foo:bar', $loader->getCacheKey('foo'));
+        $this->assertEquals('bar:foo', $loader->getCacheKey('bar'));
     }
 
     /**


### PR DESCRIPTION
This request provides an optimization for an issue [2454](https://github.com/twigphp/Twig/issues/2454)
With provided optimisation the template `{{ 'constant one ' ~ 'constant two' }}` will produce the following compiled template:
```php
protected function doDisplay(array $context, array $blocks = array())
{
     // line 1
     echo ("constant one " . "constant two");
}
```
The changes for this optimisation include simply checking the node `Twig_Node_Expression_Binary_Concat` during the save analysis phase and checks whether the both operands are save if they are we mark a `Twig_Node_Expression_Binary_Concat` node as safe as well.