### PR TITLE
Disable xdebug var_dump overload for tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,7 @@
 
   <php>
     <ini name="error_reporting" value="-1" />
+    <ini name="xdebug.overload_var_dump" value="0" />
   </php>
 
   <listeners>


### PR DESCRIPTION
#eufossa

This test template https://github.com/twigphp/Twig/blob/1.x/test/Twig/Tests/Fixtures/tags/sandbox/array.test depends on the `dump` Twig function that depends of `var_dump` PHP function.

If you have xdebug on your local machine, the default value of the `xdebug.overload_var_dump` setting is at `2`. That makes `var_dump` displays the file and the line number of where the `var_dump` was called, making the assertion fail.