### PR TITLE
Fix partial template caching after update when auto_reload is on

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 1.35.4 (2018-XX-XX)
 
- * n/a
+ * "js" filter now produces valid JSON
 
 * 1.35.3 (2018-03-20)
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1040,7 +1040,7 @@ function twig_escape_filter(Twig_Environment $env, $string, $strategy = 'html', 
 
         case 'js':
             // escape all non-alphanumeric characters
-            // into their \xHH or \uHHHH representations
+            // into their \x or \uHHHH representations
             if ('UTF-8' !== $charset) {
                 $string = twig_convert_encoding($string, 'UTF-8', $charset);
             }
@@ -1152,9 +1152,23 @@ function _twig_escape_js_callback($matches)
 {
     $char = $matches[0];
 
-    // \xHH
-    if (!isset($char[1])) {
-        return '\\x'.strtoupper(substr('00'.bin2hex($char), -2));
+    /*
+     * A few characters have short escape sequences in JSON and JavaScript.
+     * Escape sequences supported only by JavaScript, not JSON, are ommitted.
+     * \" is also supported but omitted, because the resulting string is not HTML safe.
+     */
+    static $shortMap = array(
+        '\\' => '\\\\',
+        '/' => '\\/',
+        "\x08" => '\b',
+        "\x0C" => '\f',
+        "\x0A" => '\n',
+        "\x0D" => '\r',
+        "\x09" => '\t',
+    );
+
+    if (isset($shortMap[$char])) {
+        return $shortMap[$char];
     }
 
     // \uHHHH

--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -175,7 +175,7 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
 
     public function isFresh($name, $time)
     {
-        return filemtime($this->findTemplate($name)) <= $time;
+        return filemtime($this->findTemplate($name)) < $time;
     }
 
     protected function findTemplate($name)

--- a/lib/Twig/NodeTraverser.php
+++ b/lib/Twig/NodeTraverser.php
@@ -70,8 +70,10 @@ class Twig_NodeTraverser
         $node = $visitor->enterNode($node, $this->env);
 
         foreach ($node as $k => $n) {
-            if (false !== $n = $this->traverseForVisitor($visitor, $n)) {
-                $node->setNode($k, $n);
+            if (false !== $m = $this->traverseForVisitor($visitor, $n)) {
+                if ($m !== $n) {
+                    $node->setNode($k, $m);
+                }
             } else {
                 $node->removeNode($k);
             }

--- a/test/Twig/Tests/EnvironmentTest.php
+++ b/test/Twig/Tests/EnvironmentTest.php
@@ -61,7 +61,7 @@ class Twig_Tests_EnvironmentTest extends \PHPUnit\Framework\TestCase
         ));
 
         $this->assertEquals('foo&lt;br/ &gt; foo&lt;br/ &gt;', $twig->render('html', array('foo' => 'foo<br/ >')));
-        $this->assertEquals('foo\x3Cbr\x2F\x20\x3E foo\x3Cbr\x2F\x20\x3E', $twig->render('js', array('bar' => 'foo<br/ >')));
+        $this->assertEquals('foo\u003Cbr\/\u0020\u003E foo\u003Cbr\/\u0020\u003E', $twig->render('js', array('bar' => 'foo<br/ >')));
     }
 
     public function escapingStrategyCallback($name)

--- a/test/Twig/Tests/Fixtures/autoescape/name.test
+++ b/test/Twig/Tests/Fixtures/autoescape/name.test
@@ -17,6 +17,6 @@ return array('br' => '<br />')
 return array('autoescape' => 'name')
 --EXPECT--
 &lt;br /&gt;
-\x3Cbr\x20\x2F\x3E
+\u003Cbr\u0020\/\u003E
 &lt;br /&gt;
 <br />

--- a/test/Twig/Tests/Fixtures/filters/escape_javascript.test
+++ b/test/Twig/Tests/Fixtures/filters/escape_javascript.test
@@ -5,4 +5,4 @@
 --DATA--
 return array()
 --EXPECT--
-\u00E9\x20\u265C\x20\uD834\uDF06
+\u00E9\u0020\u265C\u0020\uD834\uDF06

--- a/test/Twig/Tests/Fixtures/filters/force_escape.test
+++ b/test/Twig/Tests/Fixtures/filters/force_escape.test
@@ -14,5 +14,5 @@
 return array()
 --EXPECT--
     foo&lt;br /&gt;
-\x20\x20\x20\x20foo\x3Cbr\x20\x2F\x3E\x0A
+\u0020\u0020\u0020\u0020foo\u003Cbr\u0020\/\u003E\n
         foo<br />

--- a/test/Twig/Tests/Fixtures/tags/autoescape/functions.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/functions.test
@@ -80,4 +80,4 @@ unsafe_br()|escape
 autoescape js
 
 safe_br
-\x3Cbr\x20\x2F\x3E
+\u003Cbr\u0020\/\u003E

--- a/test/Twig/Tests/Fixtures/tags/autoescape/strategy.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/strategy.legacy.test
@@ -7,5 +7,5 @@
 --DATA--
 return array('var' => '<br />"')
 --EXPECT--
-\x3Cbr\x20\x2F\x3E\x22
+\u003Cbr\u0020\/\u003E\u0022
 &lt;br /&gt;&quot;

--- a/test/Twig/Tests/Fixtures/tags/autoescape/strategy.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/strategy.test
@@ -7,5 +7,5 @@
 --DATA--
 return array('var' => '<br />"')
 --EXPECT--
-\x3Cbr\x20\x2F\x3E\x22
+\u003Cbr\u0020\/\u003E\u0022
 &lt;br /&gt;&quot;

--- a/test/Twig/Tests/Fixtures/tags/autoescape/type.test
+++ b/test/Twig/Tests/Fixtures/tags/autoescape/type.test
@@ -44,15 +44,15 @@ return array('msg' => "<>\n'\"")
 
 1. autoescape 'html' |escape('js')
 
-<a onclick="alert(&quot;\x3C\x3E\x0A\x27\x22&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\n\u0027\u0022&quot;)"></a>
 
 2. autoescape 'html' |escape('js')
 
-<a onclick="alert(&quot;\x3C\x3E\x0A\x27\x22&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\n\u0027\u0022&quot;)"></a>
 
 3. autoescape 'js' |escape('js')
 
-<a onclick="alert(&quot;\x3C\x3E\x0A\x27\x22&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\n\u0027\u0022&quot;)"></a>
 
 4. no escape
 
@@ -61,9 +61,9 @@ return array('msg' => "<>\n'\"")
 
 5. |escape('js')|escape('html')
 
-<a onclick="alert(&quot;\x3C\x3E\x0A\x27\x22&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\n\u0027\u0022&quot;)"></a>
 
 6. autoescape 'html' |escape('js')|escape('html')
 
-<a onclick="alert(&quot;\x3C\x3E\x0A\x27\x22&quot;)"></a>
+<a onclick="alert(&quot;\u003C\u003E\n\u0027\u0022&quot;)"></a>
 

--- a/test/Twig/Tests/escapingTest.php
+++ b/test/Twig/Tests/escapingTest.php
@@ -51,13 +51,15 @@ class Twig_Test_EscapingTest extends \PHPUnit\Framework\TestCase
 
     protected $jsSpecialChars = array(
         /* HTML special chars - escape without exception to hex */
-        '<' => '\\x3C',
-        '>' => '\\x3E',
-        '\'' => '\\x27',
-        '"' => '\\x22',
-        '&' => '\\x26',
+        '<' => '\\u003C',
+        '>' => '\\u003E',
+        '\'' => '\\u0027',
+        '"' => '\\u0022',
+        '&' => '\\u0026',
+        '/' => '\\/',
         /* Characters beyond ASCII value 255 to unicode escape */
         'Ā' => '\\u0100',
+        '😀' => '\\uD83D\\uDE00',
         /* Immune chars excluded */
         ',' => ',',
         '.' => '.',
@@ -70,12 +72,14 @@ class Twig_Test_EscapingTest extends \PHPUnit\Framework\TestCase
         '0' => '0',
         '9' => '9',
         /* Basic control characters and null */
-        "\r" => '\\x0D',
-        "\n" => '\\x0A',
-        "\t" => '\\x09',
-        "\0" => '\\x00',
+        "\r" => '\r',
+        "\n" => '\n',
+        "\x08" => '\b',
+        "\t" => '\t',
+        "\x0C" => '\f',
+        "\0" => '\\u0000',
         /* Encode spaces for quoteless attribute protection */
-        ' ' => '\\x20',
+        ' ' => '\\u0020',
     );
 
     protected $urlSpecialChars = array(


### PR DESCRIPTION
**Description of the bug:**
This bug manifests itself on production servers.
And with a high load the probability of getting on this bug tends to 100%
The bug results in the caching of a partial template and the failure of a part of the site working with this template. Can only be corrected by deleting the cache.

**What's happening:**
If in the process of uploading the template file, a render() is called, the partially uploaded file gets into the cache and after the template file is fully uploaded, the cache is not updated anymore.

**How to demonstrate:**
To demonstrate the bug, you can create 2 files:
File simulating the download of a file to the server (twig_test_write.php):

```
$classTwig = new Twig_Environment( new Twig_Loader_Filesystem(__DIR__."/../../site_templates/"), array(
	'cache' => __DIR__.'/../../site_templates_cache',
	'auto_reload'=>true
));

file_put_contents(__DIR__."/../../site_templates/"."test.twig","\n<br>Template start write to filesystem");

echo $classTwig->render("test.twig", array());

file_put_contents(__DIR__."/../../site_templates/"."test.twig"," - Template end write to filesystem",FILE_APPEND);

```

File for template rendering (twig_test_read.php):
```
$classTwig = new Twig_Environment( new Twig_Loader_Filesystem(__DIR__."/../../site_templates/"), array(
	'cache' => __DIR__.'/../../site_templates_cache',
	'auto_reload'=>true
));

echo $classTwig->render("test.twig", array());
```

Result executeing file twig_test_write.php:
```
Template start write to filesystem 
```

Result executeing file twig_test_read.php:
```
Template start write to filesystem 
```

**After this fix:**
Result executeing file twig_test_read.php:
```
Template start write to filesystem - Template end write to filesystem
```