### PR TITLE
Add option to inline static values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
  * deprecated using the spaceless tag at the root level of a child template (noop anyway)
  * deprecated the possibility to define a block in a non-capturing block in a child template
  * added the Symfony ctype polyfill as a dependency
+ * add option to inline static values
 
 * 2.4.8 (2018-04-02)
 

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -146,23 +146,23 @@ final class Twig_Extension_Core extends Twig_Extension
 
             // encoding
             new Twig_Filter('url_encode', 'twig_urlencode_filter'),
-            new Twig_Filter('json_encode', 'json_encode'),
+            new Twig_Filter('json_encode', 'json_encode', array('inline' => true)),
             new Twig_Filter('convert_encoding', 'twig_convert_encoding'),
 
             // string filters
-            new Twig_Filter('title', 'twig_title_string_filter', array('needs_environment' => true)),
-            new Twig_Filter('capitalize', 'twig_capitalize_string_filter', array('needs_environment' => true)),
-            new Twig_Filter('upper', 'twig_upper_filter', array('needs_environment' => true)),
-            new Twig_Filter('lower', 'twig_lower_filter', array('needs_environment' => true)),
-            new Twig_Filter('striptags', 'strip_tags'),
-            new Twig_Filter('trim', 'twig_trim_filter'),
-            new Twig_Filter('nl2br', 'nl2br', array('pre_escape' => 'html', 'is_safe' => array('html'))),
+            new Twig_Filter('title', 'twig_title_string_filter', array('needs_environment' => true, 'inline' => true)),
+            new Twig_Filter('capitalize', 'twig_capitalize_string_filter', array('needs_environment' => true, 'inline' => true)),
+            new Twig_Filter('upper', 'twig_upper_filter', array('needs_environment' => true, 'inline' => true)),
+            new Twig_Filter('lower', 'twig_lower_filter', array('needs_environment' => true, 'inline' => true)),
+            new Twig_Filter('striptags', 'strip_tags', array('inline' => true)),
+            new Twig_Filter('trim', 'twig_trim_filter', array('inline' => true)),
+            new Twig_Filter('nl2br', 'nl2br', array('pre_escape' => 'html', 'is_safe' => array('html'), 'inline' => true)),
 
             // array helpers
             new Twig_Filter('join', 'twig_join_filter'),
             new Twig_Filter('split', 'twig_split_filter', array('needs_environment' => true)),
-            new Twig_Filter('sort', 'twig_sort_filter'),
-            new Twig_Filter('merge', 'twig_array_merge'),
+            new Twig_Filter('sort', 'twig_sort_filter', array('inline' => true)),
+            new Twig_Filter('merge', 'twig_array_merge', array('inline' => true)),
             new Twig_Filter('batch', 'twig_array_batch'),
 
             // string/array filters
@@ -170,7 +170,7 @@ final class Twig_Extension_Core extends Twig_Extension
             new Twig_Filter('length', 'twig_length_filter', array('needs_environment' => true)),
             new Twig_Filter('slice', 'twig_slice', array('needs_environment' => true)),
             new Twig_Filter('first', 'twig_first', array('needs_environment' => true)),
-            new Twig_Filter('last', 'twig_last', array('needs_environment' => true)),
+            new Twig_Filter('last', 'twig_last', array('needs_environment' => true, 'inline' => true)),
 
             // iteration and runtime
             new Twig_Filter('default', '_twig_default_filter', array('node_class' => 'Twig_Node_Expression_Filter_Default')),
