### PR TITLE
Small optimization for Twig_NodeTraverser::traverseForVisitor

### DIFF
--- a/lib/Twig/NodeTraverser.php
+++ b/lib/Twig/NodeTraverser.php
@@ -70,8 +70,10 @@ class Twig_NodeTraverser
         $node = $visitor->enterNode($node, $this->env);
 
         foreach ($node as $k => $n) {
-            if (false !== $n = $this->traverseForVisitor($visitor, $n)) {
-                $node->setNode($k, $n);
+            if (false !== $m = $this->traverseForVisitor($visitor, $n)) {
+                if ($m !== $n) {
+                    $node->setNode($k, $m);
+                }
             } else {
                 $node->removeNode($k);
             }


### PR DESCRIPTION
During traversing a node tree `Twig_NodeTraverser::traverseForVisitor` (`Twig_NodeVisitorInterface::leaveNode`) often returns a same child node (a same object). So, there is no need to set it back to its parent.

This PR adds a check if a child node was changed. With this check a lot of calls to `Twig_Node::setNode` will be skipped.

Closes #2665 