### PR TITLE
Update PhpUnitBridge and fix deprecations

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -4,6 +4,8 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,
+        '@PHPUnit75Migration:risky' => true,
+        'php_unit_dedicate_assert' => ['target' => '5.6'],
         'array_syntax' => ['syntax' => 'short'],
         'php_unit_fqcn_annotation' => true,
         'no_unreachable_default_argument_value' => false,

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,11 @@ cache:
         - vendor
         - $HOME/.composer/cache/files
 
+
 env:
-    - TWIG_EXT=no
+    global:
+        - TWIG_EXT=no
+        - SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1
 
 before_install:
     - phpenv config-rm xdebug.ini || return 0

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.4.19|^4.1.8|^5.0",
+        "symfony/phpunit-bridge": "^4.4@dev|^5.0",
         "symfony/debug": "^3.4|^4.2",
         "psr/container": "^1.0"
     },

--- a/tests/Cache/FilesystemTest.php
+++ b/tests/Cache/FilesystemTest.php
@@ -41,7 +41,7 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
 
         $dir = \dirname($key);
         @mkdir($dir, 0777, true);
-        $this->assertTrue(is_dir($dir));
+        $this->assertDirectoryExists($dir);
         $this->assertFalse(class_exists($this->classname, false));
 
         $content = $this->generateSource();
@@ -78,12 +78,11 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(file_get_contents($key), $content);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unable to create the cache directory
-     */
     public function testWriteFailMkdir()
     {
+        $this->expectException('\RuntimeException');
+        $this->expectExceptionMessage('Unable to create the cache directory');
+
         if (\defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->markTestSkipped('Read-only directories not possible on Windows.');
         }
@@ -95,17 +94,16 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
 
         // Create read-only root directory.
         @mkdir($this->directory, 0555, true);
-        $this->assertTrue(is_dir($this->directory));
+        $this->assertDirectoryExists($this->directory);
 
         $this->cache->write($key, $content);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unable to write in the cache directory
-     */
     public function testWriteFailDirWritable()
     {
+        $this->expectException('\RuntimeException');
+        $this->expectExceptionMessage('Unable to write in the cache directory');
+
         if (\defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->markTestSkipped('Read-only directories not possible on Windows.');
         }
@@ -119,17 +117,16 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
         @mkdir($this->directory, 0777, true);
         // Create read-only subdirectory.
         @mkdir($this->directory.'/cache', 0555);
-        $this->assertTrue(is_dir($this->directory.'/cache'));
+        $this->assertDirectoryExists($this->directory.'/cache');
 
         $this->cache->write($key, $content);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Failed to write cache file
-     */
     public function testWriteFailWriteFile()
     {
+        $this->expectException('\RuntimeException');
+        $this->expectExceptionMessage('Failed to write cache file');
+
         $key = $this->directory.'/cache/cachefile.php';
         $content = $this->generateSource();
 
@@ -137,7 +134,7 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
 
         // Create a directory in the place of the cache file.
         @mkdir($key, 0777, true);
-        $this->assertTrue(is_dir($key));
+        $this->assertDirectoryExists($key);
 
         $this->cache->write($key, $content);
     }
@@ -148,7 +145,7 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
 
         $dir = \dirname($key);
         @mkdir($dir, 0777, true);
-        $this->assertTrue(is_dir($dir));
+        $this->assertDirectoryExists($dir);
 
         // Create the file with a specific modification time.
         touch($key, 1234567890);

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -31,7 +31,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         }
 
         $this->assertEquals('1.2', $compiler->repr(1.2)->getSource());
-        $this->assertContains('fr', strtolower(setlocale(LC_NUMERIC, 0)));
+        $this->assertStringContainsString('fr', strtolower(setlocale(LC_NUMERIC, 0)));
 
         setlocale(LC_NUMERIC, $locale);
     }

