### PR TITLE
Ensure that the "use" TokenParser returns a node instance

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.35.0 (2017-XX-XX)
 
+ * fixed use TokenParser to return an empty Node
  * added RuntimeExtensionInterface
  * added circular reference detection when loading templates
 

--- a/lib/Twig/TokenParser/Use.php
+++ b/lib/Twig/TokenParser/Use.php
@@ -57,6 +57,8 @@ class Twig_TokenParser_Use extends Twig_TokenParser
         $stream->expect(Twig_Token::BLOCK_END_TYPE);
 
         $this->parser->addTrait(new Twig_Node(array('template' => $template, 'targets' => new Twig_Node($targets))));
+
+        return new Twig_Node();
     }
 
     public function getTag()

--- a/test/Twig/Tests/Fixtures/tags/use/use_with_parent.test
+++ b/test/Twig/Tests/Fixtures/tags/use/use_with_parent.test
@@ -1,0 +1,24 @@
+--TEST--
+"use" tag with a parent block
+--TEMPLATE--
+{% extends "parent.twig" %}
+
+{% use 'blocks.twig' %}
+
+{% block body %}
+    {{ parent() -}}
+    CHILD
+    {{ block('content') }}
+{% endblock %}
+--TEMPLATE(parent.twig)--
+{% block body %}
+    PARENT
+{% endblock %}
+--TEMPLATE(blocks.twig)--
+{% block content 'BLOCK' %}
+--DATA--
+return array()
+--EXPECT--
+PARENT
+CHILD
+    BLOCK


### PR DESCRIPTION
Alternative to #2539, fixes #2538.