### PR TITLE
Remove runtime deprecation that prevent smooth update

### DIFF
--- a/src/ExtensionSet.php
+++ b/src/ExtensionSet.php
@@ -49,6 +49,8 @@ final class ExtensionSet
 
     /**
      * Initializes the runtime environment.
+     *
+     * @deprecated since Twig 2.7
      */
     public function initRuntime(Environment $env)
     {
@@ -60,8 +62,6 @@ final class ExtensionSet
 
         foreach ($this->extensions as $extension) {
             if ($extension instanceof InitRuntimeInterface) {
-                @trigger_error(sprintf('Implementing \Twig\Extension\InitRuntimeInterface on "%s" is deprecated since Twig 2.7 as the interface will be removed in 3.0.', get_class($extension)), E_USER_DEPRECATED);
-
                 $extension->initRuntime($env);
             }
         }


### PR DESCRIPTION
This deprecation is already triggered when a class that implements `InitRuntimeInterface` is loaded.
This runtime deprecation prevents creating a continuous upgrade path.