### PR TITLE
WIP Adds Closure to ExpressionParser

### DIFF
--- a/lib/Twig/ExpressionParser.php
+++ b/lib/Twig/ExpressionParser.php
@@ -180,8 +180,10 @@ class Twig_ExpressionParser
         $names = [];
         $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, '(');
         $names[] = $stream->expect(/* Token::NAME_TYPE */ 5);
-        $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ',');
-        $names[] = $stream->expect(/* Token::NAME_TYPE */ 5);
+        while ($stream->getCurrent()->test(/* Token::PUNCTUATION_TYPE */ 9, ',')) {
+            $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ',');
+            $names[] = $stream->expect(/* Token::NAME_TYPE */ 5);
+        }
         $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ')');
         $stream->expect(/* Token::OPERATOR_TYPE */ 8, '=>');
         return $names;
@@ -191,8 +193,6 @@ class Twig_ExpressionParser
         $stream = $this->parser->getStream();
         $isList = $stream->getCurrent()->test(/* Token::PUNCTUATION_TYPE */ 9, '(');
         $left = $isList ? $this->parseListClosure() : $this->parseSingleClosure();
-        // $left = $this->parser->getStream()->next();
-        // $this->parser->getStream()->expect(/* Token::OPERATOR_TYPE */ 8, '=>');
         $right = $this->parseExpression();
         return new Twig_Node_Expression_Closure($left, $right, $left[0]->getLine());
     }

--- a/lib/Twig/Node/Expression/Closure.php
+++ b/lib/Twig/Node/Expression/Closure.php
@@ -1,0 +1,34 @@
+<?php
+
+class Twig_Node_Expression_Closure extends Twig_Node_Expression {
+
+    public function __construct(array $names, \Twig_Node $body, $lineno)
+    {
+        parent::__construct(array('body' => $body), array('names' => $names), $lineno);
+    }
+
+    public function compile(\Twig_Compiler $compiler)
+    {
+        $varNames = $this->getAttribute('names');
+
+        $compiler
+            ->raw('(function(')
+            ->raw(implode(',', array_map(function (\Twig_Token $varName) {
+                return '$__'.$varName->getValue().'__';
+            }, $varNames)))
+            ->raw('){ ')
+        ;
+        $compiler
+            ->raw(implode('', array_map(function (\Twig_Token $varName) {
+                return '$context["'.$varName->getValue().'"] = $__'.$varName->getValue().'__;';
+            }, $varNames)))
+            ->raw(' return ')
+            ->subcompile($this->getNode('body'))
+            ->raw(';')
+            ->raw('})')
+        ;
+    }
+
+    public function operator(\Twig_Compiler $compiler) {}
+
+}


### PR DESCRIPTION
I wanted to learn a little more about the Twig Lexer / Parser / Compiler flow so I did some hacking and built out functionality for closures in the ExpressionParser. There are no tests yet, the classes are in `lib` and I think they’d need to be stubbed out to `src`, and lot of other little things. All that said, I wanted to open this to get an idea if this could ever reasonably be merged upstream. If not, oh well, it was a great learning experience. If so, YAY! I really do think closures in Twig would open some nice possibilities for template developers and reduce some of the clunky filter chains in use today.

Background:
[Arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) are a part of the latest JavaScript specs and are gaining popularity. Within the React/JSX community they’re really gaining traction as a convienant way to massage data in your view layer without needing to add a bunch of overly specific helpers.

Examples:
Typically if you had an array of people and you wanted to filter them down to only show people that are older than 21 you’d either have to loop over the array once using the set tag and the merge filter to create a new array (`for person in person` then `if person.age > 21` you would `set olderPeople = olderPeople|merge([person])` or you’d have to loop over the people with a for loop and if suffix (`for person in people if person.age > 21`). The first approach is verbose and error prone with how the merge filter works. The second is much cleaner but non-standard in many languages. The second approach also breaks down when you want to count the total or `|batch` the results in to columns.

Solution
Arrow functions are great for array map/reduce callbacks. Take the previous example of showing an array of people who are older than 21. Imagine you have a custom reduce filter.

```
{% set olderPeople = people|filter(person => person.age > 21) %}
```

Because the PR implements the closure logic in the ExpressionParser you should be able to use it anywhere you can use an expression such as,

```
{% set callback = person => person.age > 21 %}
{% set olderPeople = people|filter(callback) %}
```

This would also make sense to map an array of people objects in to something else,

```
<p>With support from: {{ people|map(p => "#{p.firstName} #{p.lastName}")|join(', ') }}</p>
```

The intent here is not to expose the closure to the wider context. So you could not,

```
{% set fullName = p => “#{p.fName} #{p.lName}” %}
{{ fullName(person) }}
```