### PR TITLE
Add missing template name and line no to some deprecation messages

### DIFF
--- a/src/TokenParser/FilterTokenParser.php
+++ b/src/TokenParser/FilterTokenParser.php
@@ -30,21 +30,24 @@ final class FilterTokenParser extends AbstractTokenParser
 {
     public function parse(Token $token)
     {
-        @trigger_error('The "filter" tag is deprecated since Twig 2.9, use the "apply" tag instead.', E_USER_DEPRECATED);
+        $stream = $this->parser->getStream();
+        $lineno = $token->getLine();
+
+        @trigger_error(sprintf('The "filter" tag in "%s" at line %d is deprecated since Twig 2.9, use the "apply" tag instead.', $stream->getSourceContext()->getName(), $lineno), E_USER_DEPRECATED);
 
         $name = $this->parser->getVarName();
-        $ref = new BlockReferenceExpression(new ConstantExpression($name, $token->getLine()), null, $token->getLine(), $this->getTag());
+        $ref = new BlockReferenceExpression(new ConstantExpression($name, $lineno), null, $lineno, $this->getTag());
 
         $filter = $this->parser->getExpressionParser()->parseFilterExpressionRaw($ref, $this->getTag());
-        $this->parser->getStream()->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
 
         $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
-        $this->parser->getStream()->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
 
-        $block = new BlockNode($name, $body, $token->getLine());
+        $block = new BlockNode($name, $body, $lineno);
         $this->parser->setBlock($name, $block);
 
-        return new PrintNode($filter, $token->getLine(), $this->getTag());
+        return new PrintNode($filter, $lineno, $this->getTag());
     }
 
     public function decideBlockEnd(Token $token)

--- a/src/TokenParser/ForTokenParser.php
+++ b/src/TokenParser/ForTokenParser.php
@@ -43,7 +43,7 @@ final class ForTokenParser extends AbstractTokenParser
 
         $ifexpr = null;
         if ($stream->nextIf(/* Token::NAME_TYPE */ 5, 'if')) {
-            @trigger_error(sprintf('Using an "if" condition on "for" tag is deprecated since Twig 2.10.0, use a "filter" filter or an "if" condition inside the "for" body instead (if your condition depends on a variable updated inside the loop).', __CLASS__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Using an "if" condition on "for" tag in "%s" at line %d is deprecated since Twig 2.10.0, use a "filter" filter or an "if" condition inside the "for" body instead (if your condition depends on a variable updated inside the loop).', $stream->getSourceContext()->getName(), $lineno), E_USER_DEPRECATED);
 
             $ifexpr = $this->parser->getExpressionParser()->parseExpression();
         }

--- a/src/TokenParser/SpacelessTokenParser.php
+++ b/src/TokenParser/SpacelessTokenParser.php
@@ -30,13 +30,14 @@ final class SpacelessTokenParser extends AbstractTokenParser
 {
     public function parse(Token $token)
     {
-        @trigger_error('The spaceless tag is deprecated since Twig 2.7, use the spaceless filter instead.', E_USER_DEPRECATED);
-
+        $stream = $this->parser->getStream();
         $lineno = $token->getLine();
 
-        $this->parser->getStream()->expect(/* Token::BLOCK_END_TYPE */ 3);
+        @trigger_error(sprintf('The spaceless tag in "%s" at line %d is deprecated since Twig 2.7, use the spaceless filter instead.', $stream->getSourceContext()->getName(), $lineno), E_USER_DEPRECATED);
+
+        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
         $body = $this->parser->subparse([$this, 'decideSpacelessEnd'], true);
-        $this->parser->getStream()->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
 
         return new SpacelessNode($body, $lineno, $this->getTag());
     }

--- a/test/Twig/Tests/Fixtures/tags/block/capturing_block.test
+++ b/test/Twig/Tests/Fixtures/tags/block/capturing_block.test
@@ -1,7 +1,7 @@
 --TEST--
 capturing "block" tag
 --DEPRECATION--
-The spaceless tag is deprecated since Twig 2.7, use the spaceless filter instead.
+The spaceless tag in "index.twig" at line 4 is deprecated since Twig 2.7, use the spaceless filter instead.
 --TEMPLATE--
 {% set foo %}{% block foo %}FOO{% endblock %}{% endset %}
 {{ foo }}

--- a/test/Twig/Tests/Fixtures/tags/filter/basic.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/filter/basic.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "filter" tag applies a filter on its children
 --DEPRECATION--
-The "filter" tag is deprecated since Twig 2.9, use the "apply" tag instead.
+The "filter" tag in "index.twig" at line 2 is deprecated since Twig 2.9, use the "apply" tag instead.
 --TEMPLATE--
 {% filter upper %}
 Some text with a {{ var }}

--- a/test/Twig/Tests/Fixtures/tags/filter/json_encode.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/filter/json_encode.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "filter" tag applies a filter on its children
 --DEPRECATION--
-The "filter" tag is deprecated since Twig 2.9, use the "apply" tag instead.
+The "filter" tag in "index.twig" at line 2 is deprecated since Twig 2.9, use the "apply" tag instead.
 --TEMPLATE--
 {% filter json_encode|raw %}test{% endfilter %}
 --DATA--

--- a/test/Twig/Tests/Fixtures/tags/filter/multiple.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/filter/multiple.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "filter" tags accept multiple chained filters
 --DEPRECATION--
-The "filter" tag is deprecated since Twig 2.9, use the "apply" tag instead.
+The "filter" tag in "index.twig" at line 2 is deprecated since Twig 2.9, use the "apply" tag instead.
 --TEMPLATE--
 {% filter lower|title %}
   {{ var }}

--- a/test/Twig/Tests/Fixtures/tags/filter/nested.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/filter/nested.legacy.test
@@ -1,8 +1,8 @@
 --TEST--
 "filter" tags can be nested at will
 --DEPRECATION--
-The "filter" tag is deprecated since Twig 2.9, use the "apply" tag instead.
-The "filter" tag is deprecated since Twig 2.9, use the "apply" tag instead.
+The "filter" tag in "index.twig" at line 2 is deprecated since Twig 2.9, use the "apply" tag instead.
+The "filter" tag in "index.twig" at line 4 is deprecated since Twig 2.9, use the "apply" tag instead.
 --TEMPLATE--
 {% filter lower|title %}
   {{ var }}

--- a/test/Twig/Tests/Fixtures/tags/filter/scope.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/filter/scope.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "scope" tag creates a new scope
 --DEPRECATION--
-The "filter" tag is deprecated since Twig 2.9, use the "apply" tag instead.
+The "filter" tag in "index.twig" at line 2 is deprecated since Twig 2.9, use the "apply" tag instead.
 --TEMPLATE--
 {% filter spaceless %}
 {% set item = 'foo' %}

--- a/test/Twig/Tests/Fixtures/tags/filter/with_for_tag.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/filter/with_for_tag.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "filter" tag applies the filter on "for" tags
 --DEPRECATION--
-The "filter" tag is deprecated since Twig 2.9, use the "apply" tag instead.
+The "filter" tag in "index.twig" at line 2 is deprecated since Twig 2.9, use the "apply" tag instead.
 --TEMPLATE--
 {% filter upper %}
 {% for item in items %}

--- a/test/Twig/Tests/Fixtures/tags/filter/with_if_tag.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/filter/with_if_tag.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "filter" tag applies the filter on "if" tags
 --DEPRECATION--
-The "filter" tag is deprecated since Twig 2.9, use the "apply" tag instead.
+The "filter" tag in "index.twig" at line 2 is deprecated since Twig 2.9, use the "apply" tag instead.
 --TEMPLATE--
 {% filter upper %}
 {% if items %}

--- a/test/Twig/Tests/Fixtures/tags/for/condition.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/for/condition.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "for" tag takes a condition
 --DEPRECATION--
-Using an "if" condition on "for" tag is deprecated since Twig 2.10.0, use a "filter" filter or an "if" condition inside the "for" body instead (if your condition depends on a variable updated inside the loop).
+Using an "if" condition on "for" tag in "index.twig" at line 2 is deprecated since Twig 2.10.0, use a "filter" filter or an "if" condition inside the "for" body instead (if your condition depends on a variable updated inside the loop).
 --TEMPLATE--
 {% for i in 1..5 if i is odd -%}
     {{ loop.index }}.{{ i }}{{ foo.bar }}

--- a/test/Twig/Tests/Fixtures/tags/spaceless/root_level_in_child.legacy.test
+++ b/test/Twig/Tests/Fixtures/tags/spaceless/root_level_in_child.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "spaceless" tag in the root level of a child template
 --DEPRECATION--
-The spaceless tag is deprecated since Twig 2.7, use the spaceless filter instead.
+The spaceless tag in "index.twig" at line 3 is deprecated since Twig 2.7, use the spaceless filter instead.
 Using the spaceless tag at the root level of a child template in "index.twig" at line 3 is deprecated since Twig 2.5.0 and will become a syntax error in 3.0.
 Nesting a block definition under a non-capturing node in "index.twig" at line 4 is deprecated since Twig 2.5.0 and will become a syntax error in 3.0.
 --TEMPLATE--

--- a/test/Twig/Tests/Fixtures/tags/spaceless/simple.test
+++ b/test/Twig/Tests/Fixtures/tags/spaceless/simple.test
@@ -1,7 +1,7 @@
 --TEST--
 "spaceless" tag removes whites between HTML tags
 --DEPRECATION--
-The spaceless tag is deprecated since Twig 2.7, use the spaceless filter instead.
+The spaceless tag in "index.twig" at line 2 is deprecated since Twig 2.7, use the spaceless filter instead.
 --TEMPLATE--
 {% spaceless %}
 


### PR DESCRIPTION
before:
![twig-before](https://user-images.githubusercontent.com/2028198/58422946-e1346080-8061-11e9-80e1-b75418fe03e9.png)

after:
![twig-after](https://user-images.githubusercontent.com/2028198/58422955-e85b6e80-8061-11e9-9c20-2bbf0ccb5009.png)
