### PR TITLE
Switch the PHP ext jobs to a whitelist rather than a blacklist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ php:
 
 env:
     - TWIG_EXT=no
-    - TWIG_EXT=yes
 
 before_install:
     # turn off XDebug
@@ -47,12 +46,9 @@ matrix:
         - php: 5.3
           dist: precise
           env: TWIG_EXT=no
-    exclude:
-        - php: 7.0
+        - php: 5.4
           env: TWIG_EXT=yes
-        - php: 7.1
+        - php: 5.5
           env: TWIG_EXT=yes
-        - php: 7.2
-          env: TWIG_EXT=yes
-        - php: nightly
+        - php: 5.6
           env: TWIG_EXT=yes


### PR DESCRIPTION
Any new PHP version added in the future will be a PHP 7.x one, not a 5.x one, and so should not have a job for the extension.

the whitelist is already shorter than the blacklist today (3 whitelisted vs 4 blacklisted before, as PHP 5.3 is already handled separately due to precise anyway)