### PR TITLE
Length filter non-mb_string on 7.x fix.

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1363,6 +1363,10 @@ else {
      */
     function twig_length_filter(Twig_Environment $env, $thing)
     {
+        if (null === $thing) {
+            return 0;
+        }
+
         if (is_scalar($thing)) {
             return strlen($thing);
         }
@@ -1371,7 +1375,11 @@ else {
             return strlen((string) $thing);
         }
 
-        return count($thing);
+        if ($thing instanceof \Countable || is_array($thing)) {
+            return count($thing);
+        }
+
+        return 1;
     }
 
     /**


### PR DESCRIPTION
follow up on https://github.com/twigphp/Twig/pull/2462
after https://github.com/twigphp/Twig/issues/2464#issuecomment-301014241