### PR TITLE
Remove PHP version from Options Hash

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -935,8 +935,6 @@ class Twig_Environment
     {
         $this->optionsHash = implode(':', array(
             $this->extensionSet->getSignature(),
-            PHP_MAJOR_VERSION,
-            PHP_MINOR_VERSION,
             self::VERSION,
             (int) $this->debug,
             $this->baseTemplateClass,


### PR DESCRIPTION
Addresses #2471

- [ ] It would be great to have tests for this, but automating cached code across PHP versions will take some consideration