### PR TITLE
Fix deprecation notes

### DIFF
--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -26,7 +26,7 @@ use Twig\Source;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 2.4.0
+ * @final since Twig 2.4.0
  */
 class ModuleNode extends Node
 {

--- a/src/Profiler/Profile.php
+++ b/src/Profiler/Profile.php
@@ -14,7 +14,7 @@ namespace Twig\Profiler;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 2.4.0
+ * @final since Twig 2.4.0
  */
 class Profile implements \IteratorAggregate, \Serializable
 {

--- a/src/TwigFilter.php
+++ b/src/TwigFilter.php
@@ -17,7 +17,7 @@ use Twig\Node\Node;
 /**
  * Represents a template filter.
  *
- * @final since version 2.4.0
+ * @final since Twig 2.4.0
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *

--- a/src/TwigTest.php
+++ b/src/TwigTest.php
@@ -16,7 +16,7 @@ use Twig\Node\Expression\TestExpression;
 /**
  * Represents a template test.
  *
- * @final since version 2.4.0
+ * @final since Twig 2.4.0
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *

--- a/test/Twig/Tests/Fixtures/tags/block/capturing_block.test
+++ b/test/Twig/Tests/Fixtures/tags/block/capturing_block.test
@@ -1,7 +1,7 @@
 --TEST--
 capturing "block" tag
 --DEPRECATION--
-The spaceless tag is deprecated since version 2.7, use the spaceless filter instead.
+The spaceless tag is deprecated since Twig 2.7, use the spaceless filter instead.
 --TEMPLATE--
 {% set foo %}{% block foo %}FOO{% endblock %}{% endset %}
 {{ foo }}

--- a/test/Twig/Tests/Fixtures/tags/spaceless/root_level_in_child.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/spaceless/root_level_in_child.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "spaceless" tag in the root level of a child template
 --DEPRECATION--
-The spaceless tag is deprecated since version 2.7, use the spaceless filter instead.
+The spaceless tag is deprecated since Twig 2.7, use the spaceless filter instead.
 Using the spaceless tag at the root level of a child template in "index.twig" at line 3 is deprecated since Twig 2.5.0 and will become a syntax error in 3.0.
 Nesting a block definition under a non-capturing node in "index.twig" at line 4 is deprecated since Twig 2.5.0 and will become a syntax error in 3.0.
 --TEMPLATE--

--- a/test/Twig/Tests/Fixtures/tags/spaceless/simple.test
+++ b/test/Twig/Tests/Fixtures/tags/spaceless/simple.test
@@ -1,7 +1,7 @@
 --TEST--
 "spaceless" tag removes whites between HTML tags
 --DEPRECATION--
-The spaceless tag is deprecated since version 2.7, use the spaceless filter instead.
+The spaceless tag is deprecated since Twig 2.7, use the spaceless filter instead.
 --TEMPLATE--
 {% spaceless %}
 


### PR DESCRIPTION
`ExpressionParser` still uses `since version [...]` because the message is not only about Twig: any package providing extensions can trigger it.