### PR TITLE
Deprecate using the spaceless tag at the root level of a child template (noop anyway)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 2.5.0 (2018-XX-XX)
 
+ * deprecated using the spaceless tag at the root level of a child template (noop anyway)
  * deprecated the possibility to define a block in a non-capturing block in a child template
  * added the Symfony ctype polyfill as a dependency
 

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -13,6 +13,13 @@ Inheritance
   ``Twig_Error_Syntax`` exception. It does not work anyway, so most projects
   won't need to do anything to upgrade.
 
+Tags
+----
+
+* Using the ``spaceless`` tag at the root level of a child template is
+  deprecated in Twig 2.5.0. This does not work as one would expect it to work
+  anyway. In Twig 3.0, it will throw a ``Twig_Error_Syntax`` exception.
+
 Final Classes
 -------------
 

--- a/lib/Twig/Node/Spaceless.php
+++ b/lib/Twig/Node/Spaceless.php
@@ -16,7 +16,7 @@
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Twig_Node_Spaceless extends Twig_Node
+class Twig_Node_Spaceless extends Twig_Node implements Twig_NodeOutputInterface
 {
     public function __construct(Twig_Node $body, $lineno, $tag = 'spaceless')
     {

--- a/lib/Twig/Parser.php
+++ b/lib/Twig/Parser.php
@@ -319,7 +319,8 @@ class Twig_Parser
         if (
             ($node instanceof Twig_Node_Text && !ctype_space($node->getAttribute('data')))
             ||
-            (!$node instanceof Twig_Node_Text && !$node instanceof Twig_Node_BlockReference && $node instanceof Twig_NodeOutputInterface)
+            // the "&& !$node instanceof Twig_Node_Spaceless" part of the condition must be removed in 3.0
+            (!$node instanceof Twig_Node_Text && !$node instanceof Twig_Node_BlockReference && ($node instanceof Twig_NodeOutputInterface && !$node instanceof Twig_Node_Spaceless))
         ) {
             if (false !== strpos((string) $node, chr(0xEF).chr(0xBB).chr(0xBF))) {
                 throw new Twig_Error_Syntax('A template that extends another one cannot start with a byte order mark (BOM); it must be removed.', $node->getTemplateLine(), $this->stream->getSourceContext());
@@ -334,6 +335,11 @@ class Twig_Parser
             return $node;
         }
 
+        // to be removed completely in Twig 3.0
+        if (!$nested && $node instanceof Twig_Node_Spaceless) {
+            @trigger_error(sprintf('Using the spaceless tag at the root level of a child template in "%s" at line %d is deprecated since version 2.5.0 and will become a syntax error in 3.0.', $this->stream->getSourceContext()->getName(), $node->getTemplateLine()), E_USER_DEPRECATED);
+        }
+
         // "block" tags that are not captured (see above) are only used for defining
         // the content of the block. In such a case, nesting it does not work as
         // expected as the definition is not part of the default template code flow.
@@ -343,7 +349,8 @@ class Twig_Parser
             return;
         }
 
-        if ($node instanceof Twig_NodeOutputInterface) {
+        // the "&& !$node instanceof Twig_Node_Spaceless" part of the condition must be removed in 3.0
+        if ($node instanceof Twig_NodeOutputInterface && !$node instanceof Twig_Node_Spaceless) {
             return;
         }
 

--- a/test/Twig/Tests/Fixtures/tags/spaceless/root_level_in_child.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/spaceless/root_level_in_child.legacy.test
@@ -1,0 +1,22 @@
+--TEST--
+"spaceless" tag in the root level of a child template
+--DEPRECATION--
+Using the spaceless tag at the root level of a child template in "index.twig" at line 3 is deprecated since version 2.5.0 and will become a syntax error in 3.0.
+Nesting a block definition under a non-capturing node in "index.twig" at line 4 is deprecated since version 2.5.0 and will become a syntax error in 3.0.
+--TEMPLATE--
+{% extends "layout.twig" %}
+{% spaceless %}
+    {% block content %}
+        <h1>
+            <b>Title</b>
+        </h1>
+    {% endblock %}
+{% endspaceless %}
+--TEMPLATE(layout.twig)--
+{% block content %}FOO{% endblock %}
+--DATA--
+return array()
+--EXPECT--
+        <h1>
+            <b>Title</b>
+        </h1>


### PR DESCRIPTION
~~WIP as I'd like to trigger a deprecation notice (which will only be possible with some other changes coming up in another PR) and add some tests for the deprecated behavior.~~
