### PR TITLE
Fix the Travis config again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,21 +15,21 @@ before_install:
 
 install:
     - travis_retry composer install
-    - cd extra/cssinliner-extra && travis_retry composer install
-    - cd extra/html-extra && travis_retry composer install
-    - cd extra/inky-extra && travis_retry composer install
-    - cd extra/intl-extra && travis_retry composer install
-    - cd extra/markdown-extra && travis_retry composer install
-    - cd extra/string-extra && travis_retry composer install
+    - (cd extra/cssinliner-extra && travis_retry composer install)
+    - (cd extra/html-extra && travis_retry composer install)
+    - (cd extra/inky-extra && travis_retry composer install)
+    - (cd extra/intl-extra && travis_retry composer install)
+    - (cd extra/markdown-extra && travis_retry composer install)
+    - (cd extra/string-extra && travis_retry composer install)
 
 script:
     - ./vendor/bin/simple-phpunit
-    - cd extra/cssinliner-extra && ./vendor/bin/simple-phpunit
-    - cd extra/html-extra && ./vendor/bin/simple-phpunit
-    - cd extra/inky-extra && ./vendor/bin/simple-phpunit
-    - cd extra/intl-extra && ./vendor/bin/simple-phpunit
-    - cd extra/markdown-extra && ./vendor/bin/simple-phpunit
-    - cd extra/string-extra && ./vendor/bin/simple-phpunit
+    - (cd extra/cssinliner-extra && ./vendor/bin/simple-phpunit)
+    - (cd extra/html-extra && ./vendor/bin/simple-phpunit)
+    - (cd extra/inky-extra && ./vendor/bin/simple-phpunit)
+    - (cd extra/intl-extra && ./vendor/bin/simple-phpunit)
+    - (cd extra/markdown-extra && ./vendor/bin/simple-phpunit)
+    - (cd extra/string-extra && ./vendor/bin/simple-phpunit)
 
 jobs:
     fast_finish: true


### PR DESCRIPTION
The parenthesis around the statements are isolating the directory changes in a sub-command. So the right fix was not to remove the closing parenthesis, but to re-add the opening one.

This replaces #3187, which was merged even though Travis was still broken.