### PR TITLE
Make the "in" operator and <,>,<=,>=,==,!= more strict when comparing strings and integers/floats

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 3.0.0 (2019-XX-XX)
 
+ * made the in, <, >, <=, >=, ==, and != operators more strict when comparing strings and integers/floats
  * removed the "filter" tag
  * added type hints everywhere
  * changed Environment::resolveTemplate() to always return a TemplateWrapper instance

--- a/src/Node/Expression/Binary/EqualBinary.php
+++ b/src/Node/Expression/Binary/EqualBinary.php
@@ -15,6 +15,23 @@ use Twig\Compiler;
 
 class EqualBinary extends AbstractBinary
 {
+    public function compile(Compiler $compiler): void
+    {
+        if (\PHP_VERSION_ID >= 80000) {
+            parent::compile($compiler);
+
+            return;
+        }
+
+        $compiler
+            ->raw('0 === twig_compare(')
+            ->subcompile($this->getNode('left'))
+            ->raw(', ')
+            ->subcompile($this->getNode('right'))
+            ->raw(')')
+        ;
+    }
+
     public function operator(Compiler $compiler): Compiler
     {
         return $compiler->raw('==');

--- a/src/Node/Expression/Binary/GreaterBinary.php
+++ b/src/Node/Expression/Binary/GreaterBinary.php
@@ -15,6 +15,23 @@ use Twig\Compiler;
 
 class GreaterBinary extends AbstractBinary
 {
+    public function compile(Compiler $compiler): void
+    {
+        if (\PHP_VERSION_ID >= 80000) {
+            parent::compile($compiler);
+
+            return;
+        }
+
+        $compiler
+            ->raw('-1 === twig_compare(')
+            ->subcompile($this->getNode('left'))
+            ->raw(', ')
+            ->subcompile($this->getNode('right'))
+            ->raw(')')
+        ;
+    }
+
     public function operator(Compiler $compiler): Compiler
     {
         return $compiler->raw('>');

--- a/src/Node/Expression/Binary/GreaterEqualBinary.php
+++ b/src/Node/Expression/Binary/GreaterEqualBinary.php
@@ -15,6 +15,23 @@ use Twig\Compiler;
 
 class GreaterEqualBinary extends AbstractBinary
 {
+    public function compile(Compiler $compiler): void
+    {
+        if (\PHP_VERSION_ID >= 80000) {
+            parent::compile($compiler);
+
+            return;
+        }
+
+        $compiler
+            ->raw('0 >= twig_compare(')
+            ->subcompile($this->getNode('left'))
+            ->raw(', ')
+            ->subcompile($this->getNode('right'))
+            ->raw(')')
+        ;
+    }
+
     public function operator(Compiler $compiler): Compiler
     {
         return $compiler->raw('>=');

--- a/src/Node/Expression/Binary/LessBinary.php
+++ b/src/Node/Expression/Binary/LessBinary.php
@@ -15,6 +15,23 @@ use Twig\Compiler;
 
 class LessBinary extends AbstractBinary
 {
+    public function compile(Compiler $compiler): void
+    {
+        if (\PHP_VERSION_ID >= 80000) {
+            parent::compile($compiler);
+
+            return;
+        }
+
+        $compiler
+            ->raw('1 === twig_compare(')
+            ->subcompile($this->getNode('left'))
+            ->raw(', ')
+            ->subcompile($this->getNode('right'))
+            ->raw(')')
+        ;
+    }
+
     public function operator(Compiler $compiler): Compiler
     {
         return $compiler->raw('<');

--- a/src/Node/Expression/Binary/LessEqualBinary.php
+++ b/src/Node/Expression/Binary/LessEqualBinary.php
@@ -15,6 +15,23 @@ use Twig\Compiler;
 
 class LessEqualBinary extends AbstractBinary
 {
+    public function compile(Compiler $compiler): void
+    {
+        if (\PHP_VERSION_ID >= 80000) {
+            parent::compile($compiler);
+
+            return;
+        }
+
+        $compiler
+            ->raw('0 <= twig_compare(')
+            ->subcompile($this->getNode('left'))
+            ->raw(', ')
+            ->subcompile($this->getNode('right'))
+            ->raw(')')
+        ;
+    }
+
     public function operator(Compiler $compiler): Compiler
     {
         return $compiler->raw('<=');

--- a/src/Node/Expression/Binary/NotEqualBinary.php
+++ b/src/Node/Expression/Binary/NotEqualBinary.php
@@ -15,6 +15,23 @@ use Twig\Compiler;
 
 class NotEqualBinary extends AbstractBinary
 {
+    public function compile(Compiler $compiler): void
+    {
+        if (\PHP_VERSION_ID >= 80000) {
+            parent::compile($compiler);
+
+            return;
+        }
+
+        $compiler
+            ->raw('0 !== twig_compare(')
+            ->subcompile($this->getNode('left'))
+            ->raw(', ')
+            ->subcompile($this->getNode('right'))
+            ->raw(')')
+        ;
+    }
+
     public function operator(Compiler $compiler): Compiler
     {
         return $compiler->raw('!=');

--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -278,6 +278,67 @@ class Twig_Tests_Extension_CoreTest extends \PHPUnit\Framework\TestCase
             [[], new \ArrayIterator([1, 2]), 3],
         ];
     }
+
+    /**
+     * @dataProvider provideCompareCases
+     */
+    public function testCompare($expected, $a, $b)
+    {
+        $this->assertSame($expected, twig_compare($a, $b));
+        $this->assertSame($expected, -twig_compare($b, $a));
+    }
+
+    public function testCompareNAN()
+    {
+        $this->assertSame(1, twig_compare(NAN, 'NAN'));
+        $this->assertSame(1, twig_compare('NAN', NAN));
+        $this->assertSame(1, twig_compare(NAN, 'foo'));
+        $this->assertSame(1, twig_compare('foo', NAN));
+    }
+
+    public function provideCompareCases()
+    {
+        return [
+            [0, 'a', 'a'],
+
+            // from https://wiki.php.net/rfc/string_to_number_comparison
+            [0, 0, '0'],
+            [0, 0, '0.0'],
+
+            [-1, 0, 'foo'],
+            [1, 0, ''],
+            [0, 42, '   42'],
+            [-1, 42, '42foo'],
+
+            [0, '0', '0'],
+            [0, '0', '0.0'],
+            [1, '0', 'foo'],
+            [-1, '0', ''],
+            [0, '42', '   42'],
+            [1, '42', '42foo'],
+
+            [0, 42, '000042'],
+            [0, 42, '42.0'],
+            [0, 42.0, '+42.0E0'],
+            [0, 0, '0e214987142012'],
+
+            [0, '42', '000042'],
+            [0, '42', '42.0'],
+            [0, '42.0', '+42.0E0'],
+            [0, '0', '0e214987142012'],
+
+            [0, 42, '   42'],
+            [0, 42, '42   '],
+            [-1, 42, '42abc'],
+            [-1, 42, 'abc42'],
+            [-1, 0, 'abc42'],
+
+            [0, INF, 'INF'],
+            [0, -INF, '-INF'],
+            [0, INF, '1e1000'],
+            [0, -INF,'-1e1000'],
+        ];
+    }
 }
 
 function foo_escaper_for_test(Environment $env, $string, $charset)

--- a/test/Twig/Tests/Fixtures/tests/in.test
+++ b/test/Twig/Tests/Fixtures/tests/in.test
@@ -16,10 +16,10 @@ Twig supports the in operator
 {{ true in [0, 1] ? 'OK' : 'KO' }}
 {{ '0' in [0, 1] ? 'OK' : 'KO' }}
 {{ '0' in [1, 0] ? 'OK' : 'KO' }}
-{{ '' in [0, 1] ? 'OK' : 'KO' }}
-{{ '' in [1, 0] ? 'OK' : 'KO' }}
-{{ 0 in ['', 1] ? 'OK' : 'KO' }}
-{{ 0 in [1, ''] ? 'OK' : 'KO' }}
+{{ '' in [0, 1] ? 'KO' : 'OK' }}
+{{ '' in [1, 0] ? 'KO' : 'OK' }}
+{{ 0 in ['', 1] ? 'KO' : 'OK' }}
+{{ 0 in [1, ''] ? 'KO' : 'OK' }}
 
 {{ '' in 'foo' ? 'OK' : 'KO' }}
 {{ 0 in 'foo' ? 'KO' : 'OK' }}

--- a/test/Twig/Tests/Fixtures/tests/in_with_iterator.test
+++ b/test/Twig/Tests/Fixtures/tests/in_with_iterator.test
@@ -1,0 +1,14 @@
+--TEST--
+Twig supports the in operator when using iterators
+--TEMPLATE--
+{{ foo in iter ? 'OK' : 'KO' }}
+--DATA--
+$foo = new TwigTestFoo();
+$bar = new TwigTestFoo();
+
+$foo->position = $bar;
+$bar->position = $foo;
+
+return ['foo' => $foo, 'iter' => new \ArrayIterator([$bar, $foo])]
+--EXPECT--
+OK


### PR DESCRIPTION
The PHP non-strict comparison operator has some counter-intuitive behaviors, which we inherit in Twig. For instance, `{{ 'text' in [0] }}` returns `true`.

PHP is probably going to fix it in version 8: https://wiki.php.net/rfc/string_to_number_comparison

I propose to implement the same semantics in Twig for 3.0.

closes #2824, closes #341, closes #340
