### PR TITLE
Fix generating template name in createTemplate() method

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -489,7 +489,7 @@ class Twig_Environment
      */
     public function createTemplate($template)
     {
-        $name = sprintf('__string_template__%s', hash('sha256', uniqid(mt_rand(), true), false));
+        $name = sprintf('__string_template__%s', hash('sha256', $template, false));
 
         $loader = new Twig_Loader_Chain(array(
             new Twig_Loader_Array(array($name => $template)),


### PR DESCRIPTION
Before this change the name for the template was generated randomly based on uniqid(mt_rand()). It generated new file whenever the template was loaded as string using the `template_from_string` function even the template was the same. The generated file wasn't used anymore.

Now the cache file is generated by the content of template so using the `template_from_string` is much faster and doesn't pollute the cache folder with unneeded files.