### PR TITLE
Deprecate CoreExtension::setEscaper() and CoreExtension::getEscaper() in favor of the same methods on EscaperExtension

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * 2.11.0 (2019-XX-XX)
 
+ * deprecated CoreExtension::setEscaper() and CoreExtension::getEscapers() in favor of the same methods on EscaperExtension
  * macros are now auto-imported in the template they are defined (under the ``_self`` variable)
  * added support for macros on "is defined" tests
  * fixed macros "import" when using the same name in the parent and child templates

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -93,6 +93,13 @@ Interfaces
 * As of Twig 2.7, the ``Twig\Extension\InitRuntimeInterface`` interface is
   deprecated and will be removed in Twig 3.0.
 
+Extensions
+----------
+
+* As of Twig 2.11, the ``Twig\Extension\CoreExtension::setEscaper()`` and
+  ``Twig\Extension\CoreExtension::getEscapers()`` are deprecated. Use the same
+  methods on ``Twig\Extension\EscaperExtension`` instead.
+
 Miscellaneous
 -------------
 

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -83,9 +83,13 @@ final class CoreExtension extends AbstractExtension
      *
      * @param string   $strategy The strategy name that should be used as a strategy in the escape call
      * @param callable $callable A valid PHP callable
+     *
+     * @deprecated since Twig 2.11, to be removed in 3.0; use the same method on EscaperExtension instead
      */
     public function setEscaper($strategy, callable $callable)
     {
+        @trigger_error(sprintf('The "%s" method is deprecated since Twig 2.11; use "%s::setEscaper" instead.', __METHOD__, EscaperExtension::class), E_USER_DEPRECATED);
+
         $this->escapers[$strategy] = $callable;
     }
 
@@ -93,9 +97,15 @@ final class CoreExtension extends AbstractExtension
      * Gets all defined escapers.
      *
      * @return callable[] An array of escapers
+     *
+     * @deprecated since Twig 2.11, to be removed in 3.0; use the same method on EscaperExtension instead
      */
-    public function getEscapers()
+    public function getEscapers(/* $triggerDeprecation = true */)
     {
+        if (0 === \func_num_args() || func_get_arg(0)) {
+            @trigger_error(sprintf('The "%s" method is deprecated since Twig 2.11; use "%s::getEscapers" instead.', __METHOD__, EscaperExtension::class), E_USER_DEPRECATED);
+        }
+
         return $this->escapers;
     }
 
@@ -244,10 +254,6 @@ final class CoreExtension extends AbstractExtension
             // iteration and runtime
             new TwigFilter('default', '_twig_default_filter', ['node_class' => DefaultFilter::class]),
             new TwigFilter('keys', 'twig_get_array_keys_filter'),
-
-            // escaping
-            new TwigFilter('escape', 'twig_escape_filter', ['needs_environment' => true, 'is_safe_callback' => 'twig_escape_filter_is_safe']),
-            new TwigFilter('e', 'twig_escape_filter', ['needs_environment' => true, 'is_safe_callback' => 'twig_escape_filter_is_safe']),
         ];
     }
 
