### PR TITLE
Extend opcache check if it is enabled

### DIFF
--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -67,7 +67,7 @@ class FilesystemCache implements CacheInterface
 
             if (self::FORCE_BYTECODE_INVALIDATION == ($this->options & self::FORCE_BYTECODE_INVALIDATION)) {
                 // Compile cached file into bytecode cache
-                if (\function_exists('opcache_invalidate')) {
+                if (\function_exists('opcache_invalidate') && ini_get('opcache.enable')) {
                     opcache_invalidate($key, true);
                 } elseif (\function_exists('apc_compile_file')) {
                     apc_compile_file($key);


### PR DESCRIPTION
When trying to deploy October on shared hosting (www.websupport.sk) I received following error when accessing the frontend pages - ErrorException:> Zend OPcache API is restricted by "restrict_api" configuration directive.
Backend was working normally. 
I propose the following change to check not only if the opcache_invalidate exists but also if opcache is enabled.
The change was also needed in octobercms files, but to correspond I am also proposing to add it directly to twig.