### PR TITLE
Ensure that syntax errors are triggered with the right line

### DIFF
--- a/lib/Twig/Node/Expression/Call.php
+++ b/lib/Twig/Node/Expression/Call.php
@@ -111,7 +111,7 @@ abstract class Twig_Node_Expression_Call extends Twig_Node_Expression
                 $named = true;
                 $name = $this->normalizeName($name);
             } elseif ($named) {
-                throw new Twig_Error_Syntax(sprintf('Positional arguments cannot be used after named arguments for %s "%s".', $callType, $callName));
+                throw new Twig_Error_Syntax(sprintf('Positional arguments cannot be used after named arguments for %s "%s".', $callType, $callName), $this->getTemplateLine());
             }
 
             $parameters[$name] = $node;
@@ -143,14 +143,14 @@ abstract class Twig_Node_Expression_Call extends Twig_Node_Expression
 
             if (array_key_exists($name, $parameters)) {
                 if (array_key_exists($pos, $parameters)) {
-                    throw new Twig_Error_Syntax(sprintf('Argument "%s" is defined twice for %s "%s".', $name, $callType, $callName));
+                    throw new Twig_Error_Syntax(sprintf('Argument "%s" is defined twice for %s "%s".', $name, $callType, $callName), $this->getTemplateLine());
                 }
 
                 if (count($missingArguments)) {
                     throw new Twig_Error_Syntax(sprintf(
                         'Argument "%s" could not be assigned for %s "%s(%s)" because it is mapped to an internal PHP function which cannot determine default value for optional argument%s "%s".',
-                        $name, $callType, $callName, implode(', ', $names), count($missingArguments) > 1 ? 's' : '', implode('", "', $missingArguments))
-                    );
+                        $name, $callType, $callName, implode(', ', $names), count($missingArguments) > 1 ? 's' : '', implode('", "', $missingArguments)
+                    ), $this->getTemplateLine());
                 }
 
                 $arguments = array_merge($arguments, $optionalArguments);
@@ -172,7 +172,7 @@ abstract class Twig_Node_Expression_Call extends Twig_Node_Expression
                     $missingArguments[] = $name;
                 }
             } else {
-                throw new Twig_Error_Syntax(sprintf('Value for argument "%s" is required for %s "%s".', $name, $callType, $callName));
+                throw new Twig_Error_Syntax(sprintf('Value for argument "%s" is required for %s "%s".', $name, $callType, $callName), $this->getTemplateLine());
             }
         }
 
@@ -205,7 +205,7 @@ abstract class Twig_Node_Expression_Call extends Twig_Node_Expression
             throw new Twig_Error_Syntax(sprintf(
                 'Unknown argument%s "%s" for %s "%s(%s)".',
                 count($parameters) > 1 ? 's' : '', implode('", "', array_keys($parameters)), $callType, $callName, implode(', ', $names)
-            ), $unknownParameter ? $unknownParameter->getTemplateLine() : -1);
+            ), $unknownParameter ? $unknownParameter->getTemplateLine() : $this->getTemplateLine());
         }
 
         return $arguments;

--- a/test/Twig/Tests/Node/Expression/FilterTest.php
+++ b/test/Twig/Tests/Node/Expression/FilterTest.php
@@ -118,7 +118,7 @@ class Twig_Tests_Node_Expression_FilterTest extends Twig_Test_NodeTestCase
 
     /**
      * @expectedException        Twig_Error_Syntax
-     * @expectedExceptionMessage Value for argument "from" is required for filter "replace".
+     * @expectedExceptionMessage Value for argument "from" is required for filter "replace" at line 1.
      */
     public function testCompileWithMissingNamedArgument()
     {


### PR DESCRIPTION
When throwing the syntax error without any line and source in these places, the guessing logic enters into action. For the main template, it won't find anything. But for included templates (or any other template loaded during the rendering of another one, even as main one), the guessing will find a template (the caller one) and set the source and line based on it. The source will then be replaced by the proper template by `\Twig_Environment::compileSource`, but the guessed line number will make no sense then.

I searched for all places triggering a syntax error in Twig, to ensure that they always set the actual line number or set the source directly (so that the guessing logic knows that the template it found is the wrong one and so does not try to use it for guessing). There were only a few missing ones.