@@ -339,8 +345,6 @@ namespace {
     use Twig\Extension\CoreExtension;
     use Twig\Extension\SandboxExtension;
     use Twig\Markup;
-    use Twig\Node\Expression\ConstantExpression;
-    use Twig\Node\Node;
     use Twig\Source;
     use Twig\Template;
 
@@ -980,250 +984,6 @@ function twig_trim_filter($string, $characterMask = null, $side = 'both')
 function twig_spaceless($content)
 {
     return trim(preg_replace('/>\s+</', '><', $content));
-}
-
-/**
- * Escapes a string.
- *
- * @param mixed  $string     The value to be escaped
- * @param string $strategy   The escaping strategy
- * @param string $charset    The charset
- * @param bool   $autoescape Whether the function is called by the auto-escaping feature (true) or by the developer (false)
- *
- * @return string
- */
-function twig_escape_filter(Environment $env, $string, $strategy = 'html', $charset = null, $autoescape = false)
-{
-    if ($autoescape && $string instanceof Markup) {
-        return $string;
-    }
-
-    if (!\is_string($string)) {
-        if (\is_object($string) && method_exists($string, '__toString')) {
-            $string = (string) $string;
-        } elseif (\in_array($strategy, ['html', 'js', 'css', 'html_attr', 'url'])) {
-            return $string;
-        }
-    }
-
-    if ('' === $string) {
-        return '';
-    }
-
-    if (null === $charset) {
-        $charset = $env->getCharset();
-    }
-
-    switch ($strategy) {
-        case 'html':
-            // see https://secure.php.net/htmlspecialchars
-
-            // Using a static variable to avoid initializing the array
-            // each time the function is called. Moving the declaration on the
-            // top of the function slow downs other escaping strategies.
-            static $htmlspecialcharsCharsets = [
-                'ISO-8859-1' => true, 'ISO8859-1' => true,
-                'ISO-8859-15' => true, 'ISO8859-15' => true,
-                'utf-8' => true, 'UTF-8' => true,
-                'CP866' => true, 'IBM866' => true, '866' => true,
-                'CP1251' => true, 'WINDOWS-1251' => true, 'WIN-1251' => true,
-                '1251' => true,
-                'CP1252' => true, 'WINDOWS-1252' => true, '1252' => true,
-                'KOI8-R' => true, 'KOI8-RU' => true, 'KOI8R' => true,
-                'BIG5' => true, '950' => true,
-                'GB2312' => true, '936' => true,
-                'BIG5-HKSCS' => true,
-                'SHIFT_JIS' => true, 'SJIS' => true, '932' => true,
-                'EUC-JP' => true, 'EUCJP' => true,
-                'ISO8859-5' => true, 'ISO-8859-5' => true, 'MACROMAN' => true,
-            ];
-
-            if (isset($htmlspecialcharsCharsets[$charset])) {
-                return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
-            }
-
-            if (isset($htmlspecialcharsCharsets[strtoupper($charset)])) {
-                // cache the lowercase variant for future iterations
-                $htmlspecialcharsCharsets[$charset] = true;
-
-                return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
-            }
-
-            $string = iconv($charset, 'UTF-8', $string);
-            $string = htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-
-            return iconv('UTF-8', $charset, $string);
-
-        case 'js':
-            // escape all non-alphanumeric characters
-            // into their \x or \uHHHH representations
-            if ('UTF-8' !== $charset) {
-                $string = iconv($charset, 'UTF-8', $string);
-            }
-
-            if (!preg_match('//u', $string)) {
-                throw new RuntimeError('The string to escape is not a valid UTF-8 string.');
-            }
-
-            $string = preg_replace_callback('#[^a-zA-Z0-9,\._]#Su', function ($matches) {
-                $char = $matches[0];
-
-                /*
-                 * A few characters have short escape sequences in JSON and JavaScript.
-                 * Escape sequences supported only by JavaScript, not JSON, are ommitted.
-                 * \" is also supported but omitted, because the resulting string is not HTML safe.
-                 */
-                static $shortMap = [
-                    '\\' => '\\\\',
-                    '/' => '\\/',
-                    "\x08" => '\b',
-                    "\x0C" => '\f',
-                    "\x0A" => '\n',
-                    "\x0D" => '\r',
-                    "\x09" => '\t',
-                ];
-
-                if (isset($shortMap[$char])) {
-                    return $shortMap[$char];
-                }
-
-                // \uHHHH
-                $char = twig_convert_encoding($char, 'UTF-16BE', 'UTF-8');
-                $char = strtoupper(bin2hex($char));
-
-                if (4 >= \strlen($char)) {
-                    return sprintf('\u%04s', $char);
-                }
-
-                return sprintf('\u%04s\u%04s', substr($char, 0, -4), substr($char, -4));
-            }, $string);
-
-            if ('UTF-8' !== $charset) {
-                $string = iconv('UTF-8', $charset, $string);
-            }
-
-            return $string;
-
-        case 'css':
-            if ('UTF-8' !== $charset) {
-                $string = iconv($charset, 'UTF-8', $string);
-            }
-
-            if (!preg_match('//u', $string)) {
-                throw new RuntimeError('The string to escape is not a valid UTF-8 string.');
-            }
-
-            $string = preg_replace_callback('#[^a-zA-Z0-9]#Su', function ($matches) {
-                $char = $matches[0];
-
-                return sprintf('\\%X ', 1 === \strlen($char) ? \ord($char) : mb_ord($char, 'UTF-8'));
-            }, $string);
-
-            if ('UTF-8' !== $charset) {
-                $string = iconv('UTF-8', $charset, $string);
-            }
-
-            return $string;
-
-        case 'html_attr':
-            if ('UTF-8' !== $charset) {
-                $string = iconv($charset, 'UTF-8', $string);
-            }
-
-            if (!preg_match('//u', $string)) {
-                throw new RuntimeError('The string to escape is not a valid UTF-8 string.');
-            }
-
-            $string = preg_replace_callback('#[^a-zA-Z0-9,\.\-_]#Su', function ($matches) {
-                /**
-                 * This function is adapted from code coming from Zend Framework.
-                 *
-                 * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (https://www.zend.com)
-                 * @license   https://framework.zend.com/license/new-bsd New BSD License
-                 */
-                $chr = $matches[0];
-                $ord = \ord($chr);
-
-                /*
-                 * The following replaces characters undefined in HTML with the
-                 * hex entity for the Unicode replacement character.
-                 */
-                if (($ord <= 0x1f && "\t" != $chr && "\n" != $chr && "\r" != $chr) || ($ord >= 0x7f && $ord <= 0x9f)) {
-                    return '&#xFFFD;';
-                }
-
-                /*
-                 * Check if the current character to escape has a name entity we should
-                 * replace it with while grabbing the hex value of the character.
-                 */
-                if (1 === \strlen($chr)) {
-                    /*
-                     * While HTML supports far more named entities, the lowest common denominator
-                     * has become HTML5's XML Serialisation which is restricted to the those named
-                     * entities that XML supports. Using HTML entities would result in this error:
-                     *     XML Parsing Error: undefined entity
-                     */
-                    static $entityMap = [
-                        34 => '&quot;', /* quotation mark */
-                        38 => '&amp;',  /* ampersand */
-                        60 => '&lt;',   /* less-than sign */
-                        62 => '&gt;',   /* greater-than sign */
-                    ];
-
-                    if (isset($entityMap[$ord])) {
-                        return $entityMap[$ord];
-                    }
-
-                    return sprintf('&#x%02X;', $ord);
-                }
-
-                /*
-                 * Per OWASP recommendations, we'll use hex entities for any other
-                 * characters where a named entity does not exist.
-                 */
-                return sprintf('&#x%04X;', mb_ord($chr, 'UTF-8'));
-            }, $string);
-
-            if ('UTF-8' !== $charset) {
-                $string = iconv('UTF-8', $charset, $string);
-            }
-
-            return $string;
-
-        case 'url':
-            return rawurlencode($string);
-
-        default:
-            static $escapers;
-
-            if (null === $escapers) {
-                $escapers = $env->getExtension(CoreExtension::class)->getEscapers();
-            }
-
-            if (isset($escapers[$strategy])) {
-                return $escapers[$strategy]($env, $string, $charset);
-            }
-
-            $validStrategies = implode(', ', array_merge(['html', 'js', 'url', 'css', 'html_attr'], array_keys($escapers)));
-
-            throw new RuntimeError(sprintf('Invalid escaping strategy "%s" (valid ones: %s).', $strategy, $validStrategies));
-    }
-}
-
-/**
- * @internal
- */
-function twig_escape_filter_is_safe(Node $filterArgs)
-{
-    foreach ($filterArgs as $arg) {
-        if ($arg instanceof ConstantExpression) {
-            return [$arg->getAttribute('value')];
-        }
-
-        return [];
-    }
-
-    return ['html'];
 }
 
 function twig_convert_encoding($string, $to, $from)

--- a/src/Extension/EscaperExtension.php
+++ b/src/Extension/EscaperExtension.php
@@ -18,6 +18,7 @@ use Twig\TwigFilter;
 final class EscaperExtension extends AbstractExtension
 {
     private $defaultStrategy;
+    private $escapers = [];
 
     /**
      * @param string|false|callable $defaultStrategy An escaping strategy
@@ -42,6 +43,8 @@ final class EscaperExtension extends AbstractExtension
     public function getFilters()
     {
         return [
+            new TwigFilter('escape', 'twig_escape_filter', ['needs_environment' => true, 'is_safe_callback' => 'twig_escape_filter_is_safe']),
+            new TwigFilter('e', 'twig_escape_filter', ['needs_environment' => true, 'is_safe_callback' => 'twig_escape_filter_is_safe']),
             new TwigFilter('raw', 'twig_raw_filter', ['is_safe' => ['all']]),
         ];
     }
@@ -80,12 +83,41 @@ final class EscaperExtension extends AbstractExtension
 
         return $this->defaultStrategy;
     }
+
+    /**
+     * Defines a new escaper to be used via the escape filter.
+     *
+     * @param string   $strategy The strategy name that should be used as a strategy in the escape call
+     * @param callable $callable A valid PHP callable
+     */
+    public function setEscaper($strategy, callable $callable)
+    {
+        $this->escapers[$strategy] = $callable;
+    }
+
+    /**
+     * Gets all defined escapers.
+     *
+     * @return callable[] An array of escapers
+     */
+    public function getEscapers()
+    {
+        return $this->escapers;
+    }
 }
 
 class_alias('Twig\Extension\EscaperExtension', 'Twig_Extension_Escaper');
 }
 
 namespace {
+use Twig\Environment;
+use Twig\Error\RuntimeError;
+use Twig\Extension\CoreExtension;
+use Twig\Extension\EscaperExtension;
+use Twig\Markup;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Node;
+
 /**
  * Marks a variable as being safe.
  *
@@ -96,5 +128,253 @@ namespace {
 function twig_raw_filter($string)
 {
     return $string;
+}
+
+/**
+ * Escapes a string.
+ *
+ * @param mixed  $string     The value to be escaped
+ * @param string $strategy   The escaping strategy
+ * @param string $charset    The charset
+ * @param bool   $autoescape Whether the function is called by the auto-escaping feature (true) or by the developer (false)
+ *
+ * @return string
+ */
+function twig_escape_filter(Environment $env, $string, $strategy = 'html', $charset = null, $autoescape = false)
+{
+    if ($autoescape && $string instanceof Markup) {
+        return $string;
+    }
+
+    if (!\is_string($string)) {
+        if (\is_object($string) && method_exists($string, '__toString')) {
+            $string = (string) $string;
+        } elseif (\in_array($strategy, ['html', 'js', 'css', 'html_attr', 'url'])) {
+            return $string;
+        }
+    }
+
+    if ('' === $string) {
+        return '';
+    }
+
+    if (null === $charset) {
+        $charset = $env->getCharset();
+    }
+
+    switch ($strategy) {
+        case 'html':
+            // see https://secure.php.net/htmlspecialchars
+
+            // Using a static variable to avoid initializing the array
+            // each time the function is called. Moving the declaration on the
+            // top of the function slow downs other escaping strategies.
+            static $htmlspecialcharsCharsets = [
+                'ISO-8859-1' => true, 'ISO8859-1' => true,
+                'ISO-8859-15' => true, 'ISO8859-15' => true,
+                'utf-8' => true, 'UTF-8' => true,
+                'CP866' => true, 'IBM866' => true, '866' => true,
+                'CP1251' => true, 'WINDOWS-1251' => true, 'WIN-1251' => true,
+                '1251' => true,
+                'CP1252' => true, 'WINDOWS-1252' => true, '1252' => true,
+                'KOI8-R' => true, 'KOI8-RU' => true, 'KOI8R' => true,
+                'BIG5' => true, '950' => true,
+                'GB2312' => true, '936' => true,
+                'BIG5-HKSCS' => true,
+                'SHIFT_JIS' => true, 'SJIS' => true, '932' => true,
+                'EUC-JP' => true, 'EUCJP' => true,
+                'ISO8859-5' => true, 'ISO-8859-5' => true, 'MACROMAN' => true,
+            ];
+
+            if (isset($htmlspecialcharsCharsets[$charset])) {
+                return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
+            }
+
+            if (isset($htmlspecialcharsCharsets[strtoupper($charset)])) {
+                // cache the lowercase variant for future iterations
+                $htmlspecialcharsCharsets[$charset] = true;
+
+                return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
+            }
+
+            $string = iconv($charset, 'UTF-8', $string);
+            $string = htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+            return iconv('UTF-8', $charset, $string);
+
+        case 'js':
+            // escape all non-alphanumeric characters
+            // into their \x or \uHHHH representations
+            if ('UTF-8' !== $charset) {
+                $string = iconv($charset, 'UTF-8', $string);
+            }
+
+            if (!preg_match('//u', $string)) {
+                throw new RuntimeError('The string to escape is not a valid UTF-8 string.');
+            }
+
+            $string = preg_replace_callback('#[^a-zA-Z0-9,\._]#Su', function ($matches) {
+                $char = $matches[0];
+
+                /*
+                 * A few characters have short escape sequences in JSON and JavaScript.
+                 * Escape sequences supported only by JavaScript, not JSON, are ommitted.
+                 * \" is also supported but omitted, because the resulting string is not HTML safe.
+                 */
+                static $shortMap = [
+                    '\\' => '\\\\',
+                    '/' => '\\/',
+                    "\x08" => '\b',
+                    "\x0C" => '\f',
+                    "\x0A" => '\n',
+                    "\x0D" => '\r',
+                    "\x09" => '\t',
+                ];
+
+                if (isset($shortMap[$char])) {
+                    return $shortMap[$char];
+                }
+
+                // \uHHHH
+                $char = twig_convert_encoding($char, 'UTF-16BE', 'UTF-8');
+                $char = strtoupper(bin2hex($char));
+
+                if (4 >= \strlen($char)) {
+                    return sprintf('\u%04s', $char);
+                }
+
+                return sprintf('\u%04s\u%04s', substr($char, 0, -4), substr($char, -4));
+            }, $string);
+
+            if ('UTF-8' !== $charset) {
+                $string = iconv('UTF-8', $charset, $string);
+            }
+
+            return $string;
+
+        case 'css':
+            if ('UTF-8' !== $charset) {
+                $string = iconv($charset, 'UTF-8', $string);
+            }
+
+            if (!preg_match('//u', $string)) {
+                throw new RuntimeError('The string to escape is not a valid UTF-8 string.');
+            }
+
+            $string = preg_replace_callback('#[^a-zA-Z0-9]#Su', function ($matches) {
+                $char = $matches[0];
+
+                return sprintf('\\%X ', 1 === \strlen($char) ? \ord($char) : mb_ord($char, 'UTF-8'));
+            }, $string);
+
+            if ('UTF-8' !== $charset) {
+                $string = iconv('UTF-8', $charset, $string);
+            }
+
+            return $string;
+
+        case 'html_attr':
+            if ('UTF-8' !== $charset) {
+                $string = iconv($charset, 'UTF-8', $string);
+            }
+
+            if (!preg_match('//u', $string)) {
+                throw new RuntimeError('The string to escape is not a valid UTF-8 string.');
+            }
+
+            $string = preg_replace_callback('#[^a-zA-Z0-9,\.\-_]#Su', function ($matches) {
+                /**
+                 * This function is adapted from code coming from Zend Framework.
+                 *
+                 * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (https://www.zend.com)
+                 * @license   https://framework.zend.com/license/new-bsd New BSD License
+                 */
+                $chr = $matches[0];
+                $ord = \ord($chr);
+
+                /*
+                 * The following replaces characters undefined in HTML with the
+                 * hex entity for the Unicode replacement character.
+                 */
+                if (($ord <= 0x1f && "\t" != $chr && "\n" != $chr && "\r" != $chr) || ($ord >= 0x7f && $ord <= 0x9f)) {
+                    return '&#xFFFD;';
+                }
+
+                /*
+                 * Check if the current character to escape has a name entity we should
+                 * replace it with while grabbing the hex value of the character.
+                 */
+                if (1 === \strlen($chr)) {
+                    /*
+                     * While HTML supports far more named entities, the lowest common denominator
+                     * has become HTML5's XML Serialisation which is restricted to the those named
+                     * entities that XML supports. Using HTML entities would result in this error:
+                     *     XML Parsing Error: undefined entity
+                     */
+                    static $entityMap = [
+                        34 => '&quot;', /* quotation mark */
+                        38 => '&amp;',  /* ampersand */
+                        60 => '&lt;',   /* less-than sign */
+                        62 => '&gt;',   /* greater-than sign */
+                    ];
+
+                    if (isset($entityMap[$ord])) {
+                        return $entityMap[$ord];
+                    }
+
+                    return sprintf('&#x%02X;', $ord);
+                }
+
+                /*
+                 * Per OWASP recommendations, we'll use hex entities for any other
+                 * characters where a named entity does not exist.
+                 */
+                return sprintf('&#x%04X;', mb_ord($chr, 'UTF-8'));
+            }, $string);
+
+            if ('UTF-8' !== $charset) {
+                $string = iconv('UTF-8', $charset, $string);
+            }
+
+            return $string;
+
+        case 'url':
+            return rawurlencode($string);
+
+        default:
+            static $escapers;
+
+            if (null === $escapers) {
+                // merge the ones set on CoreExtension for BC (to be removed in 3.0)
+                $escapers = array_merge(
+                    $env->getExtension(CoreExtension::class)->getEscapers(false),
+                    $env->getExtension(EscaperExtension::class)->getEscapers()
+                );
+            }
+
+            if (isset($escapers[$strategy])) {
+                return $escapers[$strategy]($env, $string, $charset);
+            }
+
+            $validStrategies = implode(', ', array_merge(['html', 'js', 'url', 'css', 'html_attr'], array_keys($escapers)));
+
+            throw new RuntimeError(sprintf('Invalid escaping strategy "%s" (valid ones: %s).', $strategy, $validStrategies));
+    }
+}
+
+/**
+ * @internal
+ */
+function twig_escape_filter_is_safe(Node $filterArgs)
+{
+    foreach ($filterArgs as $arg) {
+        if ($arg instanceof ConstantExpression) {
+            return [$arg->getAttribute('value')];
+        }
+
+        return [];
+    }
+
+    return ['html'];
 }
 }

