### PR TITLE
Fix error_handler return type declaration

### DIFF
--- a/doc/recipes.rst
+++ b/doc/recipes.rst
@@ -40,6 +40,8 @@ below::
         if (E_USER_DEPRECATED === $type) {
             $deprecations[] = $msg;
         }
+
+        return true;
     });
 
     // run your application

--- a/src/Util/DeprecationCollector.php
+++ b/src/Util/DeprecationCollector.php
@@ -60,6 +60,8 @@ final class DeprecationCollector
             if (E_USER_DEPRECATED === $type) {
                 $deprecations[] = $msg;
             }
+
+            return true;
         });
 
         foreach ($iterator as $name => $contents) {


### PR DESCRIPTION
Hi,

Small patch to fix error handler function return type.
From php.net documentation, the error_handler should return a bool and not a void (https://www.php.net/manual/en/function.set-error-handler.php)