### PR TITLE
Fix multi-byte UTF-8 in escape('html_attr')

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1077,8 +1077,8 @@ function twig_escape_filter(Twig_Environment $env, $string, $strategy = 'html', 
                 if (1 == strlen($chr)) {
                     $hex = strtoupper(substr('00'.bin2hex($chr), -2));
                 } else {
-                    $chr = twig_convert_encoding($chr, 'UTF-16BE', 'UTF-8');
-                    $hex = strtoupper(substr('0000'.bin2hex($chr), -4));
+                    $entity = mb_encode_numericentity($chr, array(0x0, 0xffffff, 0, 0xffffff), 'UTF-8', true);
+                    $hex = substr($entity, 3, -1);
                 }
 
                 $int = hexdec($hex);

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1077,7 +1077,7 @@ function twig_escape_filter(Twig_Environment $env, $string, $strategy = 'html', 
                 if (1 == strlen($chr)) {
                     $hex = strtoupper(substr('00'.bin2hex($chr), -2));
                 } else {
-                    $entity = mb_encode_numericentity($chr, array(0x0, 0xffffff, 0, 0xffffff), 'UTF-8', true);
+                    $entity = mb_encode_numericentity($chr, array(0x0, 0x10FFFF, 0, 0xFFFFFF), 'UTF-8', true);
                     $hex = substr($entity, 3, -1);
                     if (strlen($hex) < 4) {
                         $hex = substr('0000'.$hex, -4);

--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1079,6 +1079,9 @@ function twig_escape_filter(Twig_Environment $env, $string, $strategy = 'html', 
                 } else {
                     $entity = mb_encode_numericentity($chr, array(0x0, 0xffffff, 0, 0xffffff), 'UTF-8', true);
                     $hex = substr($entity, 3, -1);
+                    if (strlen($hex) < 4) {
+                        $hex = substr('0000'.$hex, -4);
+                    }
                 }
 
                 $int = hexdec($hex);

--- a/test/Twig/Tests/escapingTest.php
+++ b/test/Twig/Tests/escapingTest.php
@@ -23,6 +23,7 @@ class Twig_Test_EscapingTest extends \PHPUnit\Framework\TestCase
         '\'' => '&#x27;',
         /* Characters beyond ASCII value 255 to unicode escape */
         'Ā' => '&#x0100;',
+        '😀' => '&#x1F600;',
         /* Immune chars excluded */
         ',' => ',',
         '.' => '.',


### PR DESCRIPTION
As far as I can see `|escape('html_attr')` corrupts some UTF-8 input/emoticons. "Normal" UTF-8 characters, e.g., æøå, works fine.

Sample input:
```
{% set P = '🥔' %}
P|length........: {{ P|length }}
P...............: {{ P }}
P|e('html').....: {{ P|escape('html') }}
P|e('html_attr'): {{ P|escape('html_attr') }}
&amp;#x1F954;...: &#x1F954;
````

Output from Twig 2.5.0:
```
P|length........: 1
P...............: 🥔
P|e('html').....: 🥔
P|e('html_attr'): &#xDD54;
&amp;#x1F954;...: &#x1F954;
```
The correct entity for potato is `&#x1F954;`.
`&#xDD54;` is a  � (Unicode replacement character).

Looking at `Twig/Extension/Core.php`, it seems that the following PR fixes this.