### PR TITLE
Optimized compilation for arrays when using a['b'] notation

### DIFF
--- a/lib/Twig/Node/Expression/GetAttr.php
+++ b/lib/Twig/Node/Expression/GetAttr.php
@@ -29,13 +29,16 @@ class Twig_Node_Expression_GetAttr extends Twig_Node_Expression
             && !$this->getAttribute('is_defined_test')
             && Twig_Template::ARRAY_CALL === $this->getAttribute('type')
         ) {
+            $var = '$'.$compiler->getVarName();
             $compiler
-                ->raw('(is_array(')
+                ->raw('(('.$var.' = ')
                 ->subcompile($this->getNode('node'))
+                ->raw(') && is_array(')
+                ->raw($var)
                 ->raw(') || ')
-                ->subcompile($this->getNode('node'))
+                ->raw($var)
                 ->raw(' instanceof ArrayAccess ? (')
-                ->subcompile($this->getNode('node'))
+                ->raw($var)
                 ->raw('[')
                 ->subcompile($this->getNode('attribute'))
                 ->raw('] ?? null) : null)')

--- a/test/Twig/Tests/Fixtures/expressions/array_non_strict.test
+++ b/test/Twig/Tests/Fixtures/expressions/array_non_strict.test
@@ -42,6 +42,8 @@ Twig supports array notation
 {{ array_access['a'] }}
 --DATA--
 return array('bar' => 'bar', 'foo' => array('bar' => 'bar'), 'array_access' => new ArrayObject(array('a' =>  'b')))
+--CONFIG--
+return array('strict_variables' => false)
 --EXPECT--
 1,2
 foo,bar

--- a/test/Twig/Tests/Node/Expression/GetAttrTest.php
+++ b/test/Twig/Tests/Node/Expression/GetAttrTest.php
@@ -37,7 +37,7 @@ class Twig_Tests_Node_Expression_GetAttrTest extends Twig_Test_NodeTestCase
         $tests[] = array($node, sprintf('%s%s, "bar", array())', $this->getAttributeGetter(), $this->getVariableGetter('foo', 1)));
 
         $node = new Twig_Node_Expression_GetAttr($expr, $attr, $args, Twig_Template::ARRAY_CALL, 1);
-        $tests[] = array($node, sprintf('%s%s, "bar", array(), "array")', $this->getAttributeGetter(), $this->getVariableGetter('foo', 1)));
+        $tests[] = array($node, sprintf('(is_array(%s) || ($context["foo"] ?? null) instanceof ArrayAccess ? (($context["foo"] ?? null)["bar"] ?? null) : null)', $this->getVariableGetter('foo', 1), $this->getVariableGetter('foo', 1)));
 
         $args = new Twig_Node_Expression_Array(array(), 1);
         $args->addElement(new Twig_Node_Expression_Name('foo', 1));

--- a/test/Twig/Tests/Node/Expression/GetAttrTest.php
+++ b/test/Twig/Tests/Node/Expression/GetAttrTest.php
@@ -37,7 +37,8 @@ class Twig_Tests_Node_Expression_GetAttrTest extends Twig_Test_NodeTestCase
         $tests[] = array($node, sprintf('%s%s, "bar", array())', $this->getAttributeGetter(), $this->getVariableGetter('foo', 1)));
 
         $node = new Twig_Node_Expression_GetAttr($expr, $attr, $args, Twig_Template::ARRAY_CALL, 1);
-        $tests[] = array($node, sprintf('(is_array(%s) || ($context["foo"] ?? null) instanceof ArrayAccess ? (($context["foo"] ?? null)["bar"] ?? null) : null)', $this->getVariableGetter('foo', 1), $this->getVariableGetter('foo', 1)));
+        $tests[] = array($node, '(($__internal_%s = // line 1'."\n".
+            '($context["foo"] ?? null)) && is_array($__internal_%s) || $__internal_%s instanceof ArrayAccess ? ($__internal_%s["bar"] ?? null) : null)', null, true);
 
         $args = new Twig_Node_Expression_Array(array(), 1);
         $args->addElement(new Twig_Node_Expression_Name('foo', 1));


### PR DESCRIPTION
Under certain conditions, and thanks to the `??` operator, it's possible to optimize array calls (and avoid the call to `twig_get_attribute()`).

On my local machine, code is almost twice as fast, which is nice if you are using a lot of `a["b"]` calls of nested ones.

refs #2547
