### PR TITLE
Throw exception on circular reference detection

### DIFF
--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -480,6 +480,33 @@ EOF
         $this->assertEquals('foo', $twig->render('func_string_named_args'));
     }
 
+    /**
+     * @expectedException Twig_Error_Runtime
+     * @expectedExceptionMessage Circular reference detected for Twig template "base.html.twig", path: base.html.twig -> base.html.twig in "base.html.twig" at line 1
+     */
+    public function testFailLoadTemplateOnCircularReference()
+    {
+        $twig = new Twig_Environment(new Twig_Loader_Array(array(
+            'base.html.twig' => '{% extends "base.html.twig" %}',
+        )));
+
+        $twig->loadTemplate('base.html.twig');
+    }
+
+    /**
+     * @expectedException Twig_Error_Runtime
+     * @expectedExceptionMessage Circular reference detected for Twig template "base1.html.twig", path: base1.html.twig -> base2.html.twig -> base1.html.twig in "base1.html.twig" at line 1
+     */
+    public function testFailLoadTemplateOnComplexCircularReference()
+    {
+        $twig = new Twig_Environment(new Twig_Loader_Array(array(
+            'base1.html.twig' => '{% extends "base2.html.twig" %}',
+            'base2.html.twig' => '{% extends "base1.html.twig" %}',
+        )));
+
+        $twig->loadTemplate('base1.html.twig');
+    }
+
     protected function getMockLoader($templateName, $templateContent)
     {
         // to be removed in 2.0


### PR DESCRIPTION
Out-the-box this isn't common... but into Symfony framework this kind of issue can happen frequently when we're overriding a template from third-party bundle (see main issue https://github.com/symfony/symfony/issues/17557)

```twig
{# app/Resources/AcmeBlogBundle/views/Blog/index.html.twig #}
{% extends '@AcmeBlog/Blog/index.html.twig' %}
    
{% block title 'New Title' %}
```

This exception avoids inifite loop or maximum execution time for this case, by detecting a recursive loading when a template extends from itself, thinking to override the parent template which has the same namespace + template name.