### PR TITLE
Use \Traversable instead of \IteratorAggregate (length filter)

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1170,7 +1170,7 @@ function twig_length_filter(Twig_Environment $env, $thing)
         return count($thing);
     }
 
-    if ($thing instanceof \IteratorAggregate) {
+    if ($thing instanceof \Traversable) {
         return iterator_count($thing);
     }
 


### PR DESCRIPTION
Especially for object implementing the \Iterator interface.