### PR TITLE
Add JSON escape strategy

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 1.35.4 (2018-XX-XX)
 
- * n/a
+ * "js" filter now produces valid JSON
 
 * 1.35.3 (2018-03-20)
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1152,11 +1152,6 @@ function _twig_escape_js_callback($matches)
 {
     $char = $matches[0];
 
-    // \xHH
-    if (!isset($char[1])) {
-        return '\\x'.strtoupper(substr('00'.bin2hex($char), -2));
-    }
-
     // \uHHHH
     $char = twig_convert_encoding($char, 'UTF-16BE', 'UTF-8');
     $char = strtoupper(bin2hex($char));

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -61,7 +61,7 @@ class Twig_Tests_EnvironmentTest extends \PHPUnit\Framework\TestCase
         ));
 
         $this->assertEquals('foo&lt;br/ &gt; foo&lt;br/ &gt;', $twig->render('html', array('foo' => 'foo<br/ >')));
-        $this->assertEquals('foo\x3Cbr\x2F\x20\x3E foo\x3Cbr\x2F\x20\x3E', $twig->render('js', array('bar' => 'foo<br/ >')));
+        $this->assertEquals('foo\u003Cbr\u002F\u0020\u003E foo\u003Cbr\u002F\u0020\u003E', $twig->render('js', array('bar' => 'foo<br/ >')));
     }
 
     public function escapingStrategyCallback($name)

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -61,7 +61,7 @@ class Twig_Tests_EnvironmentTest extends \PHPUnit\Framework\TestCase
         ));
 
         $this->assertEquals('foo&lt;br/ &gt; foo&lt;br/ &gt;', $twig->render('html', array('foo' => 'foo<br/ >')));
-        $this->assertEquals('foo\u003Cbr\u002F\u0020\u003E foo\u003Cbr\u002F\u0020\u003E', $twig->render('js', array('bar' => 'foo<br/ >')));
+        $this->assertEquals('foo\u003Cbr\/\u0020\u003E foo\u003Cbr\/\u0020\u003E', $twig->render('js', array('bar' => 'foo<br/ >')));
     }
 
     public function escapingStrategyCallback($name)

--- a/test/Twig/Tests/Fixtures/autoescape/name.test
+++ b/test/Twig/Tests/Fixtures/autoescape/name.test
@@ -17,6 +17,6 @@ return array('br' => '<br />')
 return array('autoescape' => 'name')
 --EXPECT--
 &lt;br /&gt;
-\x3Cbr\x20\x2F\x3E
+\u003Cbr\u0020\u002F\u003E
 &lt;br /&gt;
 <br />

--- a/test/Twig/Tests/Fixtures/autoescape/name.test
+++ b/test/Twig/Tests/Fixtures/autoescape/name.test
@@ -17,6 +17,6 @@ return array('br' => '<br />')
 return array('autoescape' => 'name')
 --EXPECT--
 &lt;br /&gt;
-\u003Cbr\u0020\u002F\u003E
+\u003Cbr\u0020\/\u003E
 &lt;br /&gt;
 <br />

--- a/test/Twig/Tests/Fixtures/filters/escape_javascript.test
+++ b/test/Twig/Tests/Fixtures/filters/escape_javascript.test
@@ -5,4 +5,4 @@
 --DATA--
 return array()
 --EXPECT--
-\u00E9\x20\u265C\x20\uD834\uDF06
+\u00E9\u0020\u265C\u0020\uD834\uDF06

--- a/test/Twig/Tests/Fixtures/filters/force_escape.test
+++ b/test/Twig/Tests/Fixtures/filters/force_escape.test
@@ -14,5 +14,5 @@
 return array()
 --EXPECT--
     foo&lt;br /&gt;
-\u0020\u0020\u0020\u0020foo\u003Cbr\u0020\u002F\u003E\u000A
+\u0020\u0020\u0020\u0020foo\u003Cbr\u0020\/\u003E\n
         foo<br />

--- a/test/Twig/Tests/Fixtures/filters/force_escape.test
+++ b/test/Twig/Tests/Fixtures/filters/force_escape.test
@@ -14,5 +14,5 @@
 return array()
 --EXPECT--
     foo&lt;br /&gt;
-\x20\x20\x20\x20foo\x3Cbr\x20\x2F\x3E\x0A
+\u0020\u0020\u0020\u0020foo\u003Cbr\u0020\u002F\u003E\u000A
         foo<br />

