### PR TITLE
Improved the code of an example

### DIFF
--- a/doc/tags/if.rst
+++ b/doc/tags/if.rst
@@ -50,12 +50,12 @@ use more complex ``expressions`` there too:
 
 .. code-block:: jinja
 
-    {% if kenny.sick %}
-        Kenny is sick.
-    {% elseif kenny.dead %}
-        You killed Kenny! You bastard!!!
+    {% if product.stock > 10 %}
+       Available
+    {% elseif product.stock > 0 %}
+       Only {{ product.stock }} left!
     {% else %}
-        Kenny looks okay --- so far
+       Sold-out!
     {% endif %}
 
 .. note::


### PR DESCRIPTION
The original code contains an unneeded *"pop culture"* reference. For those unaware of it, it contains two strong words ("kill" and "bastard").

The concern about this example was firstly raised in the `#diversity` channel of [Symfony Slack](https://symfony.com/support).