### PR TITLE
Fixed spaceless filter

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -997,7 +997,7 @@ function twig_trim_filter($string, $characterMask = null, $side = 'both')
  */
 function twig_spaceless($content)
 {
-    return preg_replace('/>\s+</', '><', $content);
+    return trim(preg_replace('/>\s+</', '><', $content));
 }
 
 /**


### PR DESCRIPTION
As now the `spaceless` tag is deprecated, I tried to replace it by the new `spaceless` filter instead but it broke my application. Actually there is a difference between the tag and the filter. Spaceless tag trim also whistespace (or line feed).

I propose to do the same thing on the new filter. 