### PR TITLE
add throws tags doc block for Twig_Environment:load

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -309,6 +309,10 @@ class Twig_Environment
      *
      * @param string|Twig_TemplateWrapper|Twig_Template $name The template name
      *
+     * @throws Twig_Error_Loader  When the template cannot be found
+     * @throws Twig_Error_Runtime When a previously generated cache is corrupted
+     * @throws Twig_Error_Syntax  When an error occurred during compilation
+     *
      * @return Twig_TemplateWrapper
      */
     public function load($name)


### PR DESCRIPTION
On an internal project review we noticed that `\Twig_Environment::load` is not providing throw tags. As this method is just a proxy for `\Twig_Environment::loadTemplate` which itself is _internal_ we had some discussion around.

this PR provides same throw tags as _loadTemplate_. Maybe this helps to understand code usage