@@ -185,11 +185,11 @@ final class Twig_Extension_Core extends Twig_Extension
     public function getFunctions()
     {
         return array(
-            new Twig_Function('max', 'max'),
-            new Twig_Function('min', 'min'),
-            new Twig_Function('range', 'range'),
+            new Twig_Function('max', 'max', array('inline' => true)),
+            new Twig_Function('min', 'min', array('inline' => true)),
+            new Twig_Function('range', 'range', array('inline' => true)),
             new Twig_Function('constant', 'twig_constant'),
-            new Twig_Function('cycle', 'twig_cycle'),
+            new Twig_Function('cycle', 'twig_cycle', array('inline' => true)),
             new Twig_Function('random', 'twig_random', array('needs_environment' => true)),
             new Twig_Function('date', 'twig_date_converter', array('needs_environment' => true)),
             new Twig_Function('include', 'twig_include', array('needs_environment' => true, 'needs_context' => true, 'is_safe' => array('all'))),

--- a/lib/Twig/Filter.php
+++ b/lib/Twig/Filter.php
@@ -51,6 +51,7 @@ class Twig_Filter
             'node_class' => 'Twig_Node_Expression_Filter',
             'deprecated' => false,
             'alternative' => null,
+            'inline' => false,
         ), $options);
     }
 
@@ -118,6 +119,11 @@ class Twig_Filter
     public function isVariadic()
     {
         return $this->options['is_variadic'];
+    }
+
+    public function isInline()
+    {
+        return $this->options['inline'];
     }
 
     public function isDeprecated()

--- a/lib/Twig/Function.php
+++ b/lib/Twig/Function.php
@@ -49,6 +49,7 @@ class Twig_Function
             'node_class' => 'Twig_Node_Expression_Function',
             'deprecated' => false,
             'alternative' => null,
+            'inline' => false,
         ), $options);
     }
 
@@ -108,6 +109,11 @@ class Twig_Function
     public function isVariadic()
     {
         return $this->options['is_variadic'];
+    }
+
+    public function isInline()
+    {
+        return $this->options['inline'];
     }
 
     public function isDeprecated()

--- a/lib/Twig/Node/Expression/Filter.php
+++ b/lib/Twig/Node/Expression/Filter.php
@@ -18,6 +18,20 @@ class Twig_Node_Expression_Filter extends Twig_Node_Expression_Call
 
     public function compile(Twig_Compiler $compiler)
     {
+        $this->setAttributes($compiler);
+
+        $this->compileCallable($compiler);
+    }
+
+    public function compileInline(Twig_Compiler $compiler, $callable)
+    {
+        $this->setAttributes($compiler);
+
+        parent::compileInline($compiler, $callable);
+    }
+
+    private function setAttributes(Twig_Compiler $compiler)
+    {
         $name = $this->getNode('filter')->getAttribute('value');
         $filter = $compiler->getEnvironment()->getFilter($name);
 
@@ -28,8 +42,7 @@ class Twig_Node_Expression_Filter extends Twig_Node_Expression_Call
         $this->setAttribute('arguments', $filter->getArguments());
         $this->setAttribute('callable', $filter->getCallable());
         $this->setAttribute('is_variadic', $filter->isVariadic());
-
-        $this->compileCallable($compiler);
+        $this->setAttribute('inline', $filter->isInline());
     }
 }
 

--- a/lib/Twig/Node/Expression/Function.php
+++ b/lib/Twig/Node/Expression/Function.php
@@ -17,6 +17,20 @@ class Twig_Node_Expression_Function extends Twig_Node_Expression_Call
 
     public function compile(Twig_Compiler $compiler)
     {
+        $this->setAttributes($compiler);
+
+        $this->compileCallable($compiler);
+    }
+
+    public function compileInline(Twig_Compiler $compiler, $callable)
+    {
+        $this->setAttributes($compiler);
+
+        parent::compileInline($compiler, $callable);
+    }
+
+    private function setAttributes(Twig_Compiler $compiler)
+    {
         $name = $this->getAttribute('name');
         $function = $compiler->getEnvironment()->getFunction($name);
 
@@ -31,8 +45,7 @@ class Twig_Node_Expression_Function extends Twig_Node_Expression_Call
         }
         $this->setAttribute('callable', $callable);
         $this->setAttribute('is_variadic', $function->isVariadic());
-
-        $this->compileCallable($compiler);
+        $this->setAttribute('inline', $function->isInline());
     }
 }
 

