### PR TITLE
Rewrite the implementation of the set tag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 1.38.3 (2019-XX-XX)
 
- * n/a
+ * rewrote the implementation of the set tag
 
 * 1.38.2 (2019-03-12)
 

--- a/src/TokenParser/SetTokenParser.php
+++ b/src/TokenParser/SetTokenParser.php
@@ -14,6 +14,9 @@ namespace Twig\TokenParser;
 use Twig\Error\SyntaxError;
 use Twig\Node\SetNode;
 use Twig\Token;
+use Twig\Node\Expression\BlockReferenceExpression;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\BlockNode;
 
 /**
  * Defines a variable.
@@ -53,8 +56,14 @@ class SetTokenParser extends AbstractTokenParser
 
             $stream->expect(Token::BLOCK_END_TYPE);
 
-            $values = $this->parser->subparse([$this, 'decideBlockEnd'], true);
+            $name = $this->parser->getVarName();
+            $values = new BlockReferenceExpression(new ConstantExpression($name, $token->getLine()), null, $token->getLine(), $this->getTag());
+
+            $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
             $stream->expect(Token::BLOCK_END_TYPE);
+
+            $block = new BlockNode($name, $body, $token->getLine());
+            $this->parser->setBlock($name, $block);
         }
 
         return new SetNode($capture, $names, $values, $lineno, $this->getTag());

--- a/test/Twig/Tests/Node/SetTest.php
+++ b/test/Twig/Tests/Node/SetTest.php
@@ -44,26 +44,6 @@ class Twig_Tests_Node_SetTest extends NodeTestCase
 EOF
         ];
 
-        $names = new Node([new AssignNameExpression('foo', 1)], [], 1);
-        $values = new Node([new PrintNode(new ConstantExpression('foo', 1), 1)], [], 1);
-        $node = new SetNode(true, $names, $values, 1);
-        $tests[] = [$node, <<<EOF
-// line 1
-ob_start();
-echo "foo";
-\$context["foo"] = ('' === \$tmp = ob_get_clean()) ? '' : new Markup(\$tmp, \$this->env->getCharset());
-EOF
-        ];
-
-        $names = new Node([new AssignNameExpression('foo', 1)], [], 1);
-        $values = new TextNode('foo', 1);
-        $node = new SetNode(true, $names, $values, 1);
-        $tests[] = [$node, <<<EOF
-// line 1
-\$context["foo"] = ('' === \$tmp = "foo") ? '' : new Markup(\$tmp, \$this->env->getCharset());
-EOF
-        ];
-
         $names = new Node([new AssignNameExpression('foo', 1), new AssignNameExpression('bar', 1)], [], 1);
         $values = new Node([new ConstantExpression('foo', 1), new NameExpression('bar', 1)], [], 1);
         $node = new SetNode(false, $names, $values, 1);


### PR DESCRIPTION
The current implementation of the `set` tag relies on `ob_start/ob_get_clean`, which is not a good practice anymore. Like for the `filter` tag, it's better to create a method that wraps the output. That way, we don't need to rely on the fact that the output is generated via `echo` calls. In Twig 3.x, we won't have `echo` calls anymore, but `yield` calls, so that would break.

As a bonus, it makes the code easier.