--- a/tests/CustomExtensionTest.php
+++ b/tests/CustomExtensionTest.php
@@ -22,12 +22,8 @@ class CustomExtensionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetInvalidOperators(ExtensionInterface $extension, $expectedExceptionMessage)
     {
-        if (method_exists($this, 'expectException')) {
-            $this->expectException('InvalidArgumentException');
-            $this->expectExceptionMessage($expectedExceptionMessage);
-        } else {
-            $this->setExpectedException('InvalidArgumentException', $expectedExceptionMessage);
-        }
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage($expectedExceptionMessage);
 
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock());
         $env->addExtension($extension);

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -49,16 +49,17 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
     {
         $loader = new ArrayLoader(['foo' => '{{ foo }}']);
         $env = new Environment($loader);
-        $this->assertContains('getTemplateName', $env->compileSource('{{ foo }}', 'foo'));
+        $this->assertStringContainsString('getTemplateName', $env->compileSource('{{ foo }}', 'foo'));
     }
 
     /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage You must set a loader first.
      * @group legacy
      */
     public function testRenderNoLoader()
     {
+        $this->expectException('\LogicException');
+        $this->expectExceptionMessage('You must set a loader first.');
+
         $env = new Environment();
         $env->render('test');
     }
@@ -368,7 +369,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('foo_global', $twig->getGlobals());
 
         $this->assertCount(1, $this->deprecations);
-        $this->assertContains('Defining the getGlobals() method in the "Twig\Tests\EnvironmentTest_Extension_WithGlobals" extension ', $this->deprecations[0]);
+        $this->assertStringContainsString('Defining the getGlobals() method in the "Twig\Tests\EnvironmentTest_Extension_WithGlobals" extension ', $this->deprecations[0]);
 
         restore_error_handler();
     }
@@ -440,7 +441,7 @@ EOF
         $twig->initRuntime();
 
         $this->assertCount(1, $this->deprecations);
-        $this->assertContains('Defining the initRuntime() method in the "Twig\Tests\EnvironmentTest_ExtensionWithDeprecationInitRuntime" extension is deprecated since version 1.23.', $this->deprecations[0]);
+        $this->assertStringContainsString('Defining the initRuntime() method in the "Twig\Tests\EnvironmentTest_ExtensionWithDeprecationInitRuntime" extension is deprecated since version 1.23.', $this->deprecations[0]);
 
         restore_error_handler();
     }
@@ -467,7 +468,7 @@ EOF
         $twig->addExtension(new EnvironmentTest_Extension_WithDeprecatedName());
 
         $this->assertCount(1, $this->deprecations);
-        $this->assertContains('The possibility to register the same extension twice', $this->deprecations[0]);
+        $this->assertStringContainsString('The possibility to register the same extension twice', $this->deprecations[0]);
 
         restore_error_handler();
     }

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -25,7 +25,7 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
         $error = new Error('foo');
         $error->setSourceContext(new Source('', new \SplFileInfo(__FILE__)));
 
-        $this->assertContains('tests'.\DIRECTORY_SEPARATOR.'ErrorTest.php', $error->getMessage());
+        $this->assertStringContainsString('tests'.\DIRECTORY_SEPARATOR.'ErrorTest.php', $error->getMessage());
     }
 
     public function testErrorWithArrayFilename()

--- a/tests/ExpressionParserTest.php
+++ b/tests/ExpressionParserTest.php
@@ -22,11 +22,12 @@ use Twig\Source;
 class ExpressionParserTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @expectedException \Twig\Error\SyntaxError
      * @dataProvider getFailingTestsForAssignment
      */
     public function testCanOnlyAssignToNames($template)
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
 
@@ -65,11 +66,12 @@ class ExpressionParserTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException \Twig\Error\SyntaxError
      * @dataProvider getFailingTestsForArray
      */
     public function testArraySyntaxError($template)
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
 
@@ -160,11 +162,10 @@ class ExpressionParserTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @expectedException \Twig\Error\SyntaxError
-     */
     public function testStringExpressionDoesNotConcatenateTwoConsecutiveStrings()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
         $stream = $env->tokenize(new Source('{{ "a" "b" }}', 'index'));
         $parser = new Parser($env);
