### PR TITLE
Whitespace improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * 1.39.0 (2019-XX-XX)
 
- * n/a
+ * added support for a new whitespace trimming option ({%~ ~%}, {{~ ~}}, {#~ ~#})
 
 * 1.38.4 (2019-03-23)
 

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -844,25 +844,28 @@ Whitespace Control
 .. versionadded:: 1.1
     Tag level whitespace control was added in Twig 1.1.
 
-The first newline after a template tag is removed automatically (like in PHP.)
+.. versionadded:: 1.39
+    Tag level Line whitespace control was added in Twig 1.39.
+
+The first newline after a template tag is removed automatically (like in PHP).
 Whitespace is not further modified by the template engine, so each whitespace
 (spaces, tabs, newlines etc.) is returned unchanged.
 
-Use the ``spaceless`` tag to remove whitespace *between HTML tags*:
+You can also control whitespace on a per tag level. By using the whitespace
+control modifiers on your tags, you can trim leading and or trailing whitespace.
 
-.. code-block:: jinja
+Twig supports two modifiers:
 
-    {% spaceless %}
-        <div>
-            <strong>foo bar</strong>
-        </div>
-    {% endspaceless %}
+* *Whitespace trimming* via the ``-`` modifier: Removes all whitespace
+  (including newlines);
 
-    {# output will be <div><strong>foo bar</strong></div> #}
+* *Line whitespace trimming* via the ``~`` modifier: Removes all whitespace
+  (excluding newlines). Using this modifier on the right disables the default
+  removal of the first newline inherited from PHP.
 
-In addition to the spaceless tag you can also control whitespace on a per tag
-level. By using the whitespace control modifier on your tags, you can trim
-leading and or trailing whitespace:
+The modifiers can be used on either side of the tags like in ``{%-`` or ``-%}``
+and they consume all whitespace for that side of the tag. It is possible to use
+the modifiers on one side of a tag or on both sides:
 
 .. code-block:: jinja
 
@@ -871,20 +874,34 @@ leading and or trailing whitespace:
     {%- if true -%}
         {{- value -}}
     {%- endif -%}
-
     {# output 'no spaces' #}
 
-The above sample shows the default whitespace control modifier, and how you can
-use it to remove whitespace around tags. Trimming space will consume all whitespace
-for that side of the tag.  It is possible to use whitespace trimming on one side
-of a tag:
+    <li>
+        {{ value }}    </li>
+    {# outputs '<li>\n    no spaces    </li>' #}
 
-.. code-block:: jinja
-
-    {% set value = 'no spaces' %}
-    <li>    {{- value }}    </li>
-
+    <li>
+        {{- value }}    </li>
     {# outputs '<li>no spaces    </li>' #}
+
+    <li>
+        {{~ value }}    </li>
+    {# outputs '<li>\nno spaces    </li>' #}
+
+.. tip::
+
+    In addition to the whitespace modifiers, Twig also has a ``spaceless`` filter
+    that removes whitespace **between HTML tags**:
+
+    .. code-block:: jinja
+
+        {% filter spaceless %}
+            <div>
+                <strong>foo bar</strong>
+            </div>
+        {% endfilter %}
+
+        {# output will be <div><strong>foo bar</strong></div> #}
 
 Extensions
 ----------

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -66,16 +66,81 @@ class Lexer implements \Twig_LexerInterface
         ], $options);
 
         $this->regexes = [
-            'lex_var' => '/\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_variable'][1], '/').'\s*|'.preg_quote($this->options['tag_variable'][1], '/').')/A',
-            'lex_block' => '/\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|'.preg_quote($this->options['tag_block'][1], '/').')\n?/A',
-            'lex_raw_data' => '/('.preg_quote($this->options['tag_block'][0].$this->options['whitespace_trim'], '/').'|'.preg_quote($this->options['tag_block'][0], '/').')\s*(?:end%s)\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')/s',
+            // }}
+            'lex_var' => '{
+                \s*
+                (?:'.
+                    preg_quote($this->options['whitespace_trim'].$this->options['tag_variable'][1]).'\s*'. // -}}\s*
+                    '|'.
+                    preg_quote($this->options['tag_variable'][1]). // }}
+                ')
+            }Ax',
+
+            // %}
+            'lex_block' => '{
+                \s*
+                (?:'.
+                    preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1]).'\s*\n?'. // -%}\s*\n?
+                    '|'.
+                    preg_quote($this->options['tag_block'][1]).'\n?'. // %}\n?
+                ')
+            }Ax',
+
+            // {% endverbatim %}
+            'lex_raw_data' => '{
+                ('.
+                    preg_quote($this->options['tag_block'][0].$this->options['whitespace_trim']). // {%-
+                    '|'.
+                    preg_quote($this->options['tag_block'][0]). // {%
+                ')\s*'.
+                '(?:end%s)'. // endraw or endverbatim
+                '\s*'.
+                '(?:'.
+                    preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1]).'\s*'. // -%}
+                    '|'.
+                    preg_quote($this->options['tag_block'][1]). // %}
+                ')
+            }sx',
+
             'operator' => $this->getOperatorRegex(),
