### PR TITLE
Added Twig_Extension_WhiteSpaceCutter for cutting extra white spaces

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 2.4.5 (2017-XX-XX)
 
+ * added Twig_Extension_WhiteSpaceCutter
  * fixed Environment::resolveTemplate to accept instances of TemplateWrapper
 
 * 2.4.4 (2017-09-27)

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -130,6 +130,13 @@ The following options are available:
   (default to ``-1`` -- all optimizations are enabled; set it to ``0`` to
   disable).
 
+* ``skip_whitespaces`` *boolean*
+
+  If set to ``false``, Twig will remove all extra white spaces, carriage return
+  from the Twig files. All your dynamical data from the variables won't be affected.
+  This operation will be on twig files compilation stage and don't take any effect
+  on processing requests.
+
 Loaders
 -------
 

--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -94,6 +94,7 @@ class Twig_Environment
             'cache' => false,
             'auto_reload' => null,
             'optimizations' => -1,
+            'skip_whitespaces' => true,
         ), $options);
 
         $this->debug = (bool) $options['debug'];
@@ -107,6 +108,9 @@ class Twig_Environment
         $this->addExtension(new Twig_Extension_Core());
         $this->addExtension(new Twig_Extension_Escaper($options['autoescape']));
         $this->addExtension(new Twig_Extension_Optimizer($options['optimizations']));
+        if (!$options['skip_whitespaces']) {
+            $this->addExtension(new Twig_Extension_WhiteSpaceCutter());
+        }
     }
 
     /**

--- a/lib/Twig/Extension/WhiteSpaceCutter.php
+++ b/lib/Twig/Extension/WhiteSpaceCutter.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Reduce compiled twig display block by deleting all extra white spaces.
+ *
+ * @author Konstantin Kuklin <konstantin.kuklin@gmail.com>
+ */
+final class Twig_Extension_WhiteSpaceCutter extends Twig_Extension
+{
+    public function getNodeVisitors()
+    {
+        return array(new Twig_NodeVisitor_WhiteSpaceCutter());
+    }
+}
+
+class_alias('Twig_Extension_WhiteSpaceCutter', 'Twig\Extension\WhiteSpaceCutterExtension', false);

--- a/lib/Twig/NodeVisitor/WhiteSpaceCutter.php
+++ b/lib/Twig/NodeVisitor/WhiteSpaceCutter.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Twig_NodeVisitor_WhiteSpaceCutter find all Twig_Node_Text and cut extra white spaces.
+ *
+ * @author Konstantin Kuklin <konstantin.kuklin@gmail.com>
+ */
+final class Twig_NodeVisitor_WhiteSpaceCutter extends Twig_BaseNodeVisitor
+{
+    protected function doEnterNode(Twig_Node $node, Twig_Environment $env)
+    {
+        if (!$node instanceof \Twig_Node_Text) {
+            return $node;
+        }
+
+        $data = $node->getAttribute('data');
+        if (is_string($data) && strlen($data) > 1) {
+            $data = preg_replace('/\\s+/', ' ', $data);
+            $node->setAttribute('data', $data);
+        }
+
+        return $node;
+    }
+
+    protected function doLeaveNode(Twig_Node $node, Twig_Environment $env)
+    {
+        return $node;
+    }
+
+    public function getPriority()
+    {
+        return 0;
+    }
+}
+
+class_alias('Twig_NodeVisitor_WhiteSpaceCutter', 'Twig\NodeVisitor\WhiteSpaceCutterNodeVisitor', false);

--- a/test/Twig/Tests/NodeVisitor/WhiteSpaceCutterTest.php
+++ b/test/Twig/Tests/NodeVisitor/WhiteSpaceCutterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Twig_Tests_NodeVisitor_WhiteSpaceCutterTest test for Twig_NodeVisitor_WhiteSpaceCutter
+ *
+ * @author Konstantin Kuklin <konstantin.kuklin@gmail.com>
+ */
+class Twig_Tests_NodeVisitor_WhiteSpaceCutterTest extends \PHPUnit\Framework\TestCase
+{
+    public function testDisabledWhiteSpaceCutter()
+    {
+        $code = 'f o      o ';
+        $env = new Twig_Environment(
+            $this->getMockBuilder('Twig_LoaderInterface')->getMock(),
+            ['cache' => false, 'skip_whitespaces' => true]
+        );
+
+        $parsed = $env->parse($env->tokenize(new Twig_Source($code, 'index')));
+        $result = $this->getData($parsed);
+        self::assertEquals($code, $result);
+    }
+
+    public function dataProviderEnabledWhiteSpaceCutter()
+    {
+        return [
+            [' b a        r', ' b a r'],
+            [' b a        r ', ' b a r '],
+            ['b      a r', 'b a r'],
+            ['b      a r ', 'b a r '],
+            ["b\nar  ", 'b ar '],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderEnabledWhiteSpaceCutter
+     *
+     * @throws Twig_Error_Syntax
+     */
+    public function testEnabledWhiteSpaceCutter($input, $expected)
+    {
+        $env = new Twig_Environment(
+            $this->getMockBuilder('Twig_LoaderInterface')->getMock(),
+            ['cache' => false, 'skip_whitespaces' => false]
+        );
+
+        $parsed = $env->parse($env->tokenize(new Twig_Source($input, 'index')));
+        $result = $this->getData($parsed);
+
+        self::assertEquals($expected, $result);
+    }
+
+    private function getData($parsed)
+    {
+        $bodyNode = $parsed->getNode('body');
+        $textNode = $bodyNode->getNode(0);
+
+        return $textNode->getAttribute('data');
+    }
+}


### PR DESCRIPTION
This is analog of 'spaceless' block, but without ob_* overhead and with global state on\off for all twig files.
Will be useful  to economy traffic and increase loading speed on devices which connected to internet by slow channels like mobile phones.