### PR TITLE
Fix BC breaking of TokenParserInterface

### DIFF
--- a/src/TokenParser/TokenParserInterface.php
+++ b/src/TokenParser/TokenParserInterface.php
@@ -46,3 +46,5 @@ interface TokenParserInterface
 }
 
 class_alias('Twig\TokenParser\TokenParserInterface', 'Twig_TokenParserInterface');
+class_exists('Twig_Parser');
+class_exists('Twig_Token');


### PR DESCRIPTION
After upgraded to 2.7.0, dependent which uses the legacy `\Twig_TokenParser` failed due to an unexpected BC breaking. 

https://github.com/sonata-project/SonataMediaBundle/blob/3.x/src/Twig/TokenParser/MediaTokenParser.php#L36

```
In MediaTokenParser.php line 65:
                                                                                                                                                                                                        
  Compile Error: Declaration of Sonata\MediaBundle\Twig\TokenParser\MediaTokenParser::parse(Twig_Token $token) must be compatible with Twig\TokenParser\TokenParserInterface::parse(Twig\Token $token)  
      
```