### PR TITLE
Make sure twig_include returns a string

### DIFF
--- a/lib/Twig/Extension/Core.php
+++ b/lib/Twig/Extension/Core.php
@@ -1527,7 +1527,7 @@ function twig_include(Twig_Environment $env, $context, $template, $variables = a
         }
     }
 
-    $result = null;
+    $result = '';
     try {
         $result = $env->resolveTemplate($template)->render($variables);
     } catch (Twig_Error_Loader $e) {


### PR DESCRIPTION
Currently returns `null` if `$ignoreMissing` is `true` and it's not found, but the return type is `string`.