-            'lex_comment' => '/(?:'.preg_quote($this->options['whitespace_trim'], '/').preg_quote($this->options['tag_comment'][1], '/').'\s*|'.preg_quote($this->options['tag_comment'][1], '/').')\n?/s',
-            'lex_block_raw' => '/\s*(raw|verbatim)\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|'.preg_quote($this->options['tag_block'][1], '/').')/As',
-            'lex_block_line' => '/\s*line\s+(\d+)\s*'.preg_quote($this->options['tag_block'][1], '/').'/As',
-            'lex_tokens_start' => '/('.preg_quote($this->options['tag_variable'][0], '/').'|'.preg_quote($this->options['tag_block'][0], '/').'|'.preg_quote($this->options['tag_comment'][0], '/').')('.preg_quote($this->options['whitespace_trim'], '/').')?/s',
-            'interpolation_start' => '/'.preg_quote($this->options['interpolation'][0], '/').'\s*/A',
-            'interpolation_end' => '/\s*'.preg_quote($this->options['interpolation'][1], '/').'/A',
+
+            // #}
+            'lex_comment' => '{
+                (?:'.
+                    preg_quote($this->options['whitespace_trim']).preg_quote($this->options['tag_comment'][1], '#').'\s*\n?'. // -#}\s*\n?
+                    '|'.
+                    preg_quote($this->options['tag_comment'][1], '#').'\n?'. // #}\n?
+                ')
+            }sx',
+
+            // verbatim %}
+            'lex_block_raw' => '{
+                \s*
+                (raw|verbatim)
+                \s*
+                (?:'.
+                    preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1]).'\s*'. // -%}\s*
+                    '|'.
+                    preg_quote($this->options['tag_block'][1]). // %}
+                ')
+            }Asx',
+
+            'lex_block_line' => '{\s*line\s+(\d+)\s*'.preg_quote($this->options['tag_block'][1]).'}As',
+
+            // {{ or {% or {#
+            'lex_tokens_start' => '{
+                ('.
+                    preg_quote($this->options['tag_variable'][0]). // {{
+                    '|'.
+                    preg_quote($this->options['tag_block'][0]). // {%
+                    '|'.
+                    preg_quote($this->options['tag_comment'][0], '#'). // {#
+                ')('.
+                    preg_quote($this->options['whitespace_trim']). // -
+                ')?
+            }sx',
+            'interpolation_start' => '{'.preg_quote($this->options['interpolation'][0]).'\s*}A',
+            'interpolation_end' => '{\s*'.preg_quote($this->options['interpolation'][1]).'}A',
         ];
     }
 

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -66,12 +66,12 @@ class Lexer implements \Twig_LexerInterface
         ], $options);
 
         $this->regexes = [
-            'lex_var' => '/\s*'.preg_quote($this->options['whitespace_trim'].$this->options['tag_variable'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_variable'][1], '/').'/A',
-            'lex_block' => '/\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')\n?/A',
+            'lex_var' => '/\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_variable'][1], '/').'\s*|'.preg_quote($this->options['tag_variable'][1], '/').')/A',
+            'lex_block' => '/\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|'.preg_quote($this->options['tag_block'][1], '/').')\n?/A',
             'lex_raw_data' => '/('.preg_quote($this->options['tag_block'][0].$this->options['whitespace_trim'], '/').'|'.preg_quote($this->options['tag_block'][0], '/').')\s*(?:end%s)\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')/s',
             'operator' => $this->getOperatorRegex(),
             'lex_comment' => '/(?:'.preg_quote($this->options['whitespace_trim'], '/').preg_quote($this->options['tag_comment'][1], '/').'\s*|'.preg_quote($this->options['tag_comment'][1], '/').')\n?/s',
-            'lex_block_raw' => '/\s*(raw|verbatim)\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')/As',
+            'lex_block_raw' => '/\s*(raw|verbatim)\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|'.preg_quote($this->options['tag_block'][1], '/').')/As',
             'lex_block_line' => '/\s*line\s+(\d+)\s*'.preg_quote($this->options['tag_block'][1], '/').'/As',
             'lex_tokens_start' => '/('.preg_quote($this->options['tag_variable'][0], '/').'|'.preg_quote($this->options['tag_block'][0], '/').'|'.preg_quote($this->options['tag_comment'][0], '/').')('.preg_quote($this->options['whitespace_trim'], '/').')?/s',
             'interpolation_start' => '/'.preg_quote($this->options['interpolation'][0], '/').'\s*/A',