@@ -232,34 +233,31 @@ class ExpressionParserTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @expectedException \Twig\Error\SyntaxError
-     */
     public function testAttributeCallDoesNotSupportNamedArguments()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
 
         $parser->parse($env->tokenize(new Source('{{ foo.bar(name="Foo") }}', 'index')));
     }
 
-    /**
-     * @expectedException \Twig\Error\SyntaxError
-     */
     public function testMacroCallDoesNotSupportNamedArguments()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
 
         $parser->parse($env->tokenize(new Source('{% from _self import foo %}{% macro foo() %}{% endmacro %}{{ foo(name="Foo") }}', 'index')));
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage An argument must be a name. Unexpected token "string" of value "a" ("name" expected) in "index" at line 1.
-     */
     public function testMacroDefinitionDoesNotSupportNonNameVariableName()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('An argument must be a name. Unexpected token "string" of value "a" ("name" expected) in "index" at line 1.');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
 
@@ -267,12 +265,13 @@ class ExpressionParserTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage A default value for an argument must be a constant (a boolean, a string, a number, or an array) in "index" at line 1
      * @dataProvider             getMacroDefinitionDoesNotSupportNonConstantDefaultValues
      */
     public function testMacroDefinitionDoesNotSupportNonConstantDefaultValues($template)
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('A default value for an argument must be a constant (a boolean, a string, a number, or an array) in "index" at line 1');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
 
@@ -315,72 +314,66 @@ class ExpressionParserTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unknown "cycl" function. Did you mean "cycle" in "index" at line 1?
-     */
     public function testUnknownFunction()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unknown "cycl" function. Did you mean "cycle" in "index" at line 1?');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
 
         $parser->parse($env->tokenize(new Source('{{ cycl() }}', 'index')));
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unknown "foobar" function in "index" at line 1.
-     */
     public function testUnknownFunctionWithoutSuggestions()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unknown "foobar" function in "index" at line 1.');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
 
         $parser->parse($env->tokenize(new Source('{{ foobar() }}', 'index')));
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unknown "lowe" filter. Did you mean "lower" in "index" at line 1?
-     */
     public function testUnknownFilter()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unknown "lowe" filter. Did you mean "lower" in "index" at line 1?');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
 
         $parser->parse($env->tokenize(new Source('{{ 1|lowe }}', 'index')));
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unknown "foobar" filter in "index" at line 1.
-     */
     public function testUnknownFilterWithoutSuggestions()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unknown "foobar" filter in "index" at line 1.');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
 
         $parser->parse($env->tokenize(new Source('{{ 1|foobar }}', 'index')));
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unknown "nul" test. Did you mean "null" in "index" at line 1
-     */
     public function testUnknownTest()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unknown "nul" test. Did you mean "null" in "index" at line 1');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
         $stream = $env->tokenize(new Source('{{ 1 is nul }}', 'index'));
         $parser->parse($stream);
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unknown "foobar" test in "index" at line 1.
-     */
     public function testUnknownTestWithoutSuggestions()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unknown "foobar" test in "index" at line 1.');
+
         $env = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['cache' => false, 'autoescape' => false]);
         $parser = new Parser($env);
 

--- a/tests/Extension/CoreTest.php
+++ b/tests/Extension/CoreTest.php
@@ -94,11 +94,10 @@ class CoreTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($instance, twig_random(new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock()), $instance));
     }
 
-    /**
-     * @expectedException \Twig\Error\RuntimeError
-     */
     public function testRandomFunctionOfEmptyArrayThrowsException()
     {
+        $this->expectException('\Twig\Error\RuntimeError');
+
         twig_random(new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock()), []);
     }
 
@@ -153,11 +152,10 @@ class CoreTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @expectedException \Twig\Error\RuntimeError
-     */
     public function testUnknownCustomEscaper()
     {
+        $this->expectException('\Twig\Error\RuntimeError');
+
         twig_escape_filter(new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock()), 'foo', 'bar');
     }
 

