### PR TITLE
Fix typo in Environment->getTags()

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -1079,7 +1079,7 @@ class Environment
     public function getTags()
     {
         $tags = [];
-        foreach ($this->getTokenParsers()->getParsers() as $parser) {
+        foreach ($this->getTokenParsers() as $parser) {
             if ($parser instanceof TokenParserInterface) {
                 $tags[$parser->getTag()] = $parser;
             }


### PR DESCRIPTION

I found this typo (already fixed in the 2.x branch) while looking for a problem that presented like #2898 but turned out to be unrelated (see [drupal.org #3040269](https://www.drupal.org/project/drupal/issues/3040269)).
