### PR TITLE
Fix compatibility with PHPUnit 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ cache:
         - vendor
         - $HOME/.composer/cache/files
 
-env:
-    global:
-        - SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1
-
 before_install:
     - phpenv config-rm xdebug.ini || return 0
 

--- a/tests/Cache/FilesystemTest.php
+++ b/tests/Cache/FilesystemTest.php
@@ -21,7 +21,7 @@ class FilesystemTest extends TestCase
     private $directory;
     private $cache;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $nonce = hash('sha256', uniqid(mt_rand(), true));
         $this->classname = '__Twig_Tests_Cache_FilesystemTest_Template_'.$nonce;
@@ -29,7 +29,7 @@ class FilesystemTest extends TestCase
         $this->cache = new FilesystemCache($this->directory);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (file_exists($this->directory)) {
             FilesystemHelper::removeDir($this->directory);

--- a/tests/Extension/SandboxTest.php
+++ b/tests/Extension/SandboxTest.php
@@ -28,7 +28,7 @@ class SandboxTest extends TestCase
     protected static $params;
     protected static $templates;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::$params = [
             'name' => 'Fabien',

--- a/tests/TokenStreamTest.php
+++ b/tests/TokenStreamTest.php
@@ -20,7 +20,7 @@ class TokenStreamTest extends TestCase
 {
     protected static $tokens;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::$tokens = [
             new Token(Token::TEXT_TYPE, 1, 1),


### PR DESCRIPTION
adds `: void` return typehint on methods `setup` and `teardown`