### PR TITLE
fix(with): comment some strings

### DIFF
--- a/doc/tags/with.rst
+++ b/doc/tags/with.rst
@@ -8,7 +8,7 @@ scope are not visible outside of the scope:
 
     {% with %}
         {% set foo = 42 %}
-        {{ foo }}           foo is 42 here
+        {{ foo }} {# foo is 42 here #}
     {% endwith %}
     foo is not visible here any longer
 
@@ -19,7 +19,7 @@ is equivalent to the following one:
 .. code-block:: jinja
 
     {% with { foo: 42 } %}
-        {{ foo }}           foo is 42 here
+        {{ foo }} {# foo is 42 here #}
     {% endwith %}
     foo is not visible here any longer
 


### PR DESCRIPTION
I don't know if it was intentional or not, but I find the following screenshot weird:
![Sélection_027](https://user-images.githubusercontent.com/2103975/54807668-404eb100-4c7e-11e9-8407-526f1e443414.jpg)

I think it's better with a comment instead:
![Sélection_028](https://user-images.githubusercontent.com/2103975/54807638-2ad98700-4c7e-11e9-918a-257af3baf8e1.jpg)

What do you think?

