### PR TITLE
Fixed: Endless loop if more than one parent without the macro exists

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1083,7 +1083,8 @@ function twig_capitalize_string_filter(Environment $env, $string)
 function twig_call_macro(Template $template, string $method, array $args, int $lineno, array $context, Source $source)
 {
     if (!method_exists($template, $method)) {
-        while ($parent = $template->getParent($context)) {
+        $parent = $template;
+        while ($parent = $parent->getParent($context)) {
             if (method_exists($parent, $method)) {
                 return $parent->$method(...$args);
             }


### PR DESCRIPTION
Hi @fabpot 

I made a quick fix for the parent macro method call fix you did for me in #3042. Your code works in case the direct parent has the macro. But if there is a longer hierarchy and the looked for macro is in a parent template +1 it runs into an endless loop because the `->getParent()` method is always called on `$template` but never the newer `$parent`.


Best