--- a/test/Twig/Tests/Fixtures/whitespace/trim_block.test
+++ b/test/Twig/Tests/Fixtures/whitespace/trim_block.test
@@ -1,9 +1,6 @@
 --TEST--
 Whitespace trimming on tags.
 --TEMPLATE--
-{{ 5 * '{#-'|length }}
-{{ '{{-'|length * 5 + '{%-'|length }}
-
 Trim on control tag:
 {% for i in range(1, 9) -%}
 	{{ i }}
@@ -53,9 +50,6 @@ end
 --DATA--
 return ['leading' => 'leading space', 'trailing' => 'trailing space', 'both' => 'both']
 --EXPECT--
-15
-18
-
 Trim on control tag:
 123456789
 

--- a/test/Twig/Tests/Fixtures/whitespace/trim_delimiter_as_strings.test
+++ b/test/Twig/Tests/Fixtures/whitespace/trim_delimiter_as_strings.test
@@ -1,0 +1,10 @@
+--TEST--
+Whitespace trimming as strings.
+--TEMPLATE--
+{{ 5 * '{#-'|length }}
+{{ '{{-'|length * 5 + '{%-'|length }}
+--DATA--
+return []
+--EXPECT--
+15
+18

--- a/test/Twig/Tests/Fixtures/whitespace/trim_left.test
+++ b/test/Twig/Tests/Fixtures/whitespace/trim_left.test
@@ -1,0 +1,32 @@
+--TEST--
+Whitespace trimming on tags (left side).
+--TEMPLATE--
+**{% if true %}
+foo
+    
+    	    {%- endif %}**
+
+**
+
+	    {{- 'foo' }}**
+
+**
+    
+	
+{#- comment #}**
+
+**{% verbatim %}
+foo
+    
+    	    {%- endverbatim %}**
+--DATA--
+return []
+--EXPECT--
+**foo**
+
+**foo**
+
+****
+
+**
+foo**

--- a/test/Twig/Tests/Fixtures/whitespace/trim_line_left.test
+++ b/test/Twig/Tests/Fixtures/whitespace/trim_line_left.test
@@ -1,0 +1,33 @@
+--TEST--
+Line whitespace trimming on tags (left side).
+--TEMPLATE--
+**{% if true %}
+foo
+    	    {%~ endif %}**
+
+**
+	    {{~ 'foo' }}**
+
+**
+	{#~ comment #}**
+
+**{% verbatim %}
+foo
+    
+    	    {%~ endverbatim %}**
+--DATA--
+return []
+--EXPECT--
+**foo
+**
+
+**
+foo**
+
+**
+**
+
+**
+foo
+    
+**

--- a/test/Twig/Tests/Fixtures/whitespace/trim_line_right.test
+++ b/test/Twig/Tests/Fixtures/whitespace/trim_line_right.test
@@ -1,0 +1,32 @@
+--TEST--
+Line whitespace trimming on tags (right side).
+--TEMPLATE--
+**{% if true ~%}    	    
+foo{% endif %}**
+
+**{{ 'foo' ~}}    	    
+foo
+**
+
+**{# comment ~#}	    
+	foo
+**
+
+**{% verbatim ~%}	    
+    foo{% endverbatim %}**
+--DATA--
+return []
+--EXPECT--
+**
+foo**
+
+**foo
+foo
+**
+
+**
+	foo
+**
+
+**
+    foo**

--- a/test/Twig/Tests/Fixtures/whitespace/trim_right.test
+++ b/test/Twig/Tests/Fixtures/whitespace/trim_right.test
@@ -1,0 +1,28 @@
+--TEST--
+Whitespace trimming on tags (right side).
+--TEMPLATE--
+**{% if true -%}
+    
+    	    foo{% endif %}**
+
+**{{ 'foo' -}}
+	    
+**
+
+**{# comment -#}    
+	
+**
+
+**{% verbatim -%}    
+    	    
+foo{% endverbatim %}**
+--DATA--
+return []
+--EXPECT--
+**foo**
+
+**foo**
+
+****
+
+**foo**


### PR DESCRIPTION
This pull request introduces a new whitespace control modifier in addition to the `-` one. The new `~` modifier consume whitespace excluding newlines.

closes #2924, closes #1005, closes #1423, closes #1569, and many already closed ones.