--- a/tests/Extension/SandboxTest.php
+++ b/tests/Extension/SandboxTest.php
@@ -47,12 +47,11 @@ class SandboxTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @expectedException        \Twig\Sandbox\SecurityError
-     * @expectedExceptionMessage Filter "json_encode" is not allowed in "1_child" at line 3.
-     */
     public function testSandboxWithInheritance()
     {
+        $this->expectException('\Twig\Sandbox\SecurityError');
+        $this->expectExceptionMessage('Filter "json_encode" is not allowed in "1_child" at line 3.');
+
         $twig = $this->getEnvironment(true, [], self::$templates, ['block']);
         $twig->load('1_child')->render([]);
     }

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -245,12 +245,11 @@ class LexerTest extends \PHPUnit\Framework\TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @expectedException \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unclosed """
-     */
     public function testStringWithUnterminatedInterpolation()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unclosed """');
+
         $template = '{{ "bar #{x" }}';
 
         $lexer = new Lexer(new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock()));
@@ -315,12 +314,11 @@ class LexerTest extends \PHPUnit\Framework\TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @expectedException \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unclosed "variable" in "index" at line 3
-     */
     public function testUnterminatedVariable()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unclosed "variable" in "index" at line 3');
+
         $template = '
 
 {{
@@ -334,12 +332,11 @@ bar
         $lexer->tokenize(new Source($template, 'index'));
     }
 
-    /**
-     * @expectedException \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unclosed "block" in "index" at line 3
-     */
     public function testUnterminatedBlock()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unclosed "block" in "index" at line 3');
+
         $template = '
 
 {%

--- a/tests/Loader/ArrayTest.php
+++ b/tests/Loader/ArrayTest.php
@@ -27,20 +27,20 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group legacy
-     * @expectedException \Twig\Error\LoaderError
      */
     public function testGetSourceWhenTemplateDoesNotExist()
     {
+        $this->expectException('\Twig\Error\LoaderError');
+
         $loader = new ArrayLoader([]);
 
         $loader->getSource('foo');
     }
 
-    /**
-     * @expectedException \Twig\Error\LoaderError
-     */
     public function testGetSourceContextWhenTemplateDoesNotExist()
     {
+        $this->expectException('\Twig\Error\LoaderError');
+
         $loader = new ArrayLoader([]);
 
         $loader->getSourceContext('foo');
@@ -75,11 +75,10 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('foo:__bar', $loader->getCacheKey('foo'));
     }
 
-    /**
-     * @expectedException \Twig\Error\LoaderError
-     */
     public function testGetCacheKeyWhenTemplateDoesNotExist()
     {
+        $this->expectException('\Twig\Error\LoaderError');
+
         $loader = new ArrayLoader([]);
 
         $loader->getCacheKey('foo');
@@ -99,11 +98,10 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($loader->isFresh('foo', time()));
     }
 
-    /**
-     * @expectedException \Twig\Error\LoaderError
-     */
     public function testIsFreshWhenTemplateDoesNotExist()
     {
+        $this->expectException('\Twig\Error\LoaderError');
+
         $loader = new ArrayLoader([]);
 
         $loader->isFresh('foo', time());

--- a/tests/Loader/ChainTest.php
+++ b/tests/Loader/ChainTest.php
@@ -56,11 +56,10 @@ class ChainTest extends \PHPUnit\Framework\TestCase
         $this->assertNotEquals('baz', $loader->getSourceContext('errors/base.html')->getCode());
     }
 
-    /**
-     * @expectedException \Twig\Error\LoaderError
-     */
     public function testGetSourceContextWhenTemplateDoesNotExist()
     {
+        $this->expectException('\Twig\Error\LoaderError');
+
         $loader = new ChainLoader([]);
 
         $loader->getSourceContext('foo');
@@ -68,10 +67,11 @@ class ChainTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group legacy
-     * @expectedException \Twig\Error\LoaderError
      */
     public function testGetSourceWhenTemplateDoesNotExist()
     {
+        $this->expectException('\Twig\Error\LoaderError');
+
         $loader = new ChainLoader([]);
 
         $loader->getSource('foo');
@@ -88,11 +88,10 @@ class ChainTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('bar:foo', $loader->getCacheKey('bar'));
     }
 
-    /**
-     * @expectedException \Twig\Error\LoaderError
-     */
     public function testGetCacheKeyWhenTemplateDoesNotExist()
     {
+        $this->expectException('\Twig\Error\LoaderError');
+
         $loader = new ChainLoader([]);
 
         $loader->getCacheKey('foo');

--- a/tests/Loader/FilesystemTest.php
+++ b/tests/Loader/FilesystemTest.php
@@ -36,7 +36,7 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
             $loader->getCacheKey($template);
             $this->fail();
         } catch (LoaderError $e) {
-            $this->assertNotContains('Unable to find template', $e->getMessage());
+            $this->assertStringNotContainsString('Unable to find template', $e->getMessage());
         }
     }
 
@@ -156,7 +156,7 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
             $loader->getSourceContext('@named/nowhere.html');
         } catch (\Exception $e) {
             $this->assertInstanceOf('\Twig\Error\LoaderError', $e);
-            $this->assertContains('Unable to find template "@named/nowhere.html"', $e->getMessage());
+            $this->assertStringContainsString('Unable to find template "@named/nowhere.html"', $e->getMessage());
         }
     }
 