--- a/lib/Twig/Node/Expression/Test.php
+++ b/lib/Twig/Node/Expression/Test.php
@@ -22,6 +22,20 @@ class Twig_Node_Expression_Test extends Twig_Node_Expression_Call
 
     public function compile(Twig_Compiler $compiler)
     {
+        $this->setAttributes($compiler);
+
+        $this->compileCallable($compiler);
+    }
+
+    public function compileInline(Twig_Compiler $compiler, $callable)
+    {
+        $this->setAttributes($compiler);
+
+        parent::compileInline($compiler, $callable);
+    }
+
+    private function setAttributes(Twig_Compiler $compiler)
+    {
         $name = $this->getAttribute('name');
         $test = $compiler->getEnvironment()->getTest($name);
 
@@ -29,8 +43,6 @@ class Twig_Node_Expression_Test extends Twig_Node_Expression_Call
         $this->setAttribute('type', 'test');
         $this->setAttribute('callable', $test->getCallable());
         $this->setAttribute('is_variadic', $test->isVariadic());
-
-        $this->compileCallable($compiler);
     }
 }
 

--- a/test/Twig/Tests/Node/Expression/FilterTest.php
+++ b/test/Twig/Tests/Node/Expression/FilterTest.php
@@ -35,7 +35,7 @@ class Twig_Tests_Node_Expression_FilterTest extends Twig_Test_NodeTestCase
         $node = $this->createFilter($expr, 'upper');
         $node = $this->createFilter($node, 'number_format', array(new Twig_Node_Expression_Constant(2, 1), new Twig_Node_Expression_Constant('.', 1), new Twig_Node_Expression_Constant(',', 1)));
 
-        $tests[] = array($node, 'twig_number_format_filter($this->env, twig_upper_filter($this->env, "foo"), 2, ".", ",")');
+        $tests[] = array($node, 'twig_number_format_filter($this->env, "FOO", 2, ".", ",")');
 
         // named arguments
         $date = new Twig_Node_Expression_Constant(0, 1);


### PR DESCRIPTION
Sometimes projects use filters or functions with static values, which can cause a lot additional function calls in the compiled template. If these static values are inlined in the compiled template, it can improve performance during render.

One example might be the `title` filter. If you have `{{ 'hello world'|title }}` in your template, it generates the following code in the compiled template:

```php
echo twig_escape_filter($this->env, twig_title_string_filter($this->env, "hello world"), "html", null, true);
```
where the call to `twig_title_string_filter` might be unnecessary, and the transformed value can be inlined in the template, giving the following result:

```php
echo twig_escape_filter($this->env, "Hello World", "html", null, true);
```

Another example is Symfony's `|trans` filter or `asset()` function, which generates the following code in the template respectively: 

```php
echo twig_escape_filter($this->env, $this->extensions['Symfony\Bridge\Twig\Extension\TranslationExtension']->trans("pages.home.read_more", array(), "labels"), "html", null, true);

// ... 

echo twig_escape_filter($this->env, $this->extensions['Symfony\Bridge\Twig\Extension\AssetExtension']->getAssetUrl("assets/images/Homepage.jpg"), "html", null, true);
```
Inlined, those values would look like

```php
echo twig_escape_filter($this->env, "Read More", "html", null, true);

// ... 

echo twig_escape_filter($this->env, "/assets/images/Homepage.jpg", "html", null, true);
```

(The Symfony examples are just to illustrate the functionality and not an ideal scenario as there are a lot of other factors involved, like config settings etc. which would influence the result)

On the homepage of an app with roughly 32 translations and 10 images, I saw an improvement of 17% in load time (very rough benchmark, other factors might also impact the test).

Inlining a value can be done by using the new `'inline' => true` option when defining a filter or function (E.G `new Twig_Filter('camel_case', 'my_camelcase_function', array('inline' => true))`).

If any dynamic value is encountered (E.G variables, expressions etc), the default template is compiled as it would normally be done and inlining is skipped

**TODO:**
- [ ] Add unit tests
- [ ] Enable inline mode for more core functions/filters
- [ ] Support inline mode for more expression types
- [ ] docs