### PR TITLE
Fix a PHP fatal error when calling a macro, imported in the template, in another macro

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 1.41.1 (2019-XX-XX)
 
+ * fixed a PHP fatal error when calling a macro imported in the template in another macro
  * fixed wrong error message on "import" and "from"
 
 * 1.41.0 (2019-05-14)

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -334,11 +334,7 @@ class Parser implements \Twig_ParserInterface
 
     public function getImportedSymbol($type, $alias)
     {
-        foreach ($this->importedSymbols as $functions) {
-            if (isset($functions[$type][$alias])) {
-                return $functions[$type][$alias];
-            }
-        }
+        return isset($this->importedSymbols[0][$type][$alias]) ? $this->importedSymbols[0][$type][$alias] : null;
     }
 
     public function isMainScope()

--- a/test/Twig/Tests/Fixtures/tags/macro/macro_in_a_macro.test
+++ b/test/Twig/Tests/Fixtures/tags/macro/macro_in_a_macro.test
@@ -1,0 +1,15 @@
+--TEST--
+"from" tag with syntax error
+--TEMPLATE--
+{% from _self import another %}
+
+{% macro foo() %}
+    {{ another() }}
+{% endmacro %}
+
+{% macro another() %}
+{% endmacro %}
+--DATA--
+return []
+--EXCEPTION--
+Twig\Error\SyntaxError: Unknown "another" function in "index.twig" at line 5.


### PR DESCRIPTION
The current code iterates over all imported functions (traversing all the scopes). So, the macro was found at compilation time, but didn't work at runtime, leading to a PHP fatal error. Now, you get a proper exception at compilation time.