--- a/test/Twig/Tests/Fixtures/tags/autoescape/functions.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/functions.test
@@ -80,4 +80,4 @@ unsafe_br()|escape
 autoescape js
 
 safe_br
-\x3Cbr\x20\x2F\x3E
+\u003Cbr\u0020\u002F\u003E

--- a/test/Twig/Tests/Fixtures/tags/autoescape/functions.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/functions.test
@@ -80,4 +80,4 @@ unsafe_br()|escape
 autoescape js
 
 safe_br
-\u003Cbr\u0020\u002F\u003E
+\u003Cbr\u0020\/\u003E

--- a/test/Twig/Tests/Fixtures/tags/autoescape/strategy.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/strategy.legacy.test
@@ -1,4 +1,4 @@
-  --TEST--
+--TEST--
 "autoescape" tag accepts an escaping strategy
 --TEMPLATE--
 {% autoescape true js %}{{ var }}{% endautoescape %}

--- a/test/Twig/Tests/Fixtures/tags/autoescape/strategy.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/strategy.legacy.test
@@ -7,5 +7,5 @@
 --DATA--
 return array('var' => '<br />"')
 --EXPECT--
-\u003Cbr\u0020\u002F\u003E\u0022
+\u003Cbr\u0020\/\u003E\u0022
 &lt;br /&gt;&quot;

--- a/test/Twig/Tests/Fixtures/tags/autoescape/strategy.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/strategy.legacy.test
@@ -1,4 +1,4 @@
---TEST--
+  --TEST--
 "autoescape" tag accepts an escaping strategy
 --TEMPLATE--
 {% autoescape true js %}{{ var }}{% endautoescape %}
@@ -7,5 +7,5 @@
 --DATA--
 return array('var' => '<br />"')
 --EXPECT--
-\x3Cbr\x20\x2F\x3E\x22
+\u003Cbr\u0020\u002F\u003E\u0022
 &lt;br /&gt;&quot;

--- a/test/Twig/Tests/Fixtures/tags/autoescape/strategy.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/strategy.test
@@ -7,5 +7,5 @@
 --DATA--
 return array('var' => '<br />"')
 --EXPECT--
-\x3Cbr\x20\x2F\x3E\x22
+\u003Cbr\u0020\u002F\u003E\u0022
 &lt;br /&gt;&quot;

--- a/test/Twig/Tests/Fixtures/tags/autoescape/strategy.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/strategy.test
@@ -7,5 +7,5 @@
 --DATA--
 return array('var' => '<br />"')
 --EXPECT--
-\u003Cbr\u0020\u002F\u003E\u0022
+\u003Cbr\u0020\/\u003E\u0022
 &lt;br /&gt;&quot;

--- a/test/Twig/Tests/Fixtures/tags/autoescape/type.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/type.test
@@ -44,15 +44,15 @@ return array('msg' => "<>\n'\"")
 
 1. autoescape 'html' |escape('js')
 
-<a onclick="alert(&quot;\u003C\u003E\u000A\u0027\u0022&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\n\u0027\u0022&quot;)"></a>
 
 2. autoescape 'html' |escape('js')
 
-<a onclick="alert(&quot;\u003C\u003E\u000A\u0027\u0022&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\n\u0027\u0022&quot;)"></a>
 
 3. autoescape 'js' |escape('js')
 
-<a onclick="alert(&quot;\u003C\u003E\u000A\u0027\u0022&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\n\u0027\u0022&quot;)"></a>
 
 4. no escape
 
@@ -61,9 +61,9 @@ return array('msg' => "<>\n'\"")
 
 5. |escape('js')|escape('html')
 
-<a onclick="alert(&quot;\u003C\u003E\u000A\u0027\u0022&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\n\u0027\u0022&quot;)"></a>
 
 6. autoescape 'html' |escape('js')|escape('html')
 
-<a onclick="alert(&quot;\u003C\u003E\u000A\u0027\u0022&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\n\u0027\u0022&quot;)"></a>
 

--- a/test/Twig/Tests/Fixtures/tags/autoescape/type.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/type.test
@@ -44,15 +44,15 @@ return array('msg' => "<>\n'\"")
 
 1. autoescape 'html' |escape('js')
 
