### PR TITLE
Clarify replace documentation and example

### DIFF
--- a/doc/filters/replace.rst
+++ b/doc/filters/replace.rst
@@ -1,12 +1,11 @@
 ``replace``
 ===========
 
-The ``replace`` filter formats a given string by replacing the placeholders
-(placeholders are free-form):
+The ``replace`` filter formats a given string by replacing the occurences of the search string with the replacement string:
 
 .. code-block:: jinja
 
-    {{ "I like %this% and %that%."|replace({'%this%': foo, '%that%': "bar"}) }}
+    {{ "I like this and that."|replace({'this': foo, 'that': "bar"}) }}
 
     {# outputs I like foo and bar
        if the foo parameter equals to the foo string. #}


### PR DESCRIPTION
At a quick glance the description and example for the replace filter make it seem like the filter only replaces using a special %foo% syntax rather than working on any arbitrary search and replace. See some of the confusion here:

https://stackoverflow.com/questions/4943880/str-replace-in-twig

I tweaked the description of the filter to more closely match the PHP documentation's description of str_replace, and dropped the % formatting from the example.