### PR TITLE
Update the documentation for newly added features

### DIFF
--- a/doc/filters/map.rst
+++ b/doc/filters/map.rst
@@ -2,7 +2,7 @@
 =======
 
 .. versionadded:: 1.41
-    The ``map`` filter was added in Twig 1.41.
+    The ``map`` filter was added in Twig 1.41 and 2.10.
 
 The ``map`` filter applies an arrow function to the elements of a sequence or a
 mapping. The arrow function receives the value of the sequence or mapping:

--- a/doc/filters/reduce.rst
+++ b/doc/filters/reduce.rst
@@ -2,7 +2,7 @@
 =========
 
 .. versionadded:: 1.41
-    The ``reduce`` filter was added in Twig 1.41.
+    The ``reduce`` filter was added in Twig 1.41 and 2.10.
 
 The ``reduce`` filter iteratively reduces a sequence or a mapping to a single
 value using an arrow function, so as to reduce it to a single value. The arrow


### PR DESCRIPTION
The `map`, `filter` and `reduce` functions were added in Twig 1.41 and 2.10, but the documentation for `map` and `reduce` did not contain the information in which 2.x version these functions were added. 
This minor PR fixes this.