### PR TITLE
Added hint that the php c extension is only for php5

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -55,6 +55,7 @@ Installing the C extension
     improvements. Note that the extension is not a replacement for the PHP
     code; it only implements a small part of the PHP code to improve the
     performance at runtime; you must still install the regular PHP code.
+    The C extension is only compatible and useful for **PHP5**.
 
 Twig comes with a C extension that enhances the performance of the Twig
 runtime engine; install it like any other PHP extensions:


### PR DESCRIPTION
As @fabpot mention in the slack channel the php c twig extension is only available for php5 and is not needed when using php7 as there the performance boost is not significant enough.

Related Issue: #1695