### PR TITLE
Prepare for the new serialization mechanism

### DIFF
--- a/src/Profiler/Profile.php
+++ b/src/Profiler/Profile.php
@@ -158,14 +158,24 @@ class Profile implements \IteratorAggregate, \Serializable
         return new \ArrayIterator($this->profiles);
     }
 
+    public function __serialize()
+    {
+        return [$this->template, $this->name, $this->type, $this->starts, $this->ends, $this->profiles];
+    }
+
     public function serialize()
     {
-        return serialize([$this->template, $this->name, $this->type, $this->starts, $this->ends, $this->profiles]);
+        return serialize($this->__serialize());
+    }
+
+    public function __unserialize(array $data)
+    {
+        list($this->template, $this->name, $this->type, $this->starts, $this->ends, $this->profiles) = $data;
     }
 
     public function unserialize($data)
     {
-        list($this->template, $this->name, $this->type, $this->starts, $this->ends, $this->profiles) = unserialize($data);
+        $this->__unserialize(unserialize($data));
     }
 }
 


### PR DESCRIPTION
#eufossa

related to https://github.com/symfony/symfony/pull/30965

So we are future proof and it will prevent deprecations for https://github.com/symfony/symfony/issues/30304.

Almost future proof actually because the void return type cannot be added in 7.0. I guess we can see the minimum required PHP version here once 7.4 is out and see how we can handle compatibility 😕 