### PR TITLE
Make variable names deterministic

### DIFF
--- a/lib/Twig/Compiler.php
+++ b/lib/Twig/Compiler.php
@@ -25,6 +25,7 @@ class Twig_Compiler implements Twig_CompilerInterface
     protected $sourceOffset;
     protected $sourceLine;
     protected $filename;
+    private $varNameSalt = 0;
 
     public function __construct(Twig_Environment $env)
     {
@@ -78,6 +79,7 @@ class Twig_Compiler implements Twig_CompilerInterface
         // source code starts at 1 (as we then increment it when we encounter new lines)
         $this->sourceLine = 1;
         $this->indentation = $indentation;
+        $this->varNameSalt = 0;
 
         if ($node instanceof Twig_Node_Module) {
             // to be removed in 2.0
@@ -276,7 +278,7 @@ class Twig_Compiler implements Twig_CompilerInterface
 
     public function getVarName()
     {
-        return sprintf('__internal_%s', hash('sha256', uniqid(mt_rand(), true), false));
+        return sprintf('__internal_%s', hash('sha256', __METHOD__.$this->varNameSalt++));
     }
 }
 

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -31,6 +31,7 @@ class Twig_Parser implements Twig_ParserInterface
     protected $importedSymbols;
     protected $traits;
     protected $embeddedTemplates = array();
+    private $varNameSalt = 0;
 
     public function __construct(Twig_Environment $env)
     {
@@ -49,7 +50,7 @@ class Twig_Parser implements Twig_ParserInterface
 
     public function getVarName()
     {
-        return sprintf('__internal_%s', hash('sha256', uniqid(mt_rand(), true), false));
+        return sprintf('__internal_%s', hash('sha256', __METHOD__.$this->varNameSalt++));
     }
 
     /**
@@ -98,6 +99,7 @@ class Twig_Parser implements Twig_ParserInterface
         $this->blockStack = array();
         $this->importedSymbols = array(array());
         $this->embeddedTemplates = array();
+        $this->varNameSalt = 0;
 
         try {
             $body = $this->subparse($test, $dropNeedle);

--- a/lib/Twig/Profiler/NodeVisitor/Profiler.php
+++ b/lib/Twig/Profiler/NodeVisitor/Profiler.php
@@ -55,7 +55,7 @@ class Twig_Profiler_NodeVisitor_Profiler extends Twig_BaseNodeVisitor
 
     private function getVarName()
     {
-        return sprintf('__internal_%s', hash('sha256', uniqid(mt_rand(), true), false));
+        return sprintf('__internal_%s', hash('sha256', __METHOD__));
     }
 
     public function getPriority()


### PR DESCRIPTION
Variables should be deterministic to support reproducible builds as outlined in https://github.com/symfony/symfony/issues/25958