### PR TITLE
Add "filter", "map", and "reduce" filters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.41.0 (2019-XX-XX)
 
+ * added "filter", "map", and "reduce" filters (and support for arrow functions)
  * fixed partial output leak when a PHP fatal error occurs
  * optimized context access on PHP 7.4
 

--- a/doc/filters/filter.rst
+++ b/doc/filters/filter.rst
@@ -29,6 +29,15 @@ function. The arrow function receives the value of the sequence or mapping:
     {% endfor %}
     {# output l = 40 xl = 42 #}
 
+The arrow function also receives the key as a second argument:
+
+.. code-block:: twig
+
+    {% for k, v in sizes|filter((v, k) => v > 38 and k != "xl") -%}
+        {{ k }} = {{ v }}
+    {% endfor %}
+    {# output l = 40 #}
+
 Note that the arrow function has access to the current context.
 
 Arguments

--- a/doc/filters/filter.rst
+++ b/doc/filters/filter.rst
@@ -1,0 +1,38 @@
+``filter``
+=========
+
+.. versionadded:: 1.41
+    The ``filter`` filter was added in Twig 1.41.
+
+The ``filter`` filter filters elements of a sequence or a mapping using an arrow
+function. The arrow function receives the value of the sequence or mapping:
+
+.. code-block:: twig
+
+    {% set sizes = [34, 36, 38, 40, 42] %}
+
+    {% for v in sizes|filter(|v| => v > 38) -%}
+        {{ v }}
+    {% endfor %}
+    {# output 40 42 #}
+
+    {% set sizes = {
+        xs: 34,
+        s:  36,
+        m:  38,
+        l:  40,
+        xl: 42,
+    } %}
+
+    {% for k, v in sizes|filter(|v| => v > 38) -%}
+        {{ k }} = {{ v }}
+    {% endfor %}
+    {# output l = 40 xl = 42 #}
+
+Note that the arrow function has access to the current context.
+
+Arguments
+---------
+
+* ``array``: The sequence or mapping
+* ``arrow``: The arrow function

--- a/doc/filters/filter.rst
+++ b/doc/filters/filter.rst
@@ -11,7 +11,7 @@ function. The arrow function receives the value of the sequence or mapping:
 
     {% set sizes = [34, 36, 38, 40, 42] %}
 
-    {% for v in sizes|filter(|v| => v > 38) -%}
+    {% for v in sizes|filter(v => v > 38) -%}
         {{ v }}
     {% endfor %}
     {# output 40 42 #}
@@ -24,7 +24,7 @@ function. The arrow function receives the value of the sequence or mapping:
         xl: 42,
     } %}
 
-    {% for k, v in sizes|filter(|v| => v > 38) -%}
+    {% for k, v in sizes|filter(v => v > 38) -%}
         {{ k }} = {{ v }}
     {% endfor %}
     {# output l = 40 xl = 42 #}

--- a/doc/filters/index.rst
+++ b/doc/filters/index.rst
@@ -12,6 +12,7 @@ Filters
     date_modify
     default
     escape
+    filter
     first
     format
     join
@@ -20,10 +21,12 @@ Filters
     last
     length
     lower
+    map
     merge
     nl2br
     number_format
     raw
+    reduce
     replace
     reverse
     round

--- a/doc/filters/join.rst
+++ b/doc/filters/join.rst
@@ -19,7 +19,7 @@ define it with the optional first parameter:
 
     {{ [1, 2, 3]|join('|') }}
     {# outputs 1|2|3 #}
-    
+
 A second parameter can also be provided that will be the separator used between
 the last two items of the sequence:
 
@@ -27,7 +27,7 @@ the last two items of the sequence:
 
     {{ [1, 2, 3]|join(', ', ' and ') }}
     {# outputs 1, 2 and 3 #}
-    
+
 Arguments
 ---------
 

--- a/doc/filters/map.rst
+++ b/doc/filters/map.rst
@@ -17,6 +17,18 @@ mapping. The arrow function receives the value of the sequence or mapping:
     {{ people|map(p => "#{p.first} #{p.last}")|join(', ') }}
     {# outputs Bob Smith, Alice Dupond #}
 
+The arrow function also receives the key as a second argument:
+
+.. code-block:: twig
+
+    {% set people = {
+        "Bob": "Smith",
+        "Alice": "Dupond",
+    } %}
+
+    {{ people|map((first, last) => "#{first} #{last}")|join(', ') }}
+    {# outputs Bob Smith, Alice Dupond #}
+
 Note that the arrow function has access to the current context.
 
 Arguments

--- a/doc/filters/map.rst
+++ b/doc/filters/map.rst
@@ -14,7 +14,7 @@ mapping. The arrow function receives the value of the sequence or mapping:
         {first: "Alice", last: "Dupond"},
     ] %}
 
-    {{ people|map(|p| => "#{p.first} #{p.last}")|join(', ') }}
+    {{ people|map(p => "#{p.first} #{p.last}")|join(', ') }}
     {# outputs Bob Smith, Alice Dupond #}
 
 Note that the arrow function has access to the current context.

--- a/doc/filters/map.rst
+++ b/doc/filters/map.rst
@@ -1,0 +1,26 @@
+``map``
+=======
+
+.. versionadded:: 1.41
+    The ``map`` filter was added in Twig 1.41.
+
+The ``map`` filter applies an arrow function to the elements of a sequence or a
+mapping. The arrow function receives the value of the sequence or mapping:
+
+.. code-block:: twig
+
+    {% set people = [
+        {first: "Bob", last: "Smith"},
+        {first: "Alice", last: "Dupond"},
+    ] %}
+
+    {{ people|map(|p| => "#{p.first} #{p.last}")|join(', ') }}
+    {# outputs Bob Smith, Alice Dupond #}
+
+Note that the arrow function has access to the current context.
+
+Arguments
+---------
+
+* ``array``: The sequence or mapping
+* ``arrow``: The arrow function

--- a/doc/filters/reduce.rst
+++ b/doc/filters/reduce.rst
@@ -1,0 +1,33 @@
+``reduce``
+=========
+
+.. versionadded:: 1.41
+    The ``reduce`` filter was added in Twig 1.41.
+
+The ``reduce`` filter iteratively reduces a sequence or a mapping to a single
+value using an arrow function, so as to reduce it to a single value. The arrow
+function receives the return value of the previous iteration and the current
+value of the sequence or mapping:
+
+.. code-block:: twig
+
+    {% set numbers = [1, 2, 3] %}
+
+    {{ numbers|reduce(|carry, v| => carry + v) }}
+    {# output 6 #}
+
+The ``reduce`` filter takes an ``initial`` value as a second argument:
+
+.. code-block:: twig
+
+    {{ numbers|reduce(|carry, v| => carry + v, 10) }}
+    {# output 16 #}
+
+Note that the arrow function has access to the current context.
+
+Arguments
+---------
+
+* ``array``: The sequence or mapping
+* ``arrow``: The arrow function
+* ``initial``: The initial value

--- a/doc/filters/reduce.rst
+++ b/doc/filters/reduce.rst
@@ -13,14 +13,14 @@ value of the sequence or mapping:
 
     {% set numbers = [1, 2, 3] %}
 
-    {{ numbers|reduce(|carry, v| => carry + v) }}
+    {{ numbers|reduce((carry, v) => carry + v) }}
     {# output 6 #}
 
 The ``reduce`` filter takes an ``initial`` value as a second argument:
 
 .. code-block:: twig
 
-    {{ numbers|reduce(|carry, v| => carry + v, 10) }}
+    {{ numbers|reduce((carry, v) => carry + v, 10) }}
     {# output 16 #}
 
 Note that the arrow function has access to the current context.

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1688,16 +1688,28 @@ function twig_array_batch($items, $size, $fill = null, $preserveKeys = true)
 
 function twig_array_filter($array, $arrow)
 {
-    return array_filter($array, $arrow);
+    if (\is_array($array)) {
+        return array_filter($array, $arrow);
+    }
+
+    return new \CallbackFilterIterator($array, $arrow);
 }
 
 function twig_array_map($array, $arrow)
 {
+    if (!\is_array($array)) {
+        $array = iterator_to_array($array);
+    }
+
     return array_map($arrow, $array);
 }
 
 function twig_array_reduce($array, $arrow, $initial = null)
 {
+    if (!\is_array($array)) {
+        $array = iterator_to_array($array);
+    }
+
     return array_reduce($array, $arrow, $initial);
 }
 }

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1689,6 +1689,10 @@ function twig_array_batch($items, $size, $fill = null, $preserveKeys = true)
 function twig_array_filter($array, $arrow)
 {
     if (\is_array($array)) {
+        if (\PHP_VERSION_ID >= 50600) {
+            return array_filter($array, $arrow, \ARRAY_FILTER_USE_BOTH);
+        }
+
         return array_filter($array, $arrow);
     }
 
@@ -1697,11 +1701,12 @@ function twig_array_filter($array, $arrow)
 
 function twig_array_map($array, $arrow)
 {
-    if (!\is_array($array)) {
-        $array = iterator_to_array($array);
+    $r = [];
+    foreach ($array as $k => $v) {
+        $r[$k] = $arrow($v, $k);
     }
 
-    return array_map($arrow, $array);
+    return $r;
 }
 
 function twig_array_reduce($array, $arrow, $initial = null)

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -194,6 +194,9 @@ class CoreExtension extends AbstractExtension
             new TwigFilter('sort', 'twig_sort_filter'),
             new TwigFilter('merge', 'twig_array_merge'),
             new TwigFilter('batch', 'twig_array_batch'),
+            new TwigFilter('filter', 'twig_array_filter'),
+            new TwigFilter('map', 'twig_array_map'),
+            new TwigFilter('reduce', 'twig_array_reduce'),
 
             // string/array filters
             new TwigFilter('reverse', 'twig_reverse_filter', ['needs_environment' => true]),
@@ -1681,5 +1684,20 @@ function twig_array_batch($items, $size, $fill = null, $preserveKeys = true)
     }
 
     return $result;
+}
+
+function twig_array_filter($array, $arrow)
+{
+    return array_filter($array, $arrow);
+}
+
+function twig_array_map($array, $arrow)
+{
+    return array_map($arrow, $array);
+}
+
+function twig_array_reduce($array, $arrow, $initial = null)
+{
+    return array_reduce($array, $arrow, $initial);
 }
 }

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -333,8 +333,13 @@ class Lexer implements \Twig_LexerInterface
             }
         }
 
+        // arrow function
+        if ('=' === $this->code[$this->cursor] && '>' === $this->code[$this->cursor + 1]) {
+            $this->pushToken(Token::ARROW_TYPE, '=>');
+            $this->moveCursor('=>');
+        }
         // operators
-        if (preg_match($this->regexes['operator'], $this->code, $match, 0, $this->cursor)) {
+        elseif (preg_match($this->regexes['operator'], $this->code, $match, 0, $this->cursor)) {
             $this->pushToken(Token::OPERATOR_TYPE, preg_replace('/\s+/', ' ', $match[0]));
             $this->moveCursor($match[0]);
         }

--- a/src/Node/Expression/ArrowFunctionExpression.php
+++ b/src/Node/Expression/ArrowFunctionExpression.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Node\Expression;
+
+use Twig\Compiler;
+
+/**
+ * Represents an arrow function.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ArrowFunctionExpression extends AbstractExpression
+{
+    public function __construct(AbstractExpression $expr, array $names, $lineno, $tag = null)
+    {
+        parent::__construct(['expr' => $expr], ['names' => $names], $lineno, $tag);
+    }
+
+    public function compile(Compiler $compiler)
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->raw('function (')
+        ;
+        foreach ($this->getAttribute('names') as $i => $name) {
+            if ($i) {
+                $compiler->raw(', ');
+            }
+
+            $compiler->raw('$__'.$name.'__');
+        }
+        $compiler
+            ->raw(') use ($context) { ')
+        ;
+        foreach ($this->getAttribute('names') as $name) {
+            $compiler->raw('$context["'.$name.'"] = $__'.$name.'__; ');
+        }
+        $compiler
+            ->raw('return ')
+            ->subcompile($this->getNode('expr'))
+            ->raw('; }')
+        ;
+    }
+}

--- a/src/Node/Expression/ArrowFunctionExpression.php
+++ b/src/Node/Expression/ArrowFunctionExpression.php
@@ -12,6 +12,7 @@
 namespace Twig\Node\Expression;
 
 use Twig\Compiler;
+use Twig\Node\Node;
 
 /**
  * Represents an arrow function.
@@ -20,9 +21,9 @@ use Twig\Compiler;
  */
 class ArrowFunctionExpression extends AbstractExpression
 {
-    public function __construct(AbstractExpression $expr, array $names, $lineno, $tag = null)
+    public function __construct(AbstractExpression $expr, Node $names, $lineno, $tag = null)
     {
-        parent::__construct(['expr' => $expr], ['names' => $names], $lineno, $tag);
+        parent::__construct(['expr' => $expr, 'names' => $names], [], $lineno, $tag);
     }
 
     public function compile(Compiler $compiler)
@@ -31,18 +32,28 @@ class ArrowFunctionExpression extends AbstractExpression
             ->addDebugInfo($this)
             ->raw('function (')
         ;
-        foreach ($this->getAttribute('names') as $i => $name) {
+        foreach ($this->getNode('names') as $i => $name) {
             if ($i) {
                 $compiler->raw(', ');
             }
 
-            $compiler->raw('$__'.$name.'__');
+            $compiler
+                ->raw('$__')
+                ->raw($name->getAttribute('name'))
+                ->raw('__')
+            ;
         }
         $compiler
             ->raw(') use ($context) { ')
         ;
-        foreach ($this->getAttribute('names') as $name) {
-            $compiler->raw('$context["'.$name.'"] = $__'.$name.'__; ');
+        foreach ($this->getNode('names') as $name) {
+            $compiler
+                ->raw('$context["')
+                ->raw($name->getAttribute('name'))
+                ->raw('"] = $__')
+                ->raw($name->getAttribute('name'))
+                ->raw('__; ')
+            ;
         }
         $compiler
             ->raw('return ')

--- a/src/Token.php
+++ b/src/Token.php
@@ -38,6 +38,7 @@ class Token
     const PUNCTUATION_TYPE = 9;
     const INTERPOLATION_START_TYPE = 10;
     const INTERPOLATION_END_TYPE = 11;
+    const ARROW_TYPE = 12;
 
     /**
      * @param int    $type   The type of the token
@@ -157,6 +158,9 @@ class Token
             case self::INTERPOLATION_END_TYPE:
                 $name = 'INTERPOLATION_END_TYPE';
                 break;
+            case self::ARROW_TYPE:
+                $name = 'ARROW_TYPE';
+                break;
             default:
                 throw new \LogicException(sprintf('Token of type "%s" does not exist.', $type));
         }
@@ -200,6 +204,8 @@ class Token
                 return 'begin of string interpolation';
             case self::INTERPOLATION_END_TYPE:
                 return 'end of string interpolation';
+            case self::ARROW_TYPE:
+                return 'arrow function';
             default:
                 throw new \LogicException(sprintf('Token of type "%s" does not exist.', $type));
         }

--- a/test/Twig/Tests/Fixtures/expressions/not_arrow_fn.test
+++ b/test/Twig/Tests/Fixtures/expressions/not_arrow_fn.test
@@ -1,0 +1,8 @@
+--TEST--
+A string in parentheses cannot be confused with an arrow function
+--TEMPLATE--
+{{ ["foo", "bar"]|join(("f")) }}
+--DATA--
+return []
+--EXPECT--
+foofbar

--- a/test/Twig/Tests/Fixtures/filters/filter.test
+++ b/test/Twig/Tests/Fixtures/filters/filter.test
@@ -3,10 +3,15 @@
 --TEMPLATE--
 {% set offset = 3 %}
 
-{% for k, v in [1, 5, 3, 4, 5]|filter(fn(v) => v > offset) -%}
+{% for k, v in [1, 5, 3, 4, 5]|filter((v) => v > offset) -%}
     {{ k }} = {{ v }}
 {% endfor %}
-{% for k, v in {a: 1, b: 2, c: 5, d: 2}|filter(fn(v) => v > offset) -%}
+
+{% for k, v in {a: 1, b: 2, c: 5, d: 2}|filter((v) => v > offset) -%}
+    {{ k }} = {{ v }}
+{% endfor %}
+
+{% for k, v in [1, 5, 3, 4, 5]|filter(v => v > offset) -%}
     {{ k }} = {{ v }}
 {% endfor %}
 --DATA--
@@ -15,4 +20,9 @@ return []
 1 = 5
 3 = 4
 4 = 5
+
 c = 5
+
+1 = 5
+3 = 4
+4 = 5

--- a/test/Twig/Tests/Fixtures/filters/filter.test
+++ b/test/Twig/Tests/Fixtures/filters/filter.test
@@ -1,0 +1,18 @@
+--TEST--
+"filter" filter
+--TEMPLATE--
+{% set offset = 3 %}
+
+{% for k, v in [1, 5, 3, 4, 5]|filter(|v| => v > offset) -%}
+    {{ k }} = {{ v }}
+{% endfor %}
+{% for k, v in {a: 1, b: 2, c: 5, d: 2}|filter(|v| => v > offset) -%}
+    {{ k }} = {{ v }}
+{% endfor %}
+--DATA--
+return []
+--EXPECT--
+1 = 5
+3 = 4
+4 = 5
+c = 5

--- a/test/Twig/Tests/Fixtures/filters/filter.test
+++ b/test/Twig/Tests/Fixtures/filters/filter.test
@@ -14,8 +14,12 @@
 {% for k, v in [1, 5, 3, 4, 5]|filter(v => v > offset) -%}
     {{ k }} = {{ v }}
 {% endfor %}
+
+{% for k, v in it|filter((v) => v > offset) -%}
+    {{ k }} = {{ v }}
+{% endfor %}
 --DATA--
-return []
+return ['it' => new \ArrayIterator(['a' => 1, 'b' => 2, 'c' => 5, 'd' => 2])]
 --EXPECT--
 1 = 5
 3 = 4
@@ -26,3 +30,5 @@ c = 5
 1 = 5
 3 = 4
 4 = 5
+
+c = 5

--- a/test/Twig/Tests/Fixtures/filters/filter.test
+++ b/test/Twig/Tests/Fixtures/filters/filter.test
@@ -3,10 +3,10 @@
 --TEMPLATE--
 {% set offset = 3 %}
 
-{% for k, v in [1, 5, 3, 4, 5]|filter(|v| => v > offset) -%}
+{% for k, v in [1, 5, 3, 4, 5]|filter(fn(v) => v > offset) -%}
     {{ k }} = {{ v }}
 {% endfor %}
-{% for k, v in {a: 1, b: 2, c: 5, d: 2}|filter(|v| => v > offset) -%}
+{% for k, v in {a: 1, b: 2, c: 5, d: 2}|filter(fn(v) => v > offset) -%}
     {{ k }} = {{ v }}
 {% endfor %}
 --DATA--

--- a/test/Twig/Tests/Fixtures/filters/filter.test
+++ b/test/Twig/Tests/Fixtures/filters/filter.test
@@ -7,7 +7,7 @@
     {{ k }} = {{ v }}
 {% endfor %}
 
-{% for k, v in {a: 1, b: 2, c: 5, d: 2}|filter((v) => v > offset) -%}
+{% for k, v in {a: 1, b: 2, c: 5, d: 8}|filter(v => v > offset) -%}
     {{ k }} = {{ v }}
 {% endfor %}
 
@@ -19,16 +19,18 @@
     {{ k }} = {{ v }}
 {% endfor %}
 --DATA--
-return ['it' => new \ArrayIterator(['a' => 1, 'b' => 2, 'c' => 5, 'd' => 2])]
+return ['it' => new \ArrayIterator(['a' => 1, 'b' => 2, 'c' => 5, 'd' => 8])]
 --EXPECT--
 1 = 5
 3 = 4
 4 = 5
 
 c = 5
+d = 8
 
 1 = 5
 3 = 4
 4 = 5
 
 c = 5
+d = 8

--- a/test/Twig/Tests/Fixtures/filters/filter_php_56.test
+++ b/test/Twig/Tests/Fixtures/filters/filter_php_56.test
@@ -1,0 +1,20 @@
+--TEST--
+"filter" filter (PHP 5.6 required)
+--CONDITION--
+version_compare(phpversion(), '5.6.0', '>=')
+--TEMPLATE--
+{% set offset = 3 %}
+
+{% for k, v in {a: 1, b: 2, c: 5, d: 8}|filter((v, k) => (v > offset) and (k != "d")) -%}
+    {{ k }} = {{ v }}
+{% endfor %}
+
+{% for k, v in it|filter((v, k) => (v > offset) and (k != "d")) -%}
+    {{ k }} = {{ v }}
+{% endfor %}
+--DATA--
+return ['it' => new \ArrayIterator(['a' => 1, 'b' => 2, 'c' => 5, 'd' => 8])]
+--EXPECT--
+c = 5
+
+c = 5

--- a/test/Twig/Tests/Fixtures/filters/map.test
+++ b/test/Twig/Tests/Fixtures/filters/map.test
@@ -11,6 +11,10 @@
     {{ k }} = {{ v }}
 {% endfor %}
 
+{% for k, v in {a: 1, b: 2}|map((item, k) => item ~ "*" ~ k ) -%}
+    {{ k }} = {{ v }}
+{% endfor %}
+
 {% for k, v in [1, 2]|map(item => item + 2 ) -%}
     {{ k }} = {{ v }}
 {% endfor %}
@@ -26,6 +30,9 @@ return ['it' => new \ArrayIterator([1, 2])]
 
 a = 1*
 b = 2*
+
+a = 1*a
+b = 2*b
 
 0 = 3
 1 = 4

--- a/test/Twig/Tests/Fixtures/filters/map.test
+++ b/test/Twig/Tests/Fixtures/filters/map.test
@@ -1,0 +1,18 @@
+--TEST--
+"map" filter
+--TEMPLATE--
+{% set offset = 3 %}
+
+{% for k, v in [1, 2]|map(|item| => item + 2 ) -%}
+    {{ k }} = {{ v }}
+{% endfor %}
+{% for k, v in {a: 1, b: 2}|map(|item| => item ~ "*" ) -%}
+    {{ k }} = {{ v }}
+{% endfor %}
+--DATA--
+return []
+--EXPECT--
+0 = 3
+1 = 4
+a = 1*
+b = 2*

--- a/test/Twig/Tests/Fixtures/filters/map.test
+++ b/test/Twig/Tests/Fixtures/filters/map.test
@@ -3,10 +3,10 @@
 --TEMPLATE--
 {% set offset = 3 %}
 
-{% for k, v in [1, 2]|map(|item| => item + 2 ) -%}
+{% for k, v in [1, 2]|map(fn(item) => item + 2 ) -%}
     {{ k }} = {{ v }}
 {% endfor %}
-{% for k, v in {a: 1, b: 2}|map(|item| => item ~ "*" ) -%}
+{% for k, v in {a: 1, b: 2}|map(fn(item) => item ~ "*" ) -%}
     {{ k }} = {{ v }}
 {% endfor %}
 --DATA--

--- a/test/Twig/Tests/Fixtures/filters/map.test
+++ b/test/Twig/Tests/Fixtures/filters/map.test
@@ -14,14 +14,21 @@
 {% for k, v in [1, 2]|map(item => item + 2 ) -%}
     {{ k }} = {{ v }}
 {% endfor %}
+
+{% for k, v in it|map(item => item + 2 ) -%}
+    {{ k }} = {{ v }}
+{% endfor %}
 --DATA--
-return []
+return ['it' => new \ArrayIterator([1, 2])]
 --EXPECT--
 0 = 3
 1 = 4
 
 a = 1*
 b = 2*
+
+0 = 3
+1 = 4
 
 0 = 3
 1 = 4

--- a/test/Twig/Tests/Fixtures/filters/map.test
+++ b/test/Twig/Tests/Fixtures/filters/map.test
@@ -3,10 +3,15 @@
 --TEMPLATE--
 {% set offset = 3 %}
 
-{% for k, v in [1, 2]|map(fn(item) => item + 2 ) -%}
+{% for k, v in [1, 2]|map((item) => item + 2 ) -%}
     {{ k }} = {{ v }}
 {% endfor %}
-{% for k, v in {a: 1, b: 2}|map(fn(item) => item ~ "*" ) -%}
+
+{% for k, v in {a: 1, b: 2}|map((item) => item ~ "*" ) -%}
+    {{ k }} = {{ v }}
+{% endfor %}
+
+{% for k, v in [1, 2]|map(item => item + 2 ) -%}
     {{ k }} = {{ v }}
 {% endfor %}
 --DATA--
@@ -14,5 +19,9 @@ return []
 --EXPECT--
 0 = 3
 1 = 4
+
 a = 1*
 b = 2*
+
+0 = 3
+1 = 4

--- a/test/Twig/Tests/Fixtures/filters/reduce.test
+++ b/test/Twig/Tests/Fixtures/filters/reduce.test
@@ -4,7 +4,11 @@
 {% set offset = 3 %}
 
 {{ [1, -1, 4]|reduce((carry, item) => carry + item + offset, 10) }}
+
+{{ it|reduce((carry, item) => carry + item + offset, 10) }}
 --DATA--
-return []
+return ['it' => new \ArrayIterator([1, -1, 4])]
 --EXPECT--
+23
+
 23

--- a/test/Twig/Tests/Fixtures/filters/reduce.test
+++ b/test/Twig/Tests/Fixtures/filters/reduce.test
@@ -3,7 +3,7 @@
 --TEMPLATE--
 {% set offset = 3 %}
 
-{{ [1, -1, 4]|reduce(fn(carry, item) => carry + item + offset, 10) }}
+{{ [1, -1, 4]|reduce((carry, item) => carry + item + offset, 10) }}
 --DATA--
 return []
 --EXPECT--

--- a/test/Twig/Tests/Fixtures/filters/reduce.test
+++ b/test/Twig/Tests/Fixtures/filters/reduce.test
@@ -3,7 +3,7 @@
 --TEMPLATE--
 {% set offset = 3 %}
 
-{{ [1, -1, 4]|reduce(|carry, item| => carry + item + offset, 10) }}
+{{ [1, -1, 4]|reduce(fn(carry, item) => carry + item + offset, 10) }}
 --DATA--
 return []
 --EXPECT--

--- a/test/Twig/Tests/Fixtures/filters/reduce.test
+++ b/test/Twig/Tests/Fixtures/filters/reduce.test
@@ -1,0 +1,10 @@
+--TEST--
+"reduce" filter
+--TEMPLATE--
+{% set offset = 3 %}
+
+{{ [1, -1, 4]|reduce(|carry, item| => carry + item + offset, 10) }}
+--DATA--
+return []
+--EXPECT--
+23


### PR DESCRIPTION
This PR adds support for 3 new filters: `filter`, `map`, and `reduce`. They take an arrow function as an argument (a PHP closure).

I have restricted the usage of arrow functions as much as possible as it makes no sense to support them everywhere. So, for now, they are only accepted as arguments to filters (using them as arguments to function is not supported but could be easily added if we have a use case).

The syntax is the following: `(x) => x + 3` where `(x)` is the list of arguments, `=>` starts the body, and the body is any Twig expression. Within the arrow function, the context is also available: `(x) => x + offset` works if `offset` is defined in the current context.

~~These new filters will allow us to deprecate the `if` support on the `for` tag, which does not work well with the `loop` variable:~~

```twig

{% set sizes = {xs: 34, s: 36, m: 38, l: 40, xl: 42} %}

{# before #}
{% for name, size in sizes if size < 38 %}
    {{ name }} = {{ size }}
    {% loop.last ? 'LAST' %} {# <--- works with this PR #}
{% endfor %}

{# after #}
{% for name, size in sizes|filter(size => size < 38) %}
    {{ name }} = {{ size }}
    {{ loop.last ? 'LAST' }}
{% endfor %}
```

This closes #2785 