### PR TITLE
Add warning for possible XSS vulnerabilities when using html_attr esc…

### DIFF
--- a/doc/filters/escape.rst
+++ b/doc/filters/escape.rst
@@ -87,6 +87,13 @@ The ``escape`` filter supports the following escaping strategies:
             {{ var|escape(strategy)|raw }} {# won't be double-escaped #}
         {% endautoescape %}
 
+.. caution::
+
+    ``html_attr`` escapes URLs, but 'javascript:' and 'data:' URLs will still work
+    and may cause XSS vulnerabilities when user input is passed.
+    Additional care needs to be taken in this case, e.g. allowing only specific
+    schemes.
+
 Custom Escapers
 ---------------
 


### PR DESCRIPTION
…aping.

Doc addition that handles #2623.
I think that many developers might miss this, which then leads to security issues.

(I'd still be happy to try a PR to actually handle the case instead of simply documenting it, but need a direction in which to go - see discussion in the ticket)