### PR TITLE
Use class_exists instead of require

### DIFF
--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Cache;
 
-require __DIR__.'/../../lib/Twig/Cache/Filesystem.php';
+class_exists('Twig_Cache_Filesystem');
 
 if (\false) {
     class FilesystemCache extends \Twig_Cache_Filesystem

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Cache;
 
-require __DIR__.'/../../lib/Twig/Cache/Null.php';
+class_exists('Twig_Cache_Null');
 
 if (\false) {
     class NullCache extends \Twig_Cache_Null

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/Compiler.php';
+class_exists('Twig_Compiler');
 
 if (\false) {
     class Compiler extends \Twig_Compiler

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/Environment.php';
+class_exists('Twig_Environment');
 
 if (\false) {
     class Environment extends \Twig_Environment

--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Error;
 
-require __DIR__.'/../../lib/Twig/Error.php';
+class_exists('Twig_Error');
 
 if (\false) {
     class Error extends \Twig_Error

--- a/src/Error/LoaderError.php
+++ b/src/Error/LoaderError.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Error;
 
-require __DIR__.'/../../lib/Twig/Error/Loader.php';
+class_exists('Twig_Error_Loader');
 
 if (\false) {
     class LoaderError extends \Twig_Error_Loader

--- a/src/Error/RuntimeError.php
+++ b/src/Error/RuntimeError.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Error;
 
-require __DIR__.'/../../lib/Twig/Error/Runtime.php';
+class_exists('Twig_Error_Runtime');
 
 if (\false) {
     class RuntimeError extends \Twig_Error_Runtime

--- a/src/Error/SyntaxError.php
+++ b/src/Error/SyntaxError.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Error;
 
-require __DIR__.'/../../lib/Twig/Error/Syntax.php';
+class_exists('Twig_Error_Syntax');
 
 if (\false) {
     class SyntaxError extends \Twig_Error_Syntax

--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/ExpressionParser.php';
+class_exists('Twig_ExpressionParser');
 
 if (\false) {
     class ExpressionParser extends \Twig_ExpressionParser

--- a/src/Extension/AbstractExtension.php
+++ b/src/Extension/AbstractExtension.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Extension;
 
-require __DIR__.'/../../lib/Twig/Extension.php';
+class_exists('Twig_Extension');
 
 if (\false) {
     class AbstractExtension extends \Twig_Extension

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Extension;
 
-require __DIR__.'/../../lib/Twig/Extension/Core.php';
+class_exists('Twig_Extension_Core');
 
 if (\false) {
     class CoreExtension extends \Twig_Extension_Core

--- a/src/Extension/DebugExtension.php
+++ b/src/Extension/DebugExtension.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Extension;
 
-require __DIR__.'/../../lib/Twig/Extension/Debug.php';
+class_exists('Twig_Extension_Debug');
 
 if (\false) {
     class DebugExtension extends \Twig_Extension_Debug

--- a/src/Extension/EscaperExtension.php
+++ b/src/Extension/EscaperExtension.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Extension;
 
-require __DIR__.'/../../lib/Twig/Extension/Escaper.php';
+class_exists('Twig_Extension_Escaper');
 
 if (\false) {
     class EscaperExtension extends \Twig_Extension_Escaper

--- a/src/Extension/OptimizerExtension.php
+++ b/src/Extension/OptimizerExtension.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Extension;
 
-require __DIR__.'/../../lib/Twig/Extension/Optimizer.php';
+class_exists('Twig_Extension_Optimizer');
 
 if (\false) {
     class OptimizerExtension extends \Twig_Extension_Optimizer

--- a/src/Extension/ProfilerExtension.php
+++ b/src/Extension/ProfilerExtension.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Extension;
 
-require __DIR__.'/../../lib/Twig/Extension/Profiler.php';
+class_exists('Twig_Extension_Profiler');
 
 if (\false) {
     class ProfilerExtension extends \Twig_Extension_Profiler

--- a/src/Extension/SandboxExtension.php
+++ b/src/Extension/SandboxExtension.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Extension;
 
-require __DIR__.'/../../lib/Twig/Extension/Sandbox.php';
+class_exists('Twig_Extension_Sandbox');
 
 if (\false) {
     class SandboxExtension extends \Twig_Extension_Sandbox

--- a/src/Extension/StagingExtension.php
+++ b/src/Extension/StagingExtension.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Extension;
 
-require __DIR__.'/../../lib/Twig/Extension/Staging.php';
+class_exists('Twig_Extension_Staging');
 
 if (\false) {
     class StagingExtension extends \Twig_Extension_Staging

--- a/src/Extension/StringLoaderExtension.php
+++ b/src/Extension/StringLoaderExtension.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Extension;
 
-require __DIR__.'/../../lib/Twig/Extension/StringLoader.php';
+class_exists('Twig_Extension_StringLoader');
 
 if (\false) {
     class StringLoaderExtension extends \Twig_Extension_StringLoader

--- a/src/FileExtensionEscapingStrategy.php
+++ b/src/FileExtensionEscapingStrategy.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/FileExtensionEscapingStrategy.php';
+class_exists('Twig_FileExtensionEscapingStrategy');
 
 if (\false) {
     class FileExtensionEscapingStrategy extends \Twig_FileExtensionEscapingStrategy

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/Lexer.php';
+class_exists('Twig_Lexer');
 
 if (\false) {
     class Lexer extends \Twig_Lexer

--- a/src/Loader/ArrayLoader.php
+++ b/src/Loader/ArrayLoader.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Loader;
 
-require __DIR__.'/../../lib/Twig/Loader/Array.php';
+class_exists('Twig_Loader_Array');
 
 if (\false) {
     class ArrayLoader extends \Twig_Loader_Array

--- a/src/Loader/ChainLoader.php
+++ b/src/Loader/ChainLoader.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Loader;
 
-require __DIR__.'/../../lib/Twig/Loader/Chain.php';
+class_exists('Twig_Loader_Chain');
 
 if (\false) {
     class ChainLoader extends \Twig_Loader_Chain

--- a/src/Loader/FilesystemLoader.php
+++ b/src/Loader/FilesystemLoader.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Loader;
 
-require __DIR__.'/../../lib/Twig/Loader/Filesystem.php';
+class_exists('Twig_Loader_Filesystem');
 
 if (\false) {
     class FilesystemLoader extends \Twig_Loader_Filesystem

--- a/src/Markup.php
+++ b/src/Markup.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/Markup.php';
+class_exists('Twig_Markup');
 
 if (\false) {
     class Markup extends \Twig_Markup

--- a/src/Node/AutoEscapeNode.php
+++ b/src/Node/AutoEscapeNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/AutoEscape.php';
+class_exists('Twig_Node_AutoEscape');
 
 if (\false) {
     class AutoEscapeNode extends \Twig_Node_AutoEscape

--- a/src/Node/BlockNode.php
+++ b/src/Node/BlockNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Block.php';
+class_exists('Twig_Node_Block');
 
 if (\false) {
     class BlockNode extends \Twig_Node_Block

--- a/src/Node/BlockReferenceNode.php
+++ b/src/Node/BlockReferenceNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/BlockReference.php';
+class_exists('Twig_Node_BlockReference');
 
 if (\false) {
     class BlockReferenceNode extends \Twig_Node_BlockReference

--- a/src/Node/BodyNode.php
+++ b/src/Node/BodyNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Body.php';
+class_exists('Twig_Node_Body');
 
 if (\false) {
     class BodyNode extends \Twig_Node_Body

--- a/src/Node/CheckSecurityNode.php
+++ b/src/Node/CheckSecurityNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/CheckSecurity.php';
+class_exists('Twig_Node_CheckSecurity');
 
 if (\false) {
     class CheckSecurityNode extends \Twig_Node_CheckSecurity

--- a/src/Node/DoNode.php
+++ b/src/Node/DoNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Do.php';
+class_exists('Twig_Node_Do');
 
 if (\false) {
     class DoNode extends \Twig_Node_Do

--- a/src/Node/EmbedNode.php
+++ b/src/Node/EmbedNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Embed.php';
+class_exists('Twig_Node_Embed');
 
 if (\false) {
     class EmbedNode extends \Twig_Node_Embed

--- a/src/Node/Expression/AbstractExpression.php
+++ b/src/Node/Expression/AbstractExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression.php';
+class_exists('Twig_Node_Expression');
 
 if (\false) {
     class AbstractExpression extends \Twig_Node_Expression

--- a/src/Node/Expression/ArrayExpression.php
+++ b/src/Node/Expression/ArrayExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/Array.php';
+class_exists('Twig_Node_Expression_Array');
 
 if (\false) {
     class ArrayExpression extends \Twig_Node_Expression_Array

--- a/src/Node/Expression/AssignNameExpression.php
+++ b/src/Node/Expression/AssignNameExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/AssignName.php';
+class_exists('Twig_Node_Expression_AssignName');
 
 if (\false) {
     class AssignNameExpression extends \Twig_Node_Expression_AssignName

--- a/src/Node/Expression/Binary/AbstractBinary.php
+++ b/src/Node/Expression/Binary/AbstractBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary.php';
+class_exists('Twig_Node_Expression_Binary');
 
 if (\false) {
     class AbstractBinary extends \Twig_Node_Expression_Binary

--- a/src/Node/Expression/Binary/AddBinary.php
+++ b/src/Node/Expression/Binary/AddBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Add.php';
+class_exists('Twig_Node_Expression_Binary_Add');
 
 if (\false) {
     class AddBinary extends \Twig_Node_Expression_Binary_Add

--- a/src/Node/Expression/Binary/AndBinary.php
+++ b/src/Node/Expression/Binary/AndBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/And.php';
+class_exists('Twig_Node_Expression_Binary_And');
 
 if (\false) {
     class AndBinary extends \Twig_Node_Expression_Binary_And

--- a/src/Node/Expression/Binary/BitwiseAndBinary.php
+++ b/src/Node/Expression/Binary/BitwiseAndBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/BitwiseAnd.php';
+class_exists('Twig_Node_Expression_Binary_BitwiseAnd');
 
 if (\false) {
     class BitwiseAndBinary extends \Twig_Node_Expression_Binary_BitwiseAnd

--- a/src/Node/Expression/Binary/BitwiseOrBinary.php
+++ b/src/Node/Expression/Binary/BitwiseOrBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/BitwiseOr.php';
+class_exists('Twig_Node_Expression_Binary_BitwiseOr');
 
 if (\false) {
     class BitwiseOrBinary extends \Twig_Node_Expression_Binary_BitwiseOr

--- a/src/Node/Expression/Binary/BitwiseXorBinary.php
+++ b/src/Node/Expression/Binary/BitwiseXorBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/BitwiseXor.php';
+class_exists('Twig_Node_Expression_Binary_BitwiseXor');
 
 if (\false) {
     class BitwiseXorBinary extends \Twig_Node_Expression_Binary_BitwiseXor

--- a/src/Node/Expression/Binary/ConcatBinary.php
+++ b/src/Node/Expression/Binary/ConcatBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Concat.php';
+class_exists('Twig_Node_Expression_Binary_Concat');
 
 if (\false) {
     class ConcatBinary extends \Twig_Node_Expression_Binary_Concat

--- a/src/Node/Expression/Binary/DivBinary.php
+++ b/src/Node/Expression/Binary/DivBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Div.php';
+class_exists('Twig_Node_Expression_Binary_Div');
 
 if (\false) {
     class DivBinary extends \Twig_Node_Expression_Binary_Div

--- a/src/Node/Expression/Binary/EndsWithBinary.php
+++ b/src/Node/Expression/Binary/EndsWithBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/EndsWith.php';
+class_exists('Twig_Node_Expression_Binary_EndsWith');
 
 if (\false) {
     class EndsWithBinary extends \Twig_Node_Expression_Binary_EndsWith

--- a/src/Node/Expression/Binary/EqualBinary.php
+++ b/src/Node/Expression/Binary/EqualBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Equal.php';
+class_exists('Twig_Node_Expression_Binary_Equal');
 
 if (\false) {
     class EqualBinary extends \Twig_Node_Expression_Binary_Equal

--- a/src/Node/Expression/Binary/FloorDivBinary.php
+++ b/src/Node/Expression/Binary/FloorDivBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/FloorDiv.php';
+class_exists('Twig_Node_Expression_Binary_FloorDiv');
 
 if (\false) {
     class FloorDivBinary extends \Twig_Node_Expression_Binary_FloorDiv

--- a/src/Node/Expression/Binary/GreaterBinary.php
+++ b/src/Node/Expression/Binary/GreaterBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Greater.php';
+class_exists('Twig_Node_Expression_Binary_Greater');
 
 if (\false) {
     class GreaterBinary extends \Twig_Node_Expression_Binary_Greater

--- a/src/Node/Expression/Binary/GreaterEqualBinary.php
+++ b/src/Node/Expression/Binary/GreaterEqualBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/GreaterEqual.php';
+class_exists('Twig_Node_Expression_Binary_GreaterEqual');
 
 if (\false) {
     class GreaterEqualBinary extends \Twig_Node_Expression_Binary_GreaterEqual

--- a/src/Node/Expression/Binary/InBinary.php
+++ b/src/Node/Expression/Binary/InBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/In.php';
+class_exists('Twig_Node_Expression_Binary_In');
 
 if (\false) {
     class InBinary extends \Twig_Node_Expression_Binary_In

--- a/src/Node/Expression/Binary/LessBinary.php
+++ b/src/Node/Expression/Binary/LessBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Less.php';
+class_exists('Twig_Node_Expression_Binary_Less');
 
 if (\false) {
     class LessBinary extends \Twig_Node_Expression_Binary_Less

--- a/src/Node/Expression/Binary/LessEqualBinary.php
+++ b/src/Node/Expression/Binary/LessEqualBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/LessEqual.php';
+class_exists('Twig_Node_Expression_Binary_LessEqual');
 
 if (\false) {
     class LessEqualBinary extends \Twig_Node_Expression_Binary_LessEqual

--- a/src/Node/Expression/Binary/MatchesBinary.php
+++ b/src/Node/Expression/Binary/MatchesBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Matches.php';
+class_exists('Twig_Node_Expression_Binary_Matches');
 
 if (\false) {
     class MatchesBinary extends \Twig_Node_Expression_Binary_Matches

--- a/src/Node/Expression/Binary/ModBinary.php
+++ b/src/Node/Expression/Binary/ModBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Mod.php';
+class_exists('Twig_Node_Expression_Binary_Mod');
 
 if (\false) {
     class ModBinary extends \Twig_Node_Expression_Binary_Mod

--- a/src/Node/Expression/Binary/MulBinary.php
+++ b/src/Node/Expression/Binary/MulBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Mul.php';
+class_exists('Twig_Node_Expression_Binary_Mul');
 
 if (\false) {
     class MulBinary extends \Twig_Node_Expression_Binary_Mul

--- a/src/Node/Expression/Binary/NotEqualBinary.php
+++ b/src/Node/Expression/Binary/NotEqualBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/NotEqual.php';
+class_exists('Twig_Node_Expression_Binary_NotEqual');
 
 if (\false) {
     class NotEqualBinary extends \Twig_Node_Expression_Binary_NotEqual

--- a/src/Node/Expression/Binary/NotInBinary.php
+++ b/src/Node/Expression/Binary/NotInBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/NotIn.php';
+class_exists('Twig_Node_Expression_Binary_NotIn');
 
 if (\false) {
     class NotInBinary extends \Twig_Node_Expression_Binary_NotIn

--- a/src/Node/Expression/Binary/OrBinary.php
+++ b/src/Node/Expression/Binary/OrBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Or.php';
+class_exists('Twig_Node_Expression_Binary_Or');
 
 if (\false) {
     class OrBinary extends \Twig_Node_Expression_Binary_Or

--- a/src/Node/Expression/Binary/PowerBinary.php
+++ b/src/Node/Expression/Binary/PowerBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Power.php';
+class_exists('Twig_Node_Expression_Binary_Power');
 
 if (\false) {
     class PowerBinary extends \Twig_Node_Expression_Binary_Power

--- a/src/Node/Expression/Binary/RangeBinary.php
+++ b/src/Node/Expression/Binary/RangeBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Range.php';
+class_exists('Twig_Node_Expression_Binary_Range');
 
 if (\false) {
     class RangeBinary extends \Twig_Node_Expression_Binary_Range

--- a/src/Node/Expression/Binary/StartsWithBinary.php
+++ b/src/Node/Expression/Binary/StartsWithBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/StartsWith.php';
+class_exists('Twig_Node_Expression_Binary_StartsWith');
 
 if (\false) {
     class StartsWithBinary extends \Twig_Node_Expression_Binary_StartsWith

--- a/src/Node/Expression/Binary/SubBinary.php
+++ b/src/Node/Expression/Binary/SubBinary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Binary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Binary/Sub.php';
+class_exists('Twig_Node_Expression_Binary_Sub');
 
 if (\false) {
     class SubBinary extends \Twig_Node_Expression_Binary_Sub

--- a/src/Node/Expression/BlockReferenceExpression.php
+++ b/src/Node/Expression/BlockReferenceExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/BlockReference.php';
+class_exists('Twig_Node_Expression_BlockReference');
 
 if (\false) {
     class BlockReferenceExpression extends \Twig_Node_Expression_BlockReference

--- a/src/Node/Expression/CallExpression.php
+++ b/src/Node/Expression/CallExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/Call.php';
+class_exists('Twig_Node_Expression_Call');
 
 if (\false) {
     class CallExpression extends \Twig_Node_Expression_Call

--- a/src/Node/Expression/ConditionalExpression.php
+++ b/src/Node/Expression/ConditionalExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/Conditional.php';
+class_exists('Twig_Node_Expression_Conditional');
 
 if (\false) {
     class ConditionalExpression extends \Twig_Node_Expression_Conditional

--- a/src/Node/Expression/ConstantExpression.php
+++ b/src/Node/Expression/ConstantExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/Constant.php';
+class_exists('Twig_Node_Expression_Constant');
 
 if (\false) {
     class ConstantExpression extends \Twig_Node_Expression_Constant

--- a/src/Node/Expression/Filter/DefaultFilter.php
+++ b/src/Node/Expression/Filter/DefaultFilter.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Filter;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Filter/Default.php';
+class_exists('Twig_Node_Expression_Filter_Default');
 
 if (\false) {
     class DefaultFilter extends \Twig_Node_Expression_Filter_Default

--- a/src/Node/Expression/FilterExpression.php
+++ b/src/Node/Expression/FilterExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/Filter.php';
+class_exists('Twig_Node_Expression_Filter');
 
 if (\false) {
     class FilterExpression extends \Twig_Node_Expression_Filter

--- a/src/Node/Expression/FunctionExpression.php
+++ b/src/Node/Expression/FunctionExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/Function.php';
+class_exists('Twig_Node_Expression_Function');
 
 if (\false) {
     class FunctionExpression extends \Twig_Node_Expression_Function

--- a/src/Node/Expression/GetAttrExpression.php
+++ b/src/Node/Expression/GetAttrExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/GetAttr.php';
+class_exists('Twig_Node_Expression_GetAttr');
 
 if (\false) {
     class GetAttrExpression extends \Twig_Node_Expression_GetAttr

--- a/src/Node/Expression/MethodCallExpression.php
+++ b/src/Node/Expression/MethodCallExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/MethodCall.php';
+class_exists('Twig_Node_Expression_MethodCall');
 
 if (\false) {
     class MethodCallExpression extends \Twig_Node_Expression_MethodCall

--- a/src/Node/Expression/NameExpression.php
+++ b/src/Node/Expression/NameExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/Name.php';
+class_exists('Twig_Node_Expression_Name');
 
 if (\false) {
     class NameExpression extends \Twig_Node_Expression_Name

--- a/src/Node/Expression/NullCoalesceExpression.php
+++ b/src/Node/Expression/NullCoalesceExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/NullCoalesce.php';
+class_exists('Twig_Node_Expression_NullCoalesce');
 
 if (\false) {
     class NullCoalesceExpression extends \Twig_Node_Expression_NullCoalesce

--- a/src/Node/Expression/ParentExpression.php
+++ b/src/Node/Expression/ParentExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/Parent.php';
+class_exists('Twig_Node_Expression_Parent');
 
 if (\false) {
     class ParentExpression extends \Twig_Node_Expression_Parent

--- a/src/Node/Expression/TempNameExpression.php
+++ b/src/Node/Expression/TempNameExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/TempName.php';
+class_exists('Twig_Node_Expression_TempName');
 
 if (\false) {
     class TempNameExpression extends \Twig_Node_Expression_TempName

--- a/src/Node/Expression/Test/ConstantTest.php
+++ b/src/Node/Expression/Test/ConstantTest.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Test;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Test/Constant.php';
+class_exists('Twig_Node_Expression_Test_Constant');
 
 if (\false) {
     class ConstantTest extends \Twig_Node_Expression_Test_Constant

--- a/src/Node/Expression/Test/DefinedTest.php
+++ b/src/Node/Expression/Test/DefinedTest.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Test;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Test/Defined.php';
+class_exists('Twig_Node_Expression_Test_Defined');
 
 if (\false) {
     class DefinedTest extends \Twig_Node_Expression_Test_Defined

--- a/src/Node/Expression/Test/DivisiblebyTest.php
+++ b/src/Node/Expression/Test/DivisiblebyTest.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Test;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Test/Divisibleby.php';
+class_exists('Twig_Node_Expression_Test_Divisibleby');
 
 if (\false) {
     class DivisiblebyTest extends \Twig_Node_Expression_Test_Divisibleby

--- a/src/Node/Expression/Test/EvenTest.php
+++ b/src/Node/Expression/Test/EvenTest.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Test;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Test/Even.php';
+class_exists('Twig_Node_Expression_Test_Even');
 
 if (\false) {
     class EvenTest extends \Twig_Node_Expression_Test_Even

--- a/src/Node/Expression/Test/NullTest.php
+++ b/src/Node/Expression/Test/NullTest.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Test;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Test/Null.php';
+class_exists('Twig_Node_Expression_Test_Null');
 
 if (\false) {
     class NullTest extends \Twig_Node_Expression_Test_Null

--- a/src/Node/Expression/Test/OddTest.php
+++ b/src/Node/Expression/Test/OddTest.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Test;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Test/Odd.php';
+class_exists('Twig_Node_Expression_Test_Odd');
 
 if (\false) {
     class OddTest extends \Twig_Node_Expression_Test_Odd

--- a/src/Node/Expression/Test/SameasTest.php
+++ b/src/Node/Expression/Test/SameasTest.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Test;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Test/Sameas.php';
+class_exists('Twig_Node_Expression_Test_Sameas');
 
 if (\false) {
     class SameasTest extends \Twig_Node_Expression_Test_Sameas

--- a/src/Node/Expression/TestExpression.php
+++ b/src/Node/Expression/TestExpression.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression;
 
-require __DIR__.'/../../../lib/Twig/Node/Expression/Test.php';
+class_exists('Twig_Node_Expression_Test');
 
 if (\false) {
     class TestExpression extends \Twig_Node_Expression_Test

--- a/src/Node/Expression/Unary/AbstractUnary.php
+++ b/src/Node/Expression/Unary/AbstractUnary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Unary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Unary.php';
+class_exists('Twig_Node_Expression_Unary');
 
 if (\false) {
     class AbstractUnary extends \Twig_Node_Expression_Unary

--- a/src/Node/Expression/Unary/NegUnary.php
+++ b/src/Node/Expression/Unary/NegUnary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Unary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Unary/Neg.php';
+class_exists('Twig_Node_Expression_Unary_Neg');
 
 if (\false) {
     class NegUnary extends \Twig_Node_Expression_Unary_Neg

--- a/src/Node/Expression/Unary/NotUnary.php
+++ b/src/Node/Expression/Unary/NotUnary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Unary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Unary/Not.php';
+class_exists('Twig_Node_Expression_Unary_Not');
 
 if (\false) {
     class NotUnary extends \Twig_Node_Expression_Unary_Not

--- a/src/Node/Expression/Unary/PosUnary.php
+++ b/src/Node/Expression/Unary/PosUnary.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node\Expression\Unary;
 
-require __DIR__.'/../../../../lib/Twig/Node/Expression/Unary/Pos.php';
+class_exists('Twig_Node_Expression_Unary_Pos');
 
 if (\false) {
     class PosUnary extends \Twig_Node_Expression_Unary_Pos

--- a/src/Node/FlushNode.php
+++ b/src/Node/FlushNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Flush.php';
+class_exists('Twig_Node_Flush');
 
 if (\false) {
     class FlushNode extends \Twig_Node_Flush

--- a/src/Node/ForLoopNode.php
+++ b/src/Node/ForLoopNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/ForLoop.php';
+class_exists('Twig_Node_ForLoop');
 
 if (\false) {
     class ForLoopNode extends \Twig_Node_ForLoop

--- a/src/Node/ForNode.php
+++ b/src/Node/ForNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/For.php';
+class_exists('Twig_Node_For');
 
 if (\false) {
     class ForNode extends \Twig_Node_For

--- a/src/Node/IfNode.php
+++ b/src/Node/IfNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/If.php';
+class_exists('Twig_Node_If');
 
 if (\false) {
     class IfNode extends \Twig_Node_If

--- a/src/Node/ImportNode.php
+++ b/src/Node/ImportNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Import.php';
+class_exists('Twig_Node_Import');
 
 if (\false) {
     class ImportNode extends \Twig_Node_Import

--- a/src/Node/IncludeNode.php
+++ b/src/Node/IncludeNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Include.php';
+class_exists('Twig_Node_Include');
 
 if (\false) {
     class IncludeNode extends \Twig_Node_Include

--- a/src/Node/MacroNode.php
+++ b/src/Node/MacroNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Macro.php';
+class_exists('Twig_Node_Macro');
 
 if (\false) {
     class MacroNode extends \Twig_Node_Macro

--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Module.php';
+class_exists('Twig_Node_Module');
 
 if (\false) {
     class ModuleNode extends \Twig_Node_Module

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node.php';
+class_exists('Twig_Node');
 
 if (\false) {
     class Node extends \Twig_Node

--- a/src/Node/PrintNode.php
+++ b/src/Node/PrintNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Print.php';
+class_exists('Twig_Node_Print');
 
 if (\false) {
     class PrintNode extends \Twig_Node_Print

--- a/src/Node/SandboxNode.php
+++ b/src/Node/SandboxNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Sandbox.php';
+class_exists('Twig_Node_Sandbox');
 
 if (\false) {
     class SandboxNode extends \Twig_Node_Sandbox

--- a/src/Node/SandboxedPrintNode.php
+++ b/src/Node/SandboxedPrintNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/SandboxedPrint.php';
+class_exists('Twig_Node_SandboxedPrint');
 
 if (\false) {
     class SandboxedPrintNode extends \Twig_Node_SandboxedPrint

--- a/src/Node/SetNode.php
+++ b/src/Node/SetNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Set.php';
+class_exists('Twig_Node_Set');
 
 if (\false) {
     class SetNode extends \Twig_Node_Set

--- a/src/Node/SetTempNode.php
+++ b/src/Node/SetTempNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/SetTemp.php';
+class_exists('Twig_Node_SetTemp');
 
 if (\false) {
     class SetTempNode extends \Twig_Node_SetTemp

--- a/src/Node/SpacelessNode.php
+++ b/src/Node/SpacelessNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Spaceless.php';
+class_exists('Twig_Node_Spaceless');
 
 if (\false) {
     class SpacelessNode extends \Twig_Node_Spaceless

--- a/src/Node/TextNode.php
+++ b/src/Node/TextNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/Text.php';
+class_exists('Twig_Node_Text');
 
 if (\false) {
     class TextNode extends \Twig_Node_Text

--- a/src/Node/WithNode.php
+++ b/src/Node/WithNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Node;
 
-require __DIR__.'/../../lib/Twig/Node/With.php';
+class_exists('Twig_Node_With');
 
 if (\false) {
     class WithNode extends \Twig_Node_With

--- a/src/NodeTraverser.php
+++ b/src/NodeTraverser.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/NodeTraverser.php';
+class_exists('Twig_NodeTraverser');
 
 if (\false) {
     class NodeTraverser extends \Twig_NodeTraverser

--- a/src/NodeVisitor/AbstractNodeVisitor.php
+++ b/src/NodeVisitor/AbstractNodeVisitor.php
@@ -2,7 +2,7 @@
 
 namespace Twig\NodeVisitor;
 
-require __DIR__.'/../../lib/Twig/BaseNodeVisitor.php';
+class_exists('Twig_BaseNodeVisitor');
 
 if (\false) {
     class AbstractNodeVisitor extends \Twig_BaseNodeVisitor

--- a/src/NodeVisitor/EscaperNodeVisitor.php
+++ b/src/NodeVisitor/EscaperNodeVisitor.php
@@ -2,7 +2,7 @@
 
 namespace Twig\NodeVisitor;
 
-require __DIR__.'/../../lib/Twig/NodeVisitor/Escaper.php';
+class_exists('Twig_NodeVisitor_Escaper');
 
 if (\false) {
     class EscaperNodeVisitor extends \Twig_NodeVisitor_Escaper

--- a/src/NodeVisitor/OptimizerNodeVisitor.php
+++ b/src/NodeVisitor/OptimizerNodeVisitor.php
@@ -2,7 +2,7 @@
 
 namespace Twig\NodeVisitor;
 
-require __DIR__.'/../../lib/Twig/NodeVisitor/Optimizer.php';
+class_exists('Twig_NodeVisitor_Optimizer');
 
 if (\false) {
     class OptimizerNodeVisitor extends \Twig_NodeVisitor_Optimizer

--- a/src/NodeVisitor/SafeAnalysisNodeVisitor.php
+++ b/src/NodeVisitor/SafeAnalysisNodeVisitor.php
@@ -2,7 +2,7 @@
 
 namespace Twig\NodeVisitor;
 
-require __DIR__.'/../../lib/Twig/NodeVisitor/SafeAnalysis.php';
+class_exists('Twig_NodeVisitor_SafeAnalysis');
 
 if (\false) {
     class SafeAnalysisNodeVisitor extends \Twig_NodeVisitor_SafeAnalysis

--- a/src/NodeVisitor/SandboxNodeVisitor.php
+++ b/src/NodeVisitor/SandboxNodeVisitor.php
@@ -2,7 +2,7 @@
 
 namespace Twig\NodeVisitor;
 
-require __DIR__.'/../../lib/Twig/NodeVisitor/Sandbox.php';
+class_exists('Twig_NodeVisitor_Sandbox');
 
 if (\false) {
     class SandboxNodeVisitor extends \Twig_NodeVisitor_Sandbox

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/Parser.php';
+class_exists('Twig_Parser');
 
 if (\false) {
     class Parser extends \Twig_Parser

--- a/src/Profiler/Dumper/BlackfireDumper.php
+++ b/src/Profiler/Dumper/BlackfireDumper.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Profiler\Dumper;
 
-require __DIR__.'/../../../lib/Twig/Profiler/Dumper/Blackfire.php';
+class_exists('Twig_Profiler_Dumper_Blackfire');
 
 if (\false) {
     class BlackfireDumper extends \Twig_Profiler_Dumper_Blackfire

--- a/src/Profiler/Dumper/HtmlDumper.php
+++ b/src/Profiler/Dumper/HtmlDumper.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Profiler\Dumper;
 
-require __DIR__.'/../../../lib/Twig/Profiler/Dumper/Html.php';
+class_exists('Twig_Profiler_Dumper_Html');
 
 if (\false) {
     class HtmlDumper extends \Twig_Profiler_Dumper_Html

--- a/src/Profiler/Dumper/TextDumper.php
+++ b/src/Profiler/Dumper/TextDumper.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Profiler\Dumper;
 
-require __DIR__.'/../../../lib/Twig/Profiler/Dumper/Text.php';
+class_exists('Twig_Profiler_Dumper_Text');
 
 if (\false) {
     class TextDumper extends \Twig_Profiler_Dumper_Text

--- a/src/Profiler/Node/EnterProfileNode.php
+++ b/src/Profiler/Node/EnterProfileNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Profiler\Node;
 
-require __DIR__.'/../../../lib/Twig/Profiler/Node/EnterProfile.php';
+class_exists('Twig_Profiler_Node_EnterProfile');
 
 if (\false) {
     class EnterProfileNode extends \Twig_Profiler_Node_EnterProfile

--- a/src/Profiler/Node/LeaveProfileNode.php
+++ b/src/Profiler/Node/LeaveProfileNode.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Profiler\Node;
 
-require __DIR__.'/../../../lib/Twig/Profiler/Node/LeaveProfile.php';
+class_exists('Twig_Profiler_Node_LeaveProfile');
 
 if (\false) {
     class LeaveProfileNode extends \Twig_Profiler_Node_LeaveProfile

--- a/src/Profiler/NodeVisitor/ProfilerNodeVisitor.php
+++ b/src/Profiler/NodeVisitor/ProfilerNodeVisitor.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Profiler\NodeVisitor;
 
-require __DIR__.'/../../../lib/Twig/Profiler/NodeVisitor/Profiler.php';
+class_exists('Twig_Profiler_NodeVisitor_Profiler');
 
 if (\false) {
     class ProfilerNodeVisitor extends \Twig_Profiler_NodeVisitor_Profiler

--- a/src/Profiler/Profile.php
+++ b/src/Profiler/Profile.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Profiler;
 
-require __DIR__.'/../../lib/Twig/Profiler/Profile.php';
+class_exists('Twig_Profiler_Profile');
 
 if (\false) {
     class Profile extends \Twig_Profiler_Profile

--- a/src/RuntimeLoader/ContainerRuntimeLoader.php
+++ b/src/RuntimeLoader/ContainerRuntimeLoader.php
@@ -2,7 +2,7 @@
 
 namespace Twig\RuntimeLoader;
 
-require __DIR__.'/../../lib/Twig/ContainerRuntimeLoader.php';
+class_exists('Twig_ContainerRuntimeLoader');
 
 if (\false) {
     class ContainerRuntimeLoader extends \Twig_ContainerRuntimeLoader

--- a/src/RuntimeLoader/FactoryRuntimeLoader.php
+++ b/src/RuntimeLoader/FactoryRuntimeLoader.php
@@ -2,7 +2,7 @@
 
 namespace Twig\RuntimeLoader;
 
-require __DIR__.'/../../lib/Twig/FactoryRuntimeLoader.php';
+class_exists('Twig_FactoryRuntimeLoader');
 
 if (\false) {
     class FactoryRuntimeLoader extends \Twig_FactoryRuntimeLoader

--- a/src/Sandbox/SecurityError.php
+++ b/src/Sandbox/SecurityError.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Sandbox;
 
-require __DIR__.'/../../lib/Twig/Sandbox/SecurityError.php';
+class_exists('Twig_Sandbox_SecurityError');
 
 if (\false) {
     class SecurityError extends \Twig_Sandbox_SecurityError

--- a/src/Sandbox/SecurityNotAllowedFilterError.php
+++ b/src/Sandbox/SecurityNotAllowedFilterError.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Sandbox;
 
-require __DIR__.'/../../lib/Twig/Sandbox/SecurityNotAllowedFilterError.php';
+class_exists('Twig_Sandbox_SecurityNotAllowedFilterError');
 
 if (\false) {
     class SecurityNotAllowedFilterError extends \Twig_Sandbox_SecurityNotAllowedFilterError

--- a/src/Sandbox/SecurityNotAllowedFunctionError.php
+++ b/src/Sandbox/SecurityNotAllowedFunctionError.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Sandbox;
 
-require __DIR__.'/../../lib/Twig/Sandbox/SecurityNotAllowedFunctionError.php';
+class_exists('Twig_Sandbox_SecurityNotAllowedFunctionError');
 
 if (\false) {
     class SecurityNotAllowedFunctionError extends \Twig_Sandbox_SecurityNotAllowedFunctionError

--- a/src/Sandbox/SecurityNotAllowedMethodError.php
+++ b/src/Sandbox/SecurityNotAllowedMethodError.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Sandbox;
 
-require __DIR__.'/../../lib/Twig/Sandbox/SecurityNotAllowedMethodError.php';
+class_exists('Twig_Sandbox_SecurityNotAllowedMethodError');
 
 if (\false) {
     class SecurityNotAllowedMethodError extends \Twig_Sandbox_SecurityNotAllowedMethodError

--- a/src/Sandbox/SecurityNotAllowedPropertyError.php
+++ b/src/Sandbox/SecurityNotAllowedPropertyError.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Sandbox;
 
-require __DIR__.'/../../lib/Twig/Sandbox/SecurityNotAllowedPropertyError.php';
+class_exists('Twig_Sandbox_SecurityNotAllowedPropertyError');
 
 if (\false) {
     class SecurityNotAllowedPropertyError extends \Twig_Sandbox_SecurityNotAllowedPropertyError

--- a/src/Sandbox/SecurityNotAllowedTagError.php
+++ b/src/Sandbox/SecurityNotAllowedTagError.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Sandbox;
 
-require __DIR__.'/../../lib/Twig/Sandbox/SecurityNotAllowedTagError.php';
+class_exists('Twig_Sandbox_SecurityNotAllowedTagError');
 
 if (\false) {
     class SecurityNotAllowedTagError extends \Twig_Sandbox_SecurityNotAllowedTagError

--- a/src/Sandbox/SecurityPolicy.php
+++ b/src/Sandbox/SecurityPolicy.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Sandbox;
 
-require __DIR__.'/../../lib/Twig/Sandbox/SecurityPolicy.php';
+class_exists('Twig_Sandbox_SecurityPolicy');
 
 if (\false) {
     class SecurityPolicy extends \Twig_Sandbox_SecurityPolicy

--- a/src/Source.php
+++ b/src/Source.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/Source.php';
+class_exists('Twig_Source');
 
 if (\false) {
     class Source extends \Twig_Source

--- a/src/Template.php
+++ b/src/Template.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/Template.php';
+class_exists('Twig_Template');
 
 if (\false) {
     class Template extends \Twig_Template

--- a/src/TemplateWrapper.php
+++ b/src/TemplateWrapper.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/TemplateWrapper.php';
+class_exists('Twig_TemplateWrapper');
 
 if (\false) {
     class TemplateWrapper extends \Twig_TemplateWrapper

--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Test;
 
-require __DIR__.'/../../lib/Twig/Test/IntegrationTestCase.php';
+class_exists('Twig_Test_IntegrationTestCase');
 
 if (\false) {
     class IntegrationTestCase extends \Twig_Test_IntegrationTestCase

--- a/src/Test/NodeTestCase.php
+++ b/src/Test/NodeTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Test;
 
-require __DIR__.'/../../lib/Twig/Test/NodeTestCase.php';
+class_exists('Twig_Test_NodeTestCase');
 
 if (\false) {
     class NodeTestCase extends \Twig_Test_NodeTestCase

--- a/src/Token.php
+++ b/src/Token.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/Token.php';
+class_exists('Twig_Token');
 
 if (\false) {
     class Token extends \Twig_Token

--- a/src/TokenParser/AbstractTokenParser.php
+++ b/src/TokenParser/AbstractTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser.php';
+class_exists('Twig_TokenParser');
 
 if (\false) {
     class AbstractTokenParser extends \Twig_TokenParser

--- a/src/TokenParser/AutoEscapeTokenParser.php
+++ b/src/TokenParser/AutoEscapeTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/AutoEscape.php';
+class_exists('Twig_TokenParser_AutoEscape');
 
 if (\false) {
     class AutoEscapeTokenParser extends \Twig_TokenParser_AutoEscape

--- a/src/TokenParser/BlockTokenParser.php
+++ b/src/TokenParser/BlockTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Block.php';
+class_exists('Twig_TokenParser_Block');
 
 if (\false) {
     class BlockTokenParser extends \Twig_TokenParser_Block

--- a/src/TokenParser/DoTokenParser.php
+++ b/src/TokenParser/DoTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Do.php';
+class_exists('Twig_TokenParser_Do');
 
 if (\false) {
     class DoTokenParser extends \Twig_TokenParser_Do

--- a/src/TokenParser/EmbedTokenParser.php
+++ b/src/TokenParser/EmbedTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Embed.php';
+class_exists('Twig_TokenParser_Embed');
 
 if (\false) {
     class EmbedTokenParser extends \Twig_TokenParser_Embed

--- a/src/TokenParser/ExtendsTokenParser.php
+++ b/src/TokenParser/ExtendsTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Extends.php';
+class_exists('Twig_TokenParser_Extends');
 
 if (\false) {
     class ExtendsTokenParser extends \Twig_TokenParser_Extends

--- a/src/TokenParser/FilterTokenParser.php
+++ b/src/TokenParser/FilterTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Filter.php';
+class_exists('Twig_TokenParser_Filter');
 
 if (\false) {
     class FilterTokenParser extends \Twig_TokenParser_Filter

--- a/src/TokenParser/FlushTokenParser.php
+++ b/src/TokenParser/FlushTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Flush.php';
+class_exists('Twig_TokenParser_Flush');
 
 if (\false) {
     class FlushTokenParser extends \Twig_TokenParser_Flush

--- a/src/TokenParser/ForTokenParser.php
+++ b/src/TokenParser/ForTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/For.php';
+class_exists('Twig_TokenParser_For');
 
 if (\false) {
     class ForTokenParser extends \Twig_TokenParser_For

--- a/src/TokenParser/FromTokenParser.php
+++ b/src/TokenParser/FromTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/From.php';
+class_exists('Twig_TokenParser_From');
 
 if (\false) {
     class FromTokenParser extends \Twig_TokenParser_From

--- a/src/TokenParser/IfTokenParser.php
+++ b/src/TokenParser/IfTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/If.php';
+class_exists('Twig_TokenParser_If');
 
 if (\false) {
     class IfTokenParser extends \Twig_TokenParser_If

--- a/src/TokenParser/ImportTokenParser.php
+++ b/src/TokenParser/ImportTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Import.php';
+class_exists('Twig_TokenParser_Import');
 
 if (\false) {
     class ImportTokenParser extends \Twig_TokenParser_Import

--- a/src/TokenParser/IncludeTokenParser.php
+++ b/src/TokenParser/IncludeTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Include.php';
+class_exists('Twig_TokenParser_Include');
 
 if (\false) {
     class IncludeTokenParser extends \Twig_TokenParser_Include

--- a/src/TokenParser/MacroTokenParser.php
+++ b/src/TokenParser/MacroTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Macro.php';
+class_exists('Twig_TokenParser_Macro');
 
 if (\false) {
     class MacroTokenParser extends \Twig_TokenParser_Macro

--- a/src/TokenParser/SandboxTokenParser.php
+++ b/src/TokenParser/SandboxTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Sandbox.php';
+class_exists('Twig_TokenParser_Sandbox');
 
 if (\false) {
     class SandboxTokenParser extends \Twig_TokenParser_Sandbox

--- a/src/TokenParser/SetTokenParser.php
+++ b/src/TokenParser/SetTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Set.php';
+class_exists('Twig_TokenParser_Set');
 
 if (\false) {
     class SetTokenParser extends \Twig_TokenParser_Set

--- a/src/TokenParser/SpacelessTokenParser.php
+++ b/src/TokenParser/SpacelessTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Spaceless.php';
+class_exists('Twig_TokenParser_Spaceless');
 
 if (\false) {
     class SpacelessTokenParser extends \Twig_TokenParser_Spaceless

--- a/src/TokenParser/UseTokenParser.php
+++ b/src/TokenParser/UseTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/Use.php';
+class_exists('Twig_TokenParser_Use');
 
 if (\false) {
     class UseTokenParser extends \Twig_TokenParser_Use

--- a/src/TokenParser/WithTokenParser.php
+++ b/src/TokenParser/WithTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Twig\TokenParser;
 
-require __DIR__.'/../../lib/Twig/TokenParser/With.php';
+class_exists('Twig_TokenParser_With');
 
 if (\false) {
     class WithTokenParser extends \Twig_TokenParser_With

--- a/src/TokenStream.php
+++ b/src/TokenStream.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/TokenStream.php';
+class_exists('Twig_TokenStream');
 
 if (\false) {
     class TokenStream extends \Twig_TokenStream

--- a/src/TwigFilter.php
+++ b/src/TwigFilter.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/SimpleFilter.php';
+class_exists('Twig_SimpleFilter');
 
 if (\false) {
     class TwigFilter extends \Twig_SimpleFilter

--- a/src/TwigFunction.php
+++ b/src/TwigFunction.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/SimpleFunction.php';
+class_exists('Twig_SimpleFunction');
 
 if (\false) {
     class TwigFunction extends \Twig_SimpleFunction

--- a/src/TwigTest.php
+++ b/src/TwigTest.php
@@ -2,7 +2,7 @@
 
 namespace Twig;
 
-require __DIR__.'/../lib/Twig/SimpleTest.php';
+class_exists('Twig_SimpleTest');
 
 if (\false) {
     class TwigTest extends \Twig_SimpleTest

--- a/src/Util/DeprecationCollector.php
+++ b/src/Util/DeprecationCollector.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Util;
 
-require __DIR__.'/../../lib/Twig/Util/DeprecationCollector.php';
+class_exists('Twig_Util_DeprecationCollector');
 
 if (\false) {
     class DeprecationCollector extends \Twig_Util_DeprecationCollector

--- a/src/Util/TemplateDirIterator.php
+++ b/src/Util/TemplateDirIterator.php
@@ -2,7 +2,7 @@
 
 namespace Twig\Util;
 
-require __DIR__.'/../../lib/Twig/Util/TemplateDirIterator.php';
+class_exists('Twig_Util_TemplateDirIterator');
 
 if (\false) {
     class TemplateDirIterator extends \Twig_Util_TemplateDirIterator


### PR DESCRIPTION
I think this is required for https://github.com/symfony/symfony/pull/23073 to pass. It's probably very similar to https://github.com/symfony/symfony/pull/22657.

A simple reproducer:

```php
<?php

use Twig\Node\Node;

require_once __DIR__ . '/vendor/autoload.php';

new Node();
new \Twig_Node();
```

[Without this patch](https://travis-ci.org/symfony/symfony/jobs/239712676#L2100):

```php
PHP Fatal error:  Cannot declare class Twig_Node, because the name is already in use in vendor/twig/twig/lib/Twig/Node.php on line 20
```

With, everything works fine, whatever the two calls order.