### PR TITLE
Performance optimization

### DIFF
--- a/lib/Twig/Node/CheckSecurity.php
+++ b/lib/Twig/Node/CheckSecurity.php
@@ -56,7 +56,7 @@ class Twig_Node_CheckSecurity extends Twig_Node
             ->outdent()
             ->write("} catch (Twig_Sandbox_SecurityError \$e) {\n")
             ->indent()
-            ->write("\$e->setSourceContext(\$this->getSourceContext());\n\n")
+            ->write("\$e->setSourceContext(\$this->source);\n\n")
             ->write("if (\$e instanceof Twig_Sandbox_SecurityNotAllowedTagError && isset(\$tags[\$e->getTagName()])) {\n")
             ->indent()
             ->write("\$e->setTemplateLine(\$tags[\$e->getTagName()]);\n")

--- a/lib/Twig/Node/Expression/GetAttr.php
+++ b/lib/Twig/Node/Expression/GetAttr.php
@@ -23,7 +23,7 @@ class Twig_Node_Expression_GetAttr extends Twig_Node_Expression
 
     public function compile(Twig_Compiler $compiler)
     {
-        $compiler->raw('twig_get_attribute($this->env, $this->getSourceContext(), ');
+        $compiler->raw('twig_get_attribute($this->env, $this->source, ');
 
         if ($this->getAttribute('ignore_strict_check')) {
             $this->getNode('node')->setAttribute('ignore_strict_check', true);

--- a/lib/Twig/Node/Expression/Name.php
+++ b/lib/Twig/Node/Expression/Name.php
@@ -61,7 +61,7 @@ class Twig_Node_Expression_Name extends Twig_Node_Expression
                     ->string($name)
                     ->raw(' does not exist.\', ')
                     ->repr($this->lineno)
-                    ->raw(', $this->getSourceContext()); })()')
+                    ->raw(', $this->source); })()')
                     ->raw(')')
                 ;
             }

--- a/lib/Twig/Node/Module.php
+++ b/lib/Twig/Node/Module.php
@@ -80,16 +80,7 @@ class Twig_Node_Module extends Twig_Node
 
         $this->compileClassHeader($compiler);
 
-        if (
-            count($this->getNode('blocks'))
-            || count($this->getNode('traits'))
-            || !$this->hasNode('parent')
-            || $this->getNode('parent') instanceof Twig_Node_Expression_Constant
-            || count($this->getNode('constructor_start'))
-            || count($this->getNode('constructor_end'))
-        ) {
-            $this->compileConstructor($compiler);
-        }
+        $this->compileConstructor($compiler);
 
         $this->compileGetParent($compiler);
 
@@ -155,6 +146,7 @@ class Twig_Node_Module extends Twig_Node
             ->raw(sprintf(" extends %s\n", $compiler->getEnvironment()->getBaseTemplateClass()))
             ->write("{\n")
             ->indent()
+            ->write("private \$source;\n\n")
         ;
     }
 
@@ -165,6 +157,7 @@ class Twig_Node_Module extends Twig_Node
             ->indent()
             ->subcompile($this->getNode('constructor_start'))
             ->write("parent::__construct(\$env);\n\n")
+            ->write("\$this->source = \$this->getSourceContext();\n\n")
         ;
 
         // parent

--- a/lib/Twig/Test/NodeTestCase.php
+++ b/lib/Twig/Test/NodeTestCase.php
@@ -54,7 +54,7 @@ abstract class Twig_Test_NodeTestCase extends TestCase
 
     protected function getAttributeGetter()
     {
-        return 'twig_get_attribute($this->env, $this->getSourceContext(), ';
+        return 'twig_get_attribute($this->env, $this->source, ';
     }
 }
 

--- a/test/Twig/Tests/Node/Expression/NameTest.php
+++ b/test/Twig/Tests/Node/Expression/NameTest.php
@@ -27,7 +27,7 @@ class Twig_Tests_Node_Expression_NameTest extends Twig_Test_NodeTestCase
         $env = new Twig_Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock(), array('strict_variables' => true));
         $env1 = new Twig_Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock(), array('strict_variables' => false));
 
-        $output = '(isset($context["foo"]) || array_key_exists("foo", $context) ? $context["foo"] : (function () { throw new Twig_Error_Runtime(\'Variable "foo" does not exist.\', 1, $this->getSourceContext()); })())';
+        $output = '(isset($context["foo"]) || array_key_exists("foo", $context) ? $context["foo"] : (function () { throw new Twig_Error_Runtime(\'Variable "foo" does not exist.\', 1, $this->source); })())';
 
         return array(
             array($node, "// line 1\n".$output, $env),

--- a/test/Twig/Tests/Node/ModuleTest.php
+++ b/test/Twig/Tests/Node/ModuleTest.php
@@ -48,9 +48,13 @@ class Twig_Tests_Node_ModuleTest extends Twig_Test_NodeTestCase
 /* foo.twig */
 class __TwigTemplate_%x extends Twig_Template
 {
+    private \$source;
+
     public function __construct(Twig_Environment \$env)
     {
         parent::__construct(\$env);
+
+        \$this->source = \$this->getSourceContext();
 
         \$this->parent = false;
 
@@ -71,7 +75,7 @@ class __TwigTemplate_%x extends Twig_Template
 
     public function getDebugInfo()
     {
-        return array (  19 => 1,);
+        return array (  23 => 1,);
     }
 
     public function getSourceContext()
@@ -94,9 +98,13 @@ EOF
 /* foo.twig */
 class __TwigTemplate_%x extends Twig_Template
 {
+    private \$source;
+
     public function __construct(Twig_Environment \$env)
     {
         parent::__construct(\$env);
+
+        \$this->source = \$this->getSourceContext();
 
         // line 1
         \$this->parent = \$this->loadTemplate("layout.twig", "foo.twig", 1);
@@ -129,7 +137,7 @@ class __TwigTemplate_%x extends Twig_Template
 
     public function getDebugInfo()
     {
-        return array (  26 => 1,  24 => 2,  11 => 1,);
+        return array (  30 => 1,  28 => 2,  15 => 1,);
     }
 
     public function getSourceContext()
@@ -157,6 +165,18 @@ EOF
 /* foo.twig */
 class __TwigTemplate_%x extends Twig_Template
 {
+    private \$source;
+
+    public function __construct(Twig_Environment \$env)
+    {
+        parent::__construct(\$env);
+
+        \$this->source = \$this->getSourceContext();
+
+        \$this->blocks = array(
+        );
+    }
+
     protected function doGetParent(array \$context)
     {
         // line 2
@@ -183,7 +203,7 @@ class __TwigTemplate_%x extends Twig_Template
 
     public function getDebugInfo()
     {
-        return array (  17 => 2,  15 => 4,  9 => 2,);
+        return array (  29 => 2,  27 => 4,  21 => 2,);
     }
 
     public function getSourceContext()


### PR DESCRIPTION
This PR avoids calling `$this->getSourceContext()` whenever we call `twig_get_attribute()`. That saves one method call and one object creation.
