### PR TITLE
hash literal property value shorthand

### DIFF
--- a/test/Twig/Tests/ExpressionParserTest.php
+++ b/test/Twig/Tests/ExpressionParserTest.php
@@ -116,6 +116,16 @@ class Twig_Tests_ExpressionParserTest extends \PHPUnit\Framework\TestCase
                 ], 1),
             ],
 
+            // simple hash using syntactic sugar
+            ['{{ {"a", "b"} }}', new ArrayExpression([
+                new ConstantExpression('a', 1),
+                new NameExpression('a', 1),
+
+                new ConstantExpression('b', 1),
+                new NameExpression('b', 1),
+            ], 1),
+            ],
+
             // hash with trailing ,
             ['{{ {"a": "b", "b": "c", } }}', new ArrayExpression([
                   new ConstantExpression('a', 1),


### PR DESCRIPTION
While doing some Twig templates recently. I was taking myself writing things like this:

```
{{ include('pagination.html.twig', { count: count, current_page: current_page, current_route: current_route }) }}
```
And was thinking about the ability of doing this:

```
{{ include('pagination.html.twig', { count, current_page, current_route }) }}
```

This is the purpose of this PR. This syntactic sugar comes from the JavaScript world (ES6) in the name of `Object Literal Property Value Shorthand` and It's very convenient to use.