### PR TITLE
Check if Twig_SimpleFunction or Twig\TwigFunction exist before executing class_alias

### DIFF
--- a/lib/Twig/Function.php
+++ b/lib/Twig/Function.php
@@ -127,12 +127,10 @@ class Twig_Function
 }
 
 // For Twig 1.x compatibility
-if (!class_exists('Twig_SimpleFunction')) 
-{
+if (!class_exists('Twig_SimpleFunction')) {
     class_alias('Twig_Function', 'Twig_SimpleFunction', false);
 }
 
-if (!class_exists('Twig\TwigFunction')) 
-{
+if (!class_exists('Twig\TwigFunction')) {
     class_alias('Twig_Function', 'Twig\TwigFunction', false);
 }

--- a/lib/Twig/Function.php
+++ b/lib/Twig/Function.php
@@ -127,6 +127,12 @@ class Twig_Function
 }
 
 // For Twig 1.x compatibility
-class_alias('Twig_Function', 'Twig_SimpleFunction', false);
+if (!class_exists('Twig_SimpleFunction')) 
+{
+    class_alias('Twig_Function', 'Twig_SimpleFunction', false);
+}
 
-class_alias('Twig_Function', 'Twig\TwigFunction', false);
+if (!class_exists('Twig\TwigFunction')) 
+{
+    class_alias('Twig_Function', 'Twig\TwigFunction', false);
+}


### PR DESCRIPTION
I was getting a PHP warning on my Wordpress project (using [Timber](https://github.com/timber/timber), with Twig 2.4.3), stating that `Twig_SimpleFunction` was already defined in `lib/Twig/Functions.php`, which was weird, because none of the projects tries to define that class (I did full search on the code). Anyway, it was like that file was being required two times, or something, I don't know.

Do you think this might be a Twig problem?

So, I went to the file and before doing `class_alias`, I first check if each of the two functions is already defined using `class_exists`. Doing that fully fixed the error.
Please check if this change is pertinent to the project.

Thank you

## Update
Just figured out what was causing the problem. The WPML Wordpress plugin also uses the Twig engine (version 1.33.2), and at the same time I was running the latest version of Timber, which uses Twig 2.*. So naturally `Twig_SimpleFunction` is declared in WPML, and at the same time Twig 2.* uses `class_alias` to enable the usage of `Twig_SimpleFunction`, which causes the warning.