-<a onclick="alert(&quot;\x3C\x3E\x0A\x27\x22&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\u000A\u0027\u0022&quot;)"></a>
 
 2. autoescape 'html' |escape('js')
 
-<a onclick="alert(&quot;\x3C\x3E\x0A\x27\x22&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\u000A\u0027\u0022&quot;)"></a>
 
 3. autoescape 'js' |escape('js')
 
-<a onclick="alert(&quot;\x3C\x3E\x0A\x27\x22&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\u000A\u0027\u0022&quot;)"></a>
 
 4. no escape
 
@@ -61,9 +61,9 @@ return array('msg' => "<>\n'\"")
 
 5. |escape('js')|escape('html')
 
-<a onclick="alert(&quot;\x3C\x3E\x0A\x27\x22&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\u000A\u0027\u0022&quot;)"></a>
 
 6. autoescape 'html' |escape('js')|escape('html')
 
-<a onclick="alert(&quot;\x3C\x3E\x0A\x27\x22&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\u000A\u0027\u0022&quot;)"></a>
 

--- a/test/Twig/Tests/escapingTest.php
+++ b/test/Twig/Tests/escapingTest.php
@@ -51,11 +51,11 @@ class Twig_Test_EscapingTest extends \PHPUnit\Framework\TestCase
 
     protected $jsSpecialChars = array(
         /* HTML special chars - escape without exception to hex */
-        '<' => '\\x3C',
-        '>' => '\\x3E',
-        '\'' => '\\x27',
-        '"' => '\\x22',
-        '&' => '\\x26',
+        '<' => '\\u003C',
+        '>' => '\\u003E',
+        '\'' => '\\u0027',
+        '"' => '\\u0022',
+        '&' => '\\u0026',
         /* Characters beyond ASCII value 255 to unicode escape */
         'Ā' => '\\u0100',
         /* Immune chars excluded */
@@ -70,12 +70,12 @@ class Twig_Test_EscapingTest extends \PHPUnit\Framework\TestCase
         '0' => '0',
         '9' => '9',
         /* Basic control characters and null */
-        "\r" => '\\x0D',
-        "\n" => '\\x0A',
-        "\t" => '\\x09',
-        "\0" => '\\x00',
+        "\r" => '\\u000D',
+        "\n" => '\\u000A',
+        "\t" => '\\u0009',
+        "\0" => '\\u0000',
         /* Encode spaces for quoteless attribute protection */
-        ' ' => '\\x20',
+        ' ' => '\\u0020',
     );
 
     protected $urlSpecialChars = array(

--- a/test/Twig/Tests/escapingTest.php
+++ b/test/Twig/Tests/escapingTest.php
@@ -56,8 +56,10 @@ class Twig_Test_EscapingTest extends \PHPUnit\Framework\TestCase
         '\'' => '\\u0027',
         '"' => '\\u0022',
         '&' => '\\u0026',
+        '/' => '\\/',
         /* Characters beyond ASCII value 255 to unicode escape */
         'Ā' => '\\u0100',
+        '😀' => '\\uD83D\\uDE00',
         /* Immune chars excluded */
         ',' => ',',
         '.' => '.',
@@ -70,9 +72,11 @@ class Twig_Test_EscapingTest extends \PHPUnit\Framework\TestCase
         '0' => '0',
         '9' => '9',
         /* Basic control characters and null */
-        "\r" => '\\u000D',
-        "\n" => '\\u000A',
-        "\t" => '\\u0009',
+        "\r" => '\r',
+        "\n" => '\n',
+        "\x08" => '\b',
+        "\t" => '\t',
+        "\x0C" => '\f',
         "\0" => '\\u0000',
         /* Encode spaces for quoteless attribute protection */
         ' ' => '\\u0020',


### PR DESCRIPTION
The `js` escape strategy used `\xNN`-style escape sequences. This is not allowed in JSON, only `\uNNNN` is allowed.

This PR adds a new escape strategy, `json` that is similar to `js` except that it does not use `\xNN` but uses `\uNNNN` instead.

I know that I can use `json_decode()`, but it came as a surprise to me that `escape('js')` did not work. You probably shouldn't be generating JSON structures in your templates, but sometimes it comes in handy. My use-case was generating a piece of [JSON-LD](https://json-ld.org).

A different approach that would perhaps be less confusing to users would be to change `js` to not use `\xNN`. This output is still valid JavaScript, it just uses two more bytes per occurrence. Let me know what you think.