### PR TITLE
Don't throw error on validate or parse name if throw var is false

### DIFF
--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -195,9 +195,17 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
             throw new Twig_Error_Loader($this->errorCache[$name]);
         }
 
-        $this->validateName($name);
+        try {
+            $this->validateName($name);
 
-        list($namespace, $shortname) = $this->parseName($name);
+            list($namespace, $shortname) = $this->parseName($name);
+        } catch (Twig_Error_Loader $e) {
+            if (!$throw) {
+                return false;
+            }
+
+            throw $e;
+        }
 
         if (!isset($this->paths[$namespace])) {
             $this->errorCache[$name] = sprintf('There are no registered paths for namespace "%s".', $namespace);

--- a/test/Twig/Tests/Loader/FilesystemTest.php
+++ b/test/Twig/Tests/Loader/FilesystemTest.php
@@ -223,4 +223,19 @@ class Twig_Tests_Loader_FilesystemTest extends \PHPUnit\Framework\TestCase
         $loader->addPath('phar://'.dirname(__FILE__).'/Fixtures/phar/phar-sample.phar');
         $this->assertSame('hello from phar', $loader->getSourceContext('hello.twig')->getCode());
     }
+
+    public function testTemplateExistsAlwaysReturnsBool()
+    {
+        $loader = new Twig_Loader_Filesystem(array());
+        $this->assertFalse($loader->exists("foo\0.twig"));
+        $this->assertFalse($loader->exists('../foo.twig'));
+        $this->assertFalse($loader->exists('@foo'));
+        $this->assertFalse($loader->exists('foo'));
+        $this->assertFalse($loader->exists('@foo/bar.twig'));
+
+        $loader->addPath(__DIR__.'/Fixtures/normal');
+        $this->assertTrue($loader->exists('index.html'));
+        $loader->addPath(__DIR__.'/Fixtures/normal', 'foo');
+        $this->assertTrue($loader->exists('@foo/index.html'));
+    }
 }


### PR DESCRIPTION
As spotted here https://github.com/symfony/symfony/issues/28001 `$loader->exists('@foo')` shouldn't throw an exception. e.g.: https://github.com/symfony/symfony/blob/9bfa971bc5662a6f90408b58a7b2453d7dae4f83/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php#L145