### PR TITLE
Fix `@final`-related deprecations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 2.4.0 (2017-XX-XX)
 
- * marked Twig_Node_Module as final via the @final annotation
+ * marked Twig_Filter, Twig_Function, Twig_Test, Twig_Node_Module and Twig_Profiler_Profile as final via the @final annotation
 
 * 2.3.2 (2017-04-20)
 

--- a/lib/Twig/Filter.php
+++ b/lib/Twig/Filter.php
@@ -12,7 +12,7 @@
 /**
  * Represents a template filter.
  *
- * @final
+ * @final since version 2.4.0
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
@@ -135,3 +135,6 @@ class Twig_Filter
         return $this->options['alternative'];
     }
 }
+
+// For Twig 1.x compatibility
+class_alias('Twig_Filter', 'Twig_SimpleFilter', false);

--- a/lib/Twig/Function.php
+++ b/lib/Twig/Function.php
@@ -34,6 +34,10 @@ class Twig_Function
      */
     public function __construct(string $name, $callable = null, array $options = array())
     {
+        if (__CLASS__ !== get_class($this)) {
+            @trigger_error('Overriding '.__CLASS__.' is deprecated since version 2.4.0 and the class will be final in 3.0.', E_USER_DEPRECATED);
+        }
+
         $this->name = $name;
         $this->callable = $callable;
         $this->options = array_merge(array(
@@ -121,3 +125,6 @@ class Twig_Function
         return $this->options['alternative'];
     }
 }
+
+// For Twig 1.x compatibility
+class_alias('Twig_Function', 'Twig_SimpleFunction', false);

--- a/lib/Twig/Node/Module.php
+++ b/lib/Twig/Node/Module.php
@@ -19,7 +19,7 @@
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since 2.4.0
+ * @final since version 2.4.0
  */
 class Twig_Node_Module extends Twig_Node
 {

--- a/lib/Twig/Profiler/Profile.php
+++ b/lib/Twig/Profiler/Profile.php
@@ -12,7 +12,7 @@
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final
+ * @final since version 2.4.0
  */
 class Twig_Profiler_Profile implements IteratorAggregate, Serializable
 {

--- a/lib/Twig/SimpleFilter.php
+++ b/lib/Twig/SimpleFilter.php
@@ -10,8 +10,12 @@
  */
 
 /**
- * Empty class for Twig 1.x compatibility.
+ * For Twig 1.x compatibility.
  */
-final class Twig_SimpleFilter extends Twig_Filter
-{
+require __DIR__.'/Filter.php';
+
+if (false) {
+    final class Twig_SimpleFilter extends Twig_Filter
+    {
+    }
 }

--- a/lib/Twig/SimpleFunction.php
+++ b/lib/Twig/SimpleFunction.php
@@ -10,8 +10,12 @@
  */
 
 /**
- * Empty class for Twig 1.x compatibility.
+ * For Twig 1.x compatibility.
  */
-final class Twig_SimpleFunction extends Twig_Function
-{
+require __DIR__.'/Function.php';
+
+if (false) {
+    final class Twig_SimpleFunction extends Twig_Function
+    {
+    }
 }

--- a/lib/Twig/SimpleTest.php
+++ b/lib/Twig/SimpleTest.php
@@ -10,8 +10,12 @@
  */
 
 /**
- * Empty class for Twig 1.x compatibility.
+ * For Twig 1.x compatibility.
  */
-final class Twig_SimpleTest extends Twig_Test
-{
+require __DIR__.'/Test.php';
+
+if (false) {
+    final class Twig_SimpleTest extends Twig_Test
+    {
+    }
 }

--- a/lib/Twig/Test.php
+++ b/lib/Twig/Test.php
@@ -12,7 +12,7 @@
 /**
  * Represents a template test.
  *
- * @final
+ * @final since version 2.4.0
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
@@ -87,3 +87,6 @@ class Twig_Test
         return $this->options['alternative'];
     }
 }
+
+// For Twig 1.x compatibility
+class_alias('Twig_Test', 'Twig_SimpleTest', false);


### PR DESCRIPTION
The run-time notices make Symfony fail because the check should exclude e.g. `Twig_SimpleFilter`.
But IMHO, we may not really need these run-time checks, if we say that relying on the DebugClassLoader + CHANGELOG in enough (which we did in the past).