--- a/tests/Node/Expression/CallTest.php
+++ b/tests/Node/Expression/CallTest.php
@@ -21,52 +21,47 @@ class CallTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['U', null], $node->getArguments('date', ['format' => 'U', 'timestamp' => null]));
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Positional arguments cannot be used after named arguments for function "date".
-     */
     public function testGetArgumentsWhenPositionalArgumentsAfterNamedArguments()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Positional arguments cannot be used after named arguments for function "date".');
+
         $node = new Node_Expression_Call([], ['type' => 'function', 'name' => 'date']);
         $node->getArguments('date', ['timestamp' => 123456, 'Y-m-d']);
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Argument "format" is defined twice for function "date".
-     */
     public function testGetArgumentsWhenArgumentIsDefinedTwice()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Argument "format" is defined twice for function "date".');
+
         $node = new Node_Expression_Call([], ['type' => 'function', 'name' => 'date']);
         $node->getArguments('date', ['Y-m-d', 'format' => 'U']);
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unknown argument "unknown" for function "date(format, timestamp)".
-     */
     public function testGetArgumentsWithWrongNamedArgumentName()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unknown argument "unknown" for function "date(format, timestamp)".');
+
         $node = new Node_Expression_Call([], ['type' => 'function', 'name' => 'date']);
         $node->getArguments('date', ['Y-m-d', 'timestamp' => null, 'unknown' => '']);
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unknown arguments "unknown1", "unknown2" for function "date(format, timestamp)".
-     */
     public function testGetArgumentsWithWrongNamedArgumentNames()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unknown arguments "unknown1", "unknown2" for function "date(format, timestamp)".');
+
         $node = new Node_Expression_Call([], ['type' => 'function', 'name' => 'date']);
         $node->getArguments('date', ['Y-m-d', 'timestamp' => null, 'unknown1' => '', 'unknown2' => '']);
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Argument "case_sensitivity" could not be assigned for function "substr_compare(main_str, str, offset, length, case_sensitivity)" because it is mapped to an internal PHP function which cannot determine default value for optional argument "length".
-     */
     public function testResolveArgumentsWithMissingValueForOptionalArgument()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Argument "case_sensitivity" could not be assigned for function "substr_compare(main_str, str, offset, length, case_sensitivity)" because it is mapped to an internal PHP function which cannot determine default value for optional argument "length".');
+
         $node = new Node_Expression_Call([], ['type' => 'function', 'name' => 'substr_compare']);
         $node->getArguments('substr_compare', ['abcd', 'bc', 'offset' => 1, 'case_sensitivity' => true]);
     }
