### PR TITLE
Use isset before array_key_exists

### DIFF
--- a/lib/Twig/Node/Expression/Name.php
+++ b/lib/Twig/Node/Expression/Name.php
@@ -32,7 +32,12 @@ class Twig_Node_Expression_Name extends Twig_Node_Expression
             if ($this->isSpecial()) {
                 $compiler->repr(true);
             } else {
-                $compiler->raw('array_key_exists(')->repr($name)->raw(', $context)');
+                $compiler
+                    ->raw('(isset($context[')
+                    ->string($name)
+                    ->raw(']) || array_key_exists(')
+                    ->string($name)
+                    ->raw(', $context))');
             }
         } elseif ($this->isSpecial()) {
             $compiler->raw($this->specialVars[$name]);


### PR DESCRIPTION
Small performance improvment when using

```
{% set foo = foo|default("bar") %}
```
Will render the following code
```
$context["foo"] = (((isset($context["foo"]) || array_key_exists("foo", $context))) ? (_twig_default_filter((isset($context["foo"]) || array_key_exists("foo", $context) ? $context["foo"] : (function () { throw new Twig_Error_Runtime('Variable "foo" does not exist.', 1, $this->source); })()), "bar")) : ("bar"));
```

instead of 
```
$context["foo"] = ((array_key_exists("foo", $context)) ? (_twig_default_filter((isset($context["foo"]) || array_key_exists("foo", $context) ? $context["foo"] : (function () { throw new Twig_Error_Runtime('Variable "foo" does not exist.', 1, $this->source); })()), "bar")) : ("bar"));
```