### PR TITLE
Twig 2 is compatible with PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,28 +6,34 @@ cache:
         - extra/*/vendor
         - $HOME/.composer/cache/files
 
+env:
+    global:
+        - SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1
+        - SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE=1
+
 before_install:
     - phpenv config-rm xdebug.ini || return 0
 
 install:
     - travis_retry composer install
-    - (cd extra/cssinliner-extra && travis_retry composer install)
-    - (cd extra/html-extra && travis_retry composer install)
-    - (cd extra/inky-extra && travis_retry composer install)
-    - (cd extra/intl-extra && travis_retry composer install)
-    - (cd extra/markdown-extra && travis_retry composer install)
+    - ([[ $TRAVIS_PHP_VERSION = 7.0 ]] || cd extra/cssinliner-extra && travis_retry composer install)
+    - ([[ $TRAVIS_PHP_VERSION = 7.0 ]] || cd extra/html-extra && travis_retry composer install)
+    - ([[ $TRAVIS_PHP_VERSION = 7.0 ]] || cd extra/inky-extra && travis_retry composer install)
+    - ([[ $TRAVIS_PHP_VERSION = 7.0 ]] || cd extra/intl-extra && travis_retry composer install)
+    - ([[ $TRAVIS_PHP_VERSION = 7.0 ]] || cd extra/markdown-extra && travis_retry composer install)
 
 script:
     - ./vendor/bin/simple-phpunit
-    - (cd extra/cssinliner-extra && ./vendor/bin/simple-phpunit)
-    - (cd extra/html-extra && ./vendor/bin/simple-phpunit)
-    - (cd extra/inky-extra && ./vendor/bin/simple-phpunit)
-    - (cd extra/intl-extra && ./vendor/bin/simple-phpunit)
-    - (cd extra/markdown-extra && ./vendor/bin/simple-phpunit)
+    - ([[ $TRAVIS_PHP_VERSION = 7.0 ]] || cd extra/cssinliner-extra && ./vendor/bin/simple-phpunit)
+    - ([[ $TRAVIS_PHP_VERSION = 7.0 ]] || cd extra/html-extra && ./vendor/bin/simple-phpunit)
+    - ([[ $TRAVIS_PHP_VERSION = 7.0 ]] || cd extra/inky-extra && ./vendor/bin/simple-phpunit)
+    - ([[ $TRAVIS_PHP_VERSION = 7.0 ]] || cd extra/intl-extra && ./vendor/bin/simple-phpunit)
+    - ([[ $TRAVIS_PHP_VERSION = 7.0 ]] || cd extra/markdown-extra && ./vendor/bin/simple-phpunit)
 
 jobs:
     fast_finish: true
     include:
+        - php: 7.0
         - php: 7.1
         - php: 7.2
         - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.0",
         "symfony/polyfill-mbstring": "^1.3",
         "symfony/polyfill-ctype": "^1.8"
     },

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -26,7 +26,7 @@ Slim, Yii, Laravel, and Codeigniter — just to name a few.
 Prerequisites
 -------------
 
-Twig needs at least **PHP 7.1.3** to run.
+Twig needs at least **PHP 7.0.0** to run.
 
 Installation
 ------------

--- a/tests/Cache/FilesystemTest.php
+++ b/tests/Cache/FilesystemTest.php
@@ -21,7 +21,7 @@ class FilesystemTest extends TestCase
     private $directory;
     private $cache;
 
-    protected function setUp(): void
+    protected function setUp()
     {
         $nonce = hash('sha256', uniqid(mt_rand(), true));
         $this->classname = '__Twig_Tests_Cache_FilesystemTest_Template_'.$nonce;
@@ -29,7 +29,7 @@ class FilesystemTest extends TestCase
         $this->cache = new FilesystemCache($this->directory);
     }
 
-    protected function tearDown(): void
+    protected function tearDown()
     {
         if (file_exists($this->directory)) {
             FilesystemHelper::removeDir($this->directory);

--- a/tests/Extension/SandboxTest.php
+++ b/tests/Extension/SandboxTest.php
@@ -28,7 +28,7 @@ class SandboxTest extends TestCase
     protected static $params;
     protected static $templates;
 
-    protected function setUp(): void
+    protected function setUp()
     {
         self::$params = [
             'name' => 'Fabien',

--- a/tests/TokenStreamTest.php
+++ b/tests/TokenStreamTest.php
@@ -20,7 +20,7 @@ class TokenStreamTest extends TestCase
 {
     protected static $tokens;
 
-    protected function setUp(): void
+    protected function setUp()
     {
         self::$tokens = [
             new Token(Token::TEXT_TYPE, 1, 1),


### PR DESCRIPTION
7.1 was needed for #3102, but this is not the case anymore since #3113