@@ -84,12 +79,11 @@ class CallTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['arg1'], $node->getArguments(__CLASS__.'::customStaticFunction', ['arg1' => 'arg1']));
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage The last parameter of "Twig\Tests\Node\Expression\CallTest::customFunctionWithArbitraryArguments" for function "foo" must be an array with default value, eg. "array $arg = []".
-     */
     public function testResolveArgumentsWithMissingParameterForArbitraryArguments()
     {
+        $this->expectException('\LogicException');
+        $this->expectExceptionMessage('The last parameter of "Twig\\Tests\\Node\\Expression\\CallTest::customFunctionWithArbitraryArguments" for function "foo" must be an array with default value, eg. "array $arg = []".');
+
         $node = new Node_Expression_Call([], ['type' => 'function', 'name' => 'foo', 'is_variadic' => true]);
         $node->getArguments([$this, 'customFunctionWithArbitraryArguments'], []);
     }
@@ -106,22 +100,20 @@ class CallTest extends \PHPUnit\Framework\TestCase
     {
     }
 
-    /**
-     * @expectedException              \LogicException
-     * @expectedExceptionMessageRegExp #^The last parameter of "Twig\\Tests\\Node\\Expression\\custom_Twig_Tests_Node_Expression_CallTest_function" for function "foo" must be an array with default value, eg\. "array \$arg \= \[\]"\.$#
-     */
     public function testResolveArgumentsWithMissingParameterForArbitraryArgumentsOnFunction()
     {
+        $this->expectException('\LogicException');
+        $this->expectExceptionMessageRegExp('#^The last parameter of "Twig\\\\Tests\\\\Node\\\\Expression\\\\custom_Twig_Tests_Node_Expression_CallTest_function" for function "foo" must be an array with default value, eg\\. "array \\$arg \\= \\[\\]"\\.$#');
+
         $node = new Node_Expression_Call([], ['type' => 'function', 'name' => 'foo', 'is_variadic' => true]);
         $node->getArguments('Twig\Tests\Node\Expression\custom_Twig_Tests_Node_Expression_CallTest_function', []);
     }
 
-    /**
-     * @expectedException              \LogicException
-     * @expectedExceptionMessageRegExp #^The last parameter of "Twig\\Tests\\Node\\Expression\\CallableTestClass\:\:__invoke" for function "foo" must be an array with default value, eg\. "array \$arg \= \[\]"\.$#
-     */
     public function testResolveArgumentsWithMissingParameterForArbitraryArgumentsOnObject()
     {
+        $this->expectException('\LogicException');
+        $this->expectExceptionMessageRegExp('#^The last parameter of "Twig\\\\Tests\\\\Node\\\\Expression\\\\CallableTestClass\\:\\:__invoke" for function "foo" must be an array with default value, eg\\. "array \\$arg \\= \\[\\]"\\.$#');
+
         $node = new Node_Expression_Call([], ['type' => 'function', 'name' => 'foo', 'is_variadic' => true]);
         $node->getArguments(new CallableTestClass(), []);
     }

--- a/tests/Node/Expression/FilterTest.php
+++ b/tests/Node/Expression/FilterTest.php
@@ -110,12 +110,11 @@ class FilterTest extends NodeTestCase
         return $tests;
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unknown argument "foobar" for filter "date(format, timezone)" at line 1.
-     */
     public function testCompileWithWrongNamedArgumentName()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unknown argument "foobar" for filter "date(format, timezone)" at line 1.');