--- a/test/Twig/Tests/Extension/CoreTest.php
+++ b/test/Twig/Tests/Extension/CoreTest.php
@@ -10,7 +10,6 @@
  */
 
 use Twig\Environment;
-use Twig\Extension\CoreExtension;
 use Twig\Loader\LoaderInterface;
 
 class Twig_Tests_Extension_CoreTest extends \PHPUnit\Framework\TestCase
@@ -124,34 +123,6 @@ class Twig_Tests_Extension_CoreTest extends \PHPUnit\Framework\TestCase
         $output = iconv('ISO-8859-1', 'UTF-8', twig_reverse_filter($twig, $input));
 
         $this->assertEquals($output, 'éÄ');
-    }
-
-    /**
-     * @dataProvider provideCustomEscaperCases
-     */
-    public function testCustomEscaper($expected, $string, $strategy)
-    {
-        $twig = new Environment($this->getMockBuilder(LoaderInterface::class)->getMock());
-        $twig->getExtension(CoreExtension::class)->setEscaper('foo', 'foo_escaper_for_test');
-
-        $this->assertSame($expected, twig_escape_filter($twig, $string, $strategy));
-    }
-
-    public function provideCustomEscaperCases()
-    {
-        return [
-            ['fooUTF-8', 'foo', 'foo'],
-            ['UTF-8', null, 'foo'],
-            ['42UTF-8', 42, 'foo'],
-        ];
-    }
-
-    /**
-     * @expectedException \Twig\Error\RuntimeError
-     */
-    public function testUnknownCustomEscaper()
-    {
-        twig_escape_filter(new Environment($this->getMockBuilder(LoaderInterface::class)->getMock()), 'foo', 'bar');
     }
 
     /**
@@ -278,11 +249,6 @@ class Twig_Tests_Extension_CoreTest extends \PHPUnit\Framework\TestCase
             [[], new \ArrayIterator([1, 2]), 3],
         ];
     }
-}
-
-function foo_escaper_for_test(Environment $env, $string, $charset)
-{
-    return $string.$charset;
 }
 
 final class CoreTestIteratorAggregate implements \IteratorAggregate

--- a/test/Twig/Tests/Extension/EscaperTest.php
+++ b/test/Twig/Tests/Extension/EscaperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Twig\Environment;
+use Twig\Extension\EscaperExtension;
+use Twig\Loader\LoaderInterface;
+
+class Twig_Tests_Extension_EscaperTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider provideCustomEscaperCases
+     */
+    public function testCustomEscaper($expected, $string, $strategy)
+    {
+        $twig = new Environment($this->getMockBuilder(LoaderInterface::class)->getMock());
+        $twig->getExtension(EscaperExtension::class)->setEscaper('foo', 'foo_escaper_for_test');
+
+        $this->assertSame($expected, twig_escape_filter($twig, $string, $strategy));
+    }
+
+    public function provideCustomEscaperCases()
+    {
+        return [
+            ['fooUTF-8', 'foo', 'foo'],
+            ['UTF-8', null, 'foo'],
+            ['42UTF-8', 42, 'foo'],
+        ];
+    }
+
+    /**
+     * @expectedException \Twig\Error\RuntimeError
+     */
+    public function testUnknownCustomEscaper()
+    {
+        twig_escape_filter(new Environment($this->getMockBuilder(LoaderInterface::class)->getMock()), 'foo', 'bar');
+    }
+}
+
+function foo_escaper_for_test(Environment $env, $string, $charset)
+{
+    return $string.$charset;
+}


### PR DESCRIPTION
This is some preliminary work to ease #3025. Everything related to escaping is now part of the `EscaperExtension` instead of `CoreExtension`. This PR is submitted on 2.x because both extensions are always available in 2.x (which is not the case on 1.x).
