### PR TITLE
Handle opcache_invalidate() being disabled on shared hosting platforms

### DIFF
--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -68,7 +68,7 @@ class FilesystemCache implements CacheInterface
             if (self::FORCE_BYTECODE_INVALIDATION == ($this->options & self::FORCE_BYTECODE_INVALIDATION)) {
                 // Compile cached file into bytecode cache
                 if (\function_exists('opcache_invalidate') && filter_var(ini_get('opcache.enable'), FILTER_VALIDATE_BOOLEAN)) {
-                    opcache_invalidate($key, true);
+                    @opcache_invalidate($key, true);
                 } elseif (\function_exists('apc_compile_file')) {
                     apc_compile_file($key);
                 }


### PR DESCRIPTION
This fix makes twig gracefully fail on opcache API being disabled on shared hosting platforms for security reasons.
Tested with Grav CMS.