+
         $date = new ConstantExpression(0, 1);
         $node = $this->createFilter($date, 'date', [
             'foobar' => new ConstantExpression('America/Chicago', 1),
@@ -125,12 +124,11 @@ class FilterTest extends NodeTestCase
         $compiler->compile($node);
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Value for argument "from" is required for filter "replace" at line 1.
-     */
     public function testCompileWithMissingNamedArgument()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Value for argument "from" is required for filter "replace" at line 1.');
+
         $value = new ConstantExpression(0, 1);
         $node = $this->createFilter($value, 'replace', [
             'to' => new ConstantExpression('foo', 1),

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -24,21 +24,19 @@ use Twig\TokenStream;
 
 class ParserTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @expectedException \Twig\Error\SyntaxError
-     */
     public function testSetMacroThrowsExceptionOnReservedMethods()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+
         $parser = $this->getParser();
         $parser->setMacro('parent', new MacroNode('foo', new Node(), new Node(), 1));
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unknown "foo" tag. Did you mean "for" at line 1?
-     */
     public function testUnknownTag()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unknown "foo" tag. Did you mean "for" at line 1?');
+
         $stream = new TokenStream([
             new Token(Token::BLOCK_START_TYPE, '', 1),
             new Token(Token::NAME_TYPE, 'foo', 1),
@@ -49,12 +47,11 @@ class ParserTest extends \PHPUnit\Framework\TestCase
         $parser->parse($stream);
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unknown "foobar" tag at line 1.
-     */
     public function testUnknownTagWithoutSuggestions()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unknown "foobar" tag at line 1.');
+
         $stream = new TokenStream([
             new Token(Token::BLOCK_START_TYPE, '', 1),
             new Token(Token::NAME_TYPE, 'foobar', 1),
@@ -95,10 +92,11 @@ class ParserTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider getFilterBodyNodesDataThrowsException
-     * @expectedException \Twig\Error\SyntaxError
      */
     public function testFilterBodyNodesThrowsException($input)
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+
         $parser = $this->getParser();
 
         $parser->filterBodyNodes($input);

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -25,11 +25,10 @@ use Twig\Template;
 
 class TemplateTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @expectedException \LogicException
-     */
     public function testDisplayBlocksAcceptTemplateOnlyAsBlocks()
     {
+        $this->expectException('\LogicException');
+
         $twig = new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock());
         $template = new TemplateForTest($twig);
         $template->displayBlock('foo', [], ['foo' => [new \stdClass(), 'foo']]);
@@ -110,7 +109,7 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
                 $this->addToAssertionCount(1);
             }
 
-            $this->assertContains('is not allowed', $e->getMessage());
+            $this->assertStringContainsString('is not allowed', $e->getMessage());
         }
     }
 
@@ -276,13 +275,9 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
         if ($defined) {
             $this->assertEquals($value, $template->getAttribute($object, $item, $arguments, $type));
         } else {
-            if (method_exists($this, 'expectException')) {
-                $this->expectException('\Twig\Error\RuntimeError');
-                if (null !== $exceptionMessage) {
-                    $this->expectExceptionMessage($exceptionMessage);
-                }
-            } else {
-                $this->setExpectedException('\Twig\Error\RuntimeError', $exceptionMessage);
+            $this->expectException('\Twig\Error\RuntimeError');
+            if (null !== $exceptionMessage) {
+                $this->expectExceptionMessage($exceptionMessage);
             }
             $this->assertEquals($value, $template->getAttribute($object, $item, $arguments, $type));
         }
@@ -449,11 +444,10 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
         return $tests;
     }
 
-    /**
-     * @expectedException \Twig\Error\RuntimeError
-     */
     public function testGetIsMethods()
     {
+        $this->expectException('\Twig\Error\RuntimeError');
+
         $getIsObject = new TemplateGetIsMethods();
         $template = new TemplateForTest(new Environment($this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock(), ['strict_variables' => true]));
         // first time should not create a cache for "get"

--- a/tests/TokenStreamTest.php
+++ b/tests/TokenStreamTest.php
@@ -56,12 +56,11 @@ class TokenStreamTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('1, 2, 3, 4, 5, 6, 7', implode(', ', $repr), '->next() advances the pointer and returns the current token');
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unexpected end of template
-     */
     public function testEndOfTemplateNext()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unexpected end of template');
+
         $stream = new TokenStream([
             new Token(Token::BLOCK_START_TYPE, 1, 1),
         ]);
@@ -70,12 +69,11 @@ class TokenStreamTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unexpected end of template
-     */
     public function testEndOfTemplateLook()
     {
+        $this->expectException('\Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unexpected end of template');
+
         $stream = new TokenStream([
             new Token(Token::BLOCK_START_TYPE, 1, 1),
         ]);


### PR DESCRIPTION
This PR:
- update dev dependency to `phpunit-bridge` to `^4.4@dev` in order to get polyfill methods
- fix deprecated tests
- update cs-fixer rule
