### PR TITLE
Deprecate returning "false" to remove a Node from NodeVisitorInterface::leaveNode()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 2.9.0 (2019-XX-XX)
 
+ * deprecated returning "false" to remove a Node from NodeVisitorInterface::leaveNode()
  * allowed Twig\NodeVisitor\NodeVisitorInterface::leaveNode() to return "null" instead of "false" (same meaning)
  * deprecated the "filter" tag (use the "apply" tag instead)
  * added the "apply" tag as a replacement for the "filter" tag

--- a/src/NodeTraverser.php
+++ b/src/NodeTraverser.php
@@ -70,6 +70,10 @@ final class NodeTraverser
                     $node->setNode($k, $m);
                 }
             } else {
+                if (false === $m) {
+                    @trigger_error('Returning "false" to remove a Node from NodeVisitorInterface::leaveNode() is deprecated since Twig version 2.9; return "null" instead.', E_USER_DEPRECATED);
+                }
+
                 $node->removeNode($k);
             }
         }


### PR DESCRIPTION
We now need to return "null" instead.