### PR TITLE
Add information for when `filter` filter was added in 2.x branch

### DIFF
--- a/doc/filters/filter.rst
+++ b/doc/filters/filter.rst
@@ -2,7 +2,7 @@
 =========
 
 .. versionadded:: 1.41
-    The ``filter`` filter was added in Twig 1.41.
+    The ``filter`` filter was added in Twig 1.41 and 2.10, if you're on 2.x.
 
 The ``filter`` filter filters elements of a sequence or a mapping using an arrow
 function. The arrow function receives the value of the sequence or mapping:


### PR DESCRIPTION
The current "versionadded" info can be confusing to developers, if they assume 2.9 > 1.41 and don't know that 1.x and 2.x branches are still developed simultaneously.