### PR TITLE
Remove unneeded requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     ],
     "require": {
         "php": "^7.0",
-        "symfony/polyfill-mbstring": "^1.3",
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {


### PR DESCRIPTION
mbstring is not used anywhere anymore in Twig 2.x.