### PR TITLE
Support ArrayAccess in containment operator

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -716,7 +716,7 @@ It returns ``true`` if the left operand is contained in the right:
 .. tip::
 
     You can use this filter to perform a containment test on strings, arrays,
-    or objects implementing the ``Traversable`` interface.
+    or objects implementing the ``ArrayAccess` or ``Traversable`` interfaces.
 
 To perform a negative test, use the ``not in`` operator:
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -831,6 +831,8 @@ function twig_in_filter($value, $compare)
         return in_array($value, $compare, is_object($value) || is_resource($value));
     } elseif (is_string($compare) && (is_string($value) || is_int($value) || is_float($value))) {
         return '' === $value || false !== strpos($compare, (string) $value);
+    } elseif ($compare instanceof ArrayAccess) {
+        return $compare->offsetExists($value);
     } elseif ($compare instanceof Traversable) {
         if (is_object($value) || is_resource($value)) {
             foreach ($compare as $item) {

--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -227,6 +227,8 @@ class Twig_Tests_Extension_CoreTest extends PHPUnit_Framework_TestCase
             array(false, 4, new CoreTestIteratorAggregateAggregate($array, $keys, true)),
             array(false, 1, 1),
             array(true, 'b', new SimpleXMLElement('<xml><a>b</a></xml>')),
+            array(true, 'foo', new ArrayObject(array('foo' => 'bar'))),
+            array(false, 'baz', new ArrayObject(array('foo' => 'bar'))),
         );
     }
 


### PR DESCRIPTION
`ArrayAccess` could easily be supported via its `offsetExists` method.

It is important `ArrayAccess` to be checked before `Traversable`, because it is common objects to implement both interfaces, but `ArrayAccess` may be implemented without the need of traversing.