### PR TITLE
Added pssibility to reset the profiler

### DIFF
--- a/lib/Twig/Profiler/Profile.php
+++ b/lib/Twig/Profiler/Profile.php
@@ -145,6 +145,12 @@ class Twig_Profiler_Profile implements IteratorAggregate, Serializable
         );
     }
 
+    public function reset()
+    {
+        $this->starts = $this->ends = $this->profiles = array();
+        $this->enter();
+    }
+
     public function getIterator()
     {
         return new ArrayIterator($this->profiles);

--- a/test/Twig/Tests/Profiler/ProfileTest.php
+++ b/test/Twig/Tests/Profiler/ProfileTest.php
@@ -97,4 +97,14 @@ class Twig_Tests_Profiler_ProfileTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($profile1->getType(), $profile3->getType());
         $this->assertEquals($profile1->getName(), $profile3->getName());
     }
+
+    public function testReset()
+    {
+        $profile = new Twig_Profiler_Profile();
+        usleep(1);
+        $profile->leave();
+        $profile->reset();
+
+        $this->assertEquals(0, $profile->getDuration());
+    }
 }


### PR DESCRIPTION
In order to implement symfony/symfony#18244 properly, I needed the ability to reset a Twig profile.