### PR TITLE
remove duplicated directory separator

### DIFF
--- a/lib/Twig/Loader/Filesystem.php
+++ b/lib/Twig/Loader/Filesystem.php
@@ -219,7 +219,7 @@ class Twig_Loader_Filesystem implements Twig_LoaderInterface, Twig_ExistsLoaderI
 
         foreach ($this->paths[$namespace] as $path) {
             if (!$this->isAbsolutePath($path)) {
-                $path = $this->rootPath.'/'.$path;
+                $path = $this->rootPath.$path;
             }
 
             if (is_file($path.'/'.$shortname)) {


### PR DESCRIPTION
The $rootPath property is already initialized with a trailing directory
separator in the class constructor.