### PR TITLE
Make Template::getSourceContext() abstract

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -66,10 +66,7 @@ abstract class Template
      *
      * @return Source
      */
-    public function getSourceContext()
-    {
-        return new Source('', $this->getTemplateName());
-    }
+    abstract public function getSourceContext();
 
     /**
      * Returns the parent template.

--- a/test/Twig/Tests/TemplateTest.php
+++ b/test/Twig/Tests/TemplateTest.php
@@ -16,6 +16,7 @@ use Twig\Loader\ArrayLoader;
 use Twig\Loader\LoaderInterface;
 use Twig\Sandbox\SecurityError;
 use Twig\Sandbox\SecurityPolicy;
+use Twig\Source;
 use Twig\Template;
 
 class Twig_Tests_TemplateTest extends \PHPUnit\Framework\TestCase
@@ -438,6 +439,11 @@ class Twig_TemplateTest extends Template
     public function getDebugInfo()
     {
         return [];
+    }
+
+    public function getSourceContext()
+    {
+        return new Source('', $this->getTemplateName());
     }
 
     protected function doGetParent(array $context)


### PR DESCRIPTION
As the implementation is always provided by ModuleNode.