### PR TITLE
Fix profiler unicity when several ones are registered

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 1.35.2 (2018-XX-XX)
 
- * n/a
+ * fixed a regression in the way the profiler is registered in templates
 
 * 1.35.1 (2018-03-02)
 

--- a/lib/Twig/Profiler/NodeVisitor/Profiler.php
+++ b/lib/Twig/Profiler/NodeVisitor/Profiler.php
@@ -55,7 +55,7 @@ class Twig_Profiler_NodeVisitor_Profiler extends Twig_BaseNodeVisitor
 
     private function getVarName()
     {
-        return sprintf('__internal_%s', hash('sha256', __METHOD__));
+        return sprintf('__internal_%s', hash('sha256', $this->extensionName));
     }
 
     public function getPriority()

--- a/lib/Twig/Profiler/Profile.php
+++ b/lib/Twig/Profiler/Profile.php
@@ -76,7 +76,7 @@ class Twig_Profiler_Profile implements IteratorAggregate, Serializable
         return $this->profiles;
     }
 
-    public function addProfile(self $profile)
+    public function addProfile(Twig_Profiler_Profile $profile)
     {
         $this->profiles[] = $profile;
     }


### PR DESCRIPTION
Closes #2627, closes #2643, alternative to #2645

What happens is that both Twig and Symfony register a Twig profiler. Unfortunately, the current code does assign the same variable for both profiler, which means that trying to close it twice does not work.
