### PR TITLE
[v1] Fixed counting children of SimpleXMLElement object

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1263,6 +1263,10 @@ if (function_exists('mb_get_info')) {
             return mb_strlen($thing, $env->getCharset());
         }
 
+        if ($thing instanceof \SimpleXMLElement) {
+            return count($thing);
+        }
+
         if (is_object($thing) && method_exists($thing, '__toString') && !$thing instanceof \Countable) {
             return mb_strlen((string) $thing, $env->getCharset());
         }
@@ -1364,6 +1368,10 @@ else {
 
         if (is_scalar($thing)) {
             return strlen($thing);
+        }
+
+        if ($thing instanceof \SimpleXMLElement) {
+            return count($thing);
         }
 
         if (is_object($thing) && method_exists($thing, '__toString') && !$thing instanceof \Countable) {

--- a/test/Twig/Tests/Fixtures/filters/length.test
+++ b/test/Twig/Tests/Fixtures/filters/length.test
@@ -10,6 +10,7 @@
 {{ null|length }}
 {{ magic|length }}
 {{ non_countable|length }}
+{{ simple_xml_element|length }}
 --DATA--
 return array(
     'array' => array(1, 4),
@@ -21,6 +22,7 @@ return array(
     'null'          => null,
     'magic'         => new MagicCallStub(),     /* used to assert we do *not* call __call */
     'non_countable' => new \StdClass(),
+    'simple_xml_element' => new \SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><doc><elem/><elem/></doc>'),
 );
 --EXPECT--
 2
@@ -32,3 +34,4 @@ return array(
 0
 1
 1
+2


### PR DESCRIPTION
It works correctly in v1.32 and since v1.33 it is not working correctly.
See: https://github.com/twigphp/Twig/compare/v1.32.0...v1.33.0#diff-d7378002f67a61c458c1de0468eef74fR1265

Test code:
```php
$xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><doc><elem/><elem/></doc>');

var_dump($xml instanceof \Countable);
echo 'Count: ' . count($xml), PHP_EOL;
echo 'Strlen: ' . strlen($xml), PHP_EOL;
echo 'MB Strlen: ' . mb_strlen($xml), PHP_EOL;
```

Results:
```
bool(false)
Count: 2
Strlen: 0
MB Strlen: 0
```

https://3v4l.org/VvUXG