### PR TITLE
doc(filter): add example of `filter` without `for` use

### DIFF
--- a/doc/filters/filter.rst
+++ b/doc/filters/filter.rst
@@ -29,6 +29,9 @@ function. The arrow function receives the value of the sequence or mapping:
     {% endfor %}
     {# output l = 40 xl = 42 #}
 
+    {{ sizes|filter(v => v > 38)|join(', ') }}
+    {# output 40, 42 #}
+
 The arrow function also receives the key as a second argument:
 
 .. code-block:: twig


### PR DESCRIPTION
First, thanks for #2996! :)

This PR add an example of `filter` usage without using a `for` loop, to prevend some misinterpretation to people.

At first read, I thought `filter` was only usable with `for` loop, but nope. In fact it iterates on the result produced by `filter`.
