### PR TITLE
Try to avoid guessing template info on errors

### DIFF
--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -63,7 +63,7 @@ class Error extends \Exception
      * @param Source|string|null $source   The source context where the error occurred
      * @param \Exception         $previous The previous exception
      */
-    public function __construct($message, $lineno = -1, $source = null, \Exception $previous = null)
+    public function __construct($message, $lineno = -1, $source = null, \Exception $previous = null, $autoGuess = true)
     {
         if (null === $source) {
             $name = null;
@@ -80,7 +80,7 @@ class Error extends \Exception
         $this->lineno = $lineno;
         $this->filename = $name;
 
-        if (-1 === $lineno || null === $name || null === $this->sourcePath) {
+        if ($autoGuess && (-1 === $lineno || null === $name || null === $this->sourcePath)) {
             $this->guessTemplateInfo();
         }
 

--- a/src/Error/LoaderError.php
+++ b/src/Error/LoaderError.php
@@ -28,10 +28,7 @@ class LoaderError extends Error
 {
     public function __construct($message, $lineno = -1, $source = null, \Exception $previous = null)
     {
-        \Exception::__construct('', 0, $previous);
-
-        $this->appendMessage($message);
-        $this->setTemplateLine(-2);
+        parent::__construct($message, $lineno, $source, $previous, false);
     }
 }
 

--- a/src/Node/Expression/CallExpression.php
+++ b/src/Node/Expression/CallExpression.php
@@ -121,7 +121,7 @@ abstract class CallExpression extends AbstractExpression
                 $named = true;
                 $name = $this->normalizeName($name);
             } elseif ($named) {
-                throw new SyntaxError(sprintf('Positional arguments cannot be used after named arguments for %s "%s".', $callType, $callName), $this->getTemplateLine());
+                throw new SyntaxError(sprintf('Positional arguments cannot be used after named arguments for %s "%s".', $callType, $callName), $this->getTemplateLine(), null, null, false);
             }
 
             $parameters[$name] = $node;
@@ -153,14 +153,14 @@ abstract class CallExpression extends AbstractExpression
 
             if (\array_key_exists($name, $parameters)) {
                 if (\array_key_exists($pos, $parameters)) {
-                    throw new SyntaxError(sprintf('Argument "%s" is defined twice for %s "%s".', $name, $callType, $callName), $this->getTemplateLine());
+                    throw new SyntaxError(sprintf('Argument "%s" is defined twice for %s "%s".', $name, $callType, $callName), $this->getTemplateLine(), null, null, false);
                 }
 
                 if (\count($missingArguments)) {
                     throw new SyntaxError(sprintf(
                         'Argument "%s" could not be assigned for %s "%s(%s)" because it is mapped to an internal PHP function which cannot determine default value for optional argument%s "%s".',
                         $name, $callType, $callName, implode(', ', $names), \count($missingArguments) > 1 ? 's' : '', implode('", "', $missingArguments)
-                    ), $this->getTemplateLine());
+                    ), $this->getTemplateLine(), null, null, false);
                 }
 
                 $arguments = array_merge($arguments, $optionalArguments);
@@ -182,7 +182,7 @@ abstract class CallExpression extends AbstractExpression
                     $missingArguments[] = $name;
                 }
             } else {
-                throw new SyntaxError(sprintf('Value for argument "%s" is required for %s "%s".', $name, $callType, $callName), $this->getTemplateLine());
+                throw new SyntaxError(sprintf('Value for argument "%s" is required for %s "%s".', $name, $callType, $callName), $this->getTemplateLine(), null, null, false);
             }
         }
 
@@ -215,7 +215,7 @@ abstract class CallExpression extends AbstractExpression
             throw new SyntaxError(sprintf(
                 'Unknown argument%s "%s" for %s "%s(%s)".',
                 \count($parameters) > 1 ? 's' : '', implode('", "', array_keys($parameters)), $callType, $callName, implode(', ', $names)
-            ), $unknownParameter ? $unknownParameter->getTemplateLine() : $this->getTemplateLine());
+            ), $unknownParameter ? $unknownParameter->getTemplateLine() : $this->getTemplateLine(), null, null, false);
         }
 
         return $arguments;

--- a/src/Node/Expression/Test/DefinedTest.php
+++ b/src/Node/Expression/Test/DefinedTest.php
@@ -47,7 +47,7 @@ class DefinedTest extends TestExpression
         } elseif ($node instanceof ConstantExpression || $node instanceof ArrayExpression) {
             $node = new ConstantExpression(true, $node->getTemplateLine());
         } else {
-            throw new SyntaxError('The "defined" test only works with simple variables.', $this->getTemplateLine());
+            throw new SyntaxError('The "defined" test only works with simple variables.', $this->getTemplateLine(), null, null, false);
         }
 
         parent::__construct($node, $name, $arguments, $lineno);

--- a/src/Node/MacroNode.php
+++ b/src/Node/MacroNode.php
@@ -27,7 +27,7 @@ class MacroNode extends Node
     {
         foreach ($arguments as $argumentName => $argument) {
             if (self::VARARGS_NAME === $argumentName) {
-                throw new SyntaxError(sprintf('The argument "%s" in macro "%s" cannot be defined because the variable "%s" is reserved for arbitrary arguments.', self::VARARGS_NAME, $name, self::VARARGS_NAME), $argument->getTemplateLine());
+                throw new SyntaxError(sprintf('The argument "%s" in macro "%s" cannot be defined because the variable "%s" is reserved for arbitrary arguments.', self::VARARGS_NAME, $name, self::VARARGS_NAME), $argument->getTemplateLine(), null, null, false);
             }
         }
 

--- a/src/Template.php
+++ b/src/Template.php
@@ -221,8 +221,7 @@ abstract class Template implements \Twig_TemplateInterface
 
                 // this is mostly useful for \Twig\Error\LoaderError exceptions
                 // see \Twig\Error\LoaderError
-                if (-2 === $e->getTemplateLine()) {
-                    $e->setTemplateLine(-1);
+                if (-1 === $e->getTemplateLine()) {
                     $e->guess();
                 }
 
@@ -424,8 +423,7 @@ abstract class Template implements \Twig_TemplateInterface
 
             // this is mostly useful for \Twig\Error\LoaderError exceptions
             // see \Twig\Error\LoaderError
-            if (-2 === $e->getTemplateLine()) {
-                $e->setTemplateLine(-1);
+            if (-1 === $e->getTemplateLine()) {
                 $e->guess();
             }
 


### PR DESCRIPTION
Right now, for syntax errors triggered in a Node, we guess the template line and source, but we then try to set the information in the Parser class. This PR avoids the guessing as it's slow.