### PR TITLE
"in" operator strictness

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.39.2 (2019-XX-XX)
 
+ * made the "in" operator more strict when comparing strings and integers/floats
  * added support for "Twig\Markup" instances in the "in" test
  * fixed Lexer when using custom options containing the # char
  * fixed "import" when macros are stored in a template string

--- a/src/Node/Expression/Binary/EqualBinary.php
+++ b/src/Node/Expression/Binary/EqualBinary.php
@@ -15,6 +15,17 @@ use Twig\Compiler;
 
 class EqualBinary extends AbstractBinary
 {
+    public function compile(Compiler $compiler)
+    {
+        $compiler
+            ->raw('twig_compare(')
+            ->subcompile($this->getNode('left'))
+            ->raw(', ')
+            ->subcompile($this->getNode('right'))
+            ->raw(')')
+        ;
+    }
+
     public function operator(Compiler $compiler)
     {
         return $compiler->raw('==');

--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -283,6 +283,54 @@ class Twig_Tests_Extension_CoreTest extends \PHPUnit\Framework\TestCase
             [[], new \ArrayIterator([1, 2]), 3],
         ];
     }
+
+    /**
+     * @dataProvider provideCompareCases
+     */
+    public function testCompare($expected, $a, $b)
+    {
+        $this->assertSame($expected, twig_compare($a, $b));
+        $this->assertSame($expected, twig_compare($b, $a));
+    }
+
+    public function provideCompareCases()
+    {
+        return [
+            [true, 'a', 'a'],
+
+            // from https://wiki.php.net/rfc/string_to_number_comparison
+            [true, 0, '0'],
+            [true, 0, '0.0'],
+
+            [false, 0, 'foo'],
+            [false, 0, ''],
+            [true, 42, '   42'],
+            [false, 42, '42foo'],
+
+            [true, '0', '0'],
+            [true, '0', '0.0'],
+            [false, '0', 'foo'],
+            [false, '0', ''],
+            [true, '42', '   42'],
+            [false, '42', '42foo'],
+
+            [true, 42, '000042'],
+            [true, 42, '42.0'],
+            [true, 42.0, '+42.0E0'],
+            [true, 0, '0e214987142012'],
+
+            [true, '42', '000042'],
+            [true, '42', '42.0'],
+            [true, '42.0', '+42.0E0'],
+            [true, '0', '0e214987142012'],
+
+            [true, 42, '   42'],
+            [true, 42, '42   '],
+            [false, 42, '42abc'],
+            [false, 42, 'abc42'],
+            [false, 0, 'abc42'],
+        ];
+    }
 }
 
 function foo_escaper_for_test(Environment $env, $string, $charset)

--- a/test/Twig/Tests/Fixtures/tests/in.test
+++ b/test/Twig/Tests/Fixtures/tests/in.test
@@ -16,10 +16,10 @@ Twig supports the in operator
 {{ true in [0, 1] ? 'OK' : 'KO' }}
 {{ '0' in [0, 1] ? 'OK' : 'KO' }}
 {{ '0' in [1, 0] ? 'OK' : 'KO' }}
-{{ '' in [0, 1] ? 'OK' : 'KO' }}
-{{ '' in [1, 0] ? 'OK' : 'KO' }}
-{{ 0 in ['', 1] ? 'OK' : 'KO' }}
-{{ 0 in [1, ''] ? 'OK' : 'KO' }}
+{{ '' in [0, 1] ? 'KO' : 'OK' }}
+{{ '' in [1, 0] ? 'KO' : 'OK' }}
+{{ 0 in ['', 1] ? 'KO' : 'OK' }}
+{{ 0 in [1, ''] ? 'KO' : 'OK' }}
 
 {{ '' in 'foo' ? 'OK' : 'KO' }}
 {{ 0 in 'foo' ? 'KO' : 'OK' }}


### PR DESCRIPTION
The PHP non-strict comparison operator has some counter-intuitive behaviors, which we inherit in Twig. For instance, `{{ 'text' in [0] }}` returns `true`.

PHP is probably going to fix it in version 8: https://wiki.php.net/rfc/string_to_number_comparison

I propose to implement the same semantics in Twig. We have two options here: do the changes in 1.x as a bug fix or implement it in 3.0. WDYT?

closes #2824, closes #341, closes #340
