### PR TITLE
Include extensionName in the sha256 hash

### DIFF
--- a/lib/Twig/Profiler/NodeVisitor/Profiler.php
+++ b/lib/Twig/Profiler/NodeVisitor/Profiler.php
@@ -53,7 +53,7 @@ final class Twig_Profiler_NodeVisitor_Profiler extends Twig_BaseNodeVisitor
 
     private function getVarName()
     {
-        return sprintf('__internal_%s', hash('sha256', __METHOD__));
+        return sprintf('__internal_%s', hash('sha256', __METHOD__.$this->extensionName));
     }
 
     public function getPriority()


### PR DESCRIPTION
Proposed fix for #2627 and #2643 (same issue, same problem) implementing suggestion from @nieuwenhuisen at https://github.com/twigphp/Twig/issues/2627#issuecomment-370140438 which seems to resolve the issue

This issue was introduced with  6ab5fe9 of #2621 

After applying this PR for testing please remember to clear caches. 

The underlying issue is that Symfony 3.4.4 demands [Twig 2.4.4 in its composer.json](https://github.com/symfony/symfony/blob/master/composer.json#L23) but some developers have twig/twig in their own composer.json, unbounded to an exact version number, (or [symfony/twig-bundle which has a requirement of just "^2.4"](https://github.com/symfony/twig-bundle/blob/master/composer.json#L24)) and so when they composer upgrade they are getting Twig 2.4.5 which is not what Symfony itself wants or promotes. 

I guess one could say that this is not a Symfony bug currently, as Symfony 3.4.4 is EXPECTING you to use Twig 2.4.4...