### PR TITLE
[3.0] remove the most blocking return types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2.9",
         "symfony/polyfill-mbstring": "^1.3",
         "symfony/polyfill-ctype": "^1.8"
     },

--- a/src/Extension/AbstractExtension.php
+++ b/src/Extension/AbstractExtension.php
@@ -13,32 +13,32 @@ namespace Twig\Extension;
 
 abstract class AbstractExtension implements ExtensionInterface
 {
-    public function getTokenParsers(): array
+    public function getTokenParsers()
     {
         return [];
     }
 
-    public function getNodeVisitors(): array
+    public function getNodeVisitors()
     {
         return [];
     }
 
-    public function getFilters(): array
+    public function getFilters()
     {
         return [];
     }
 
-    public function getTests(): array
+    public function getTests()
     {
         return [];
     }
 
-    public function getFunctions(): array
+    public function getFunctions()
     {
         return [];
     }
 
-    public function getOperators(): array
+    public function getOperators()
     {
         return [];
     }

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -29,40 +29,40 @@ interface ExtensionInterface
      *
      * @return TokenParserInterface[]
      */
-    public function getTokenParsers(): array;
+    public function getTokenParsers();
 
     /**
      * Returns the node visitor instances to add to the existing list.
      *
      * @return NodeVisitorInterface[]
      */
-    public function getNodeVisitors(): array;
+    public function getNodeVisitors();
 
     /**
      * Returns a list of filters to add to the existing list.
      *
      * @return TwigFilter[]
      */
-    public function getFilters(): array;
+    public function getFilters();
 
     /**
      * Returns a list of tests to add to the existing list.
      *
      * @return TwigTest[]
      */
-    public function getTests(): array;
+    public function getTests();
 
     /**
      * Returns a list of functions to add to the existing list.
      *
      * @return TwigFunction[]
      */
-    public function getFunctions(): array;
+    public function getFunctions();
 
     /**
      * Returns a list of operators to add to the existing list.
      *
      * @return array<array> First array of unary operators, second array of binary operators
      */
-    public function getOperators(): array;
+    public function getOperators();
 }

--- a/src/Extension/ProfilerExtension.php
+++ b/src/Extension/ProfilerExtension.php
@@ -23,13 +23,19 @@ class ProfilerExtension extends AbstractExtension
         $this->actives[] = $profile;
     }
 
-    public function enter(Profile $profile): void
+    /**
+     * @return void
+     */
+    public function enter(Profile $profile)
     {
         $this->actives[0]->addProfile($profile);
         array_unshift($this->actives, $profile);
     }
 
-    public function leave(Profile $profile): void
+    /**
+     * @return void
+     */
+    public function leave(Profile $profile)
     {
         $profile->leave();
         array_shift($this->actives);

--- a/src/Loader/FilesystemLoader.php
+++ b/src/Loader/FilesystemLoader.php
@@ -139,7 +139,10 @@ class FilesystemLoader implements LoaderInterface
         return $path;
     }
 
-    public function exists(string $name): bool
+    /**
+     * @return bool
+     */
+    public function exists(string $name)
     {
         $name = $this->normalizeName($name);
 
@@ -160,7 +163,10 @@ class FilesystemLoader implements LoaderInterface
         return filemtime($path) < $time;
     }
 
-    protected function findTemplate(string $name, bool $throw = true): ?string
+    /**
+     * @return string|null
+     */
+    protected function findTemplate(string $name, bool $throw = true)
     {
         $name = $this->normalizeName($name);
 

--- a/src/Loader/LoaderInterface.php
+++ b/src/Loader/LoaderInterface.php
@@ -42,5 +42,8 @@ interface LoaderInterface
      */
     public function isFresh(string $name, int $time): bool;
 
-    public function exists(string $name): bool;
+    /**
+     * @return bool
+     */
+    public function exists(string $name);
 }

--- a/src/Node/Expression/Binary/SpaceshipBinary.php
+++ b/src/Node/Expression/Binary/SpaceshipBinary.php
@@ -15,7 +15,7 @@ use Twig\Compiler;
 
 class SpaceshipBinary extends AbstractBinary
 {
-    public function operator(Compiler $compiler)
+    public function operator(Compiler $compiler): Compiler
     {
         return $compiler->raw('<=>');
     }

--- a/src/Node/Expression/FunctionExpression.php
+++ b/src/Node/Expression/FunctionExpression.php
@@ -21,7 +21,7 @@ class FunctionExpression extends CallExpression
         parent::__construct(['arguments' => $arguments], ['name' => $name, 'is_defined_test' => false], $lineno);
     }
 
-    public function compile(Compiler $compiler): void
+    public function compile(Compiler $compiler)
     {
         $name = $this->getAttribute('name');
         $function = $compiler->getEnvironment()->getFunction($name);

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -77,7 +77,10 @@ class Node implements \Countable, \IteratorAggregate
         return implode("\n", $repr);
     }
 
-    public function compile(Compiler $compiler): void
+    /**
+     * @return void
+     */
+    public function compile(Compiler $compiler)
     {
         foreach ($this->nodes as $node) {
             $node->compile($compiler);
@@ -123,10 +126,7 @@ class Node implements \Countable, \IteratorAggregate
         return isset($this->nodes[$name]);
     }
 
-    /**
-     * @param string|int $name
-     */
-    public function getNode($name): self
+    public function getNode(string $name): self
     {
         if (!isset($this->nodes[$name])) {
             throw new \LogicException(sprintf('Node "%s" does not exist for Node "%s".', $name, \get_class($this)));
@@ -150,7 +150,7 @@ class Node implements \Countable, \IteratorAggregate
         return \count($this->nodes);
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->nodes);
     }

--- a/src/NodeVisitor/AbstractNodeVisitor.php
+++ b/src/NodeVisitor/AbstractNodeVisitor.php
@@ -38,12 +38,12 @@ abstract class AbstractNodeVisitor implements NodeVisitorInterface
      *
      * @return Node The modified node
      */
-    abstract protected function doEnterNode(Node $node, Environment $env): Node;
+    abstract protected function doEnterNode(Node $node, Environment $env);
 
     /**
      * Called after child nodes are visited.
      *
      * @return Node|null The modified node or null if the node must be removed
      */
-    abstract protected function doLeaveNode(Node $node, Environment $env): ?Node;
+    abstract protected function doLeaveNode(Node $node, Environment $env);
 }

--- a/src/Profiler/Profile.php
+++ b/src/Profiler/Profile.php
@@ -148,7 +148,7 @@ final class Profile implements \IteratorAggregate, \Serializable
         $this->enter();
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->profiles);
     }

--- a/src/TokenParser/TokenParserInterface.php
+++ b/src/TokenParser/TokenParserInterface.php
@@ -31,12 +31,16 @@ interface TokenParserInterface
     /**
      * Parses a token and returns a node.
      *
+     * @return Node
+     *
      * @throws SyntaxError
      */
-    public function parse(Token $token): Node;
+    public function parse(Token $token);
 
     /**
      * Gets the tag name associated with this token parser.
+     *
+     * @return string
      */
-    public function getTag(): string;
+    public function getTag();
 }


### PR DESCRIPTION
These return types make it needlessly hard to move to Twig 3.
This should make Symfony 4.4 compatible with Twig 3, and should help make the CI of Symfony 5 green.
> `Declaration of Twig\Extra\CssInliner\CssInlinerExtension::getFilters() must be compatible with Twig\Extension\AbstractExtension::getFilters(): array in /home/travis/build/symfony/symfony/vendor/twig/cssinliner-extra/src/CssInlinerExtension.php`