### PR TITLE
update filesystem.php to fix OPcache warnings... causes crash in GRAV…

### DIFF
--- a/lib/Twig/Cache/Filesystem.php
+++ b/lib/Twig/Cache/Filesystem.php
@@ -66,7 +66,7 @@ class Twig_Cache_Filesystem implements Twig_CacheInterface
             if (self::FORCE_BYTECODE_INVALIDATION == ($this->options & self::FORCE_BYTECODE_INVALIDATION)) {
                 // Compile cached file into bytecode cache
                 if (function_exists('opcache_invalidate')) {
-                    opcache_invalidate($key, true);
+                    @opcache_invalidate($key, true);
                 } elseif (function_exists('apc_compile_file')) {
                     apc_compile_file($key);
                 }


### PR DESCRIPTION
Currently php 7.2 / twig / GRAV  throws an error and crashes with this message:

> An exception has been thrown during the rendering of a template (“Zend OPcache API is restricted by “restrict_api” configuration directive”).

this is fixed by adding the @ prefix on line 71 of this file... suggest it would be a good idea to roll into next version?