### PR TITLE
Add support for runtime loaders to IntegrationTestCase

### DIFF
--- a/lib/Twig/Test/IntegrationTestCase.php
+++ b/lib/Twig/Test/IntegrationTestCase.php
@@ -25,6 +25,14 @@ abstract class Twig_Test_IntegrationTestCase extends TestCase
     abstract protected function getFixturesDir();
 
     /**
+     * @return Twig_RuntimeLoaderInterface[]
+     */
+    protected function getRuntimeLoaders()
+    {
+        return array();
+    }
+
+    /**
      * @return Twig_ExtensionInterface[]
      */
     protected function getExtensions()
@@ -143,6 +151,10 @@ abstract class Twig_Test_IntegrationTestCase extends TestCase
             ), $match[2] ? eval($match[2].';') : array());
             $twig = new Twig_Environment($loader, $config);
             $twig->addGlobal('global', 'global');
+            foreach ($this->getRuntimeLoaders() as $runtimeLoader) {
+                $twig->addRuntimeLoader($runtimeLoader);
+            }
+
             foreach ($this->getExtensions() as $extension) {
                 $twig->addExtension($extension);
             }


### PR DESCRIPTION
Adds the ability to provide runtime loaders in `IntegrationTestCase`. Otherwise, there's no way to test extensions that use them.

Fixes #2492