### PR TITLE
Environment::resolveTemplate now accepts instances of TemplateWrapper

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -453,12 +453,12 @@ class Twig_Environment
     /**
      * Tries to load a template consecutively from an array.
      *
-     * Similar to loadTemplate() but it also accepts Twig_Template instances and an array
-     * of templates where each is tried to be loaded.
+     * Similar to loadTemplate() but it also accepts instances of Twig_Template and
+     * Twig_TemplateWrapper, and an array of templates where each is tried to be loaded.
      *
-     * @param string|Twig_Template|array $names A template or an array of templates to try consecutively
+     * @param string|Twig_Template|Twig_TemplateWrapper|array $names A template or an array of templates to try consecutively
      *
-     * @return Twig_Template
+     * @return Twig_Template|Twig_TemplateWrapper
      *
      * @throws Twig_Error_Loader When none of the templates can be found
      * @throws Twig_Error_Syntax When an error occurred during compilation
@@ -471,6 +471,10 @@ class Twig_Environment
 
         foreach ($names as $name) {
             if ($name instanceof Twig_Template) {
+                return $name;
+            }
+
+            if ($name instanceof Twig_TemplateWrapper) {
                 return $name;
             }
 


### PR DESCRIPTION
The [documentation on the include function](https://twig.symfony.com/doc/2.x/functions/include.html) states (on the template expression):
> And if the expression evaluates to a Twig_Template or a Twig_TemplateWrapper instance, Twig will use it directly […]

This is currently broken, as `twig_include` [relies on `resolveTemplate`](https://github.com/twigphp/Twig/blob/31b577863b5ae8d19e2cefd174e95a433f16491f/lib/Twig/Extension/Core.php#L1304), which doesn't handle instances of `TemplateWrapper`. This PR fixes that.

For the sake of completeness: the `include` tag doesn't have this problem, as it relies on the `loadTemplate` method of the `Template` class which _does_ handle this case.