### PR TITLE
Add globals option in constructor and set globals by array with new method

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -118,7 +118,7 @@ class Environment
         $this->strictVariables = (bool) $options['strict_variables'];
         $this->setCache($options['cache']);
         $this->extensionSet = new ExtensionSet();
-        $this->globals = $options['globals'];
+        $this->globals = is_array($options['globals']) ? $options['globals'] : [] ;
 
         $this->addExtension(new CoreExtension());
         $this->addExtension(new EscaperExtension($options['autoescape']));

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -53,7 +53,7 @@ class Environment
     private $lexer;
     private $parser;
     private $compiler;
-    private $globals = [];
+    private $globals;
     private $resolvedGlobals;
     private $loadedTemplates;
     private $strictVariables;
@@ -94,6 +94,8 @@ class Environment
      *  * optimizations: A flag that indicates which optimizations to apply
      *                   (default to -1 which means that all optimizations are enabled;
      *                   set it to 0 to disable).
+     *
+     *  * globals: If you got set global parameters when you create a new instance (array: name => value).
      */
     public function __construct(LoaderInterface $loader, $options = [])
     {
@@ -107,6 +109,7 @@ class Environment
             'cache' => false,
             'auto_reload' => null,
             'optimizations' => -1,
+            'globals' => [],
         ], $options);
 
         $this->debug = (bool) $options['debug'];
@@ -115,6 +118,7 @@ class Environment
         $this->strictVariables = (bool) $options['strict_variables'];
         $this->setCache($options['cache']);
         $this->extensionSet = new ExtensionSet();
+        $this->globals = $options['globals'];
 
         $this->addExtension(new CoreExtension());
         $this->addExtension(new EscaperExtension($options['autoescape']));
@@ -754,6 +758,21 @@ class Environment
             $this->resolvedGlobals[$name] = $value;
         } else {
             $this->globals[$name] = $value;
+        }
+    }
+
+    /**
+     * Registers a Globals by array: name => value.
+     *
+     * New globals can be added before compiling or rendering a template;
+     * but after, you can only update existing globals.
+     *
+     * @param array $values The global values
+     */
+    public function addGlobals(array $values): void
+    {
+        foreach ($values as $name => $value) {
+            $this->addGlobal($name, $value);
         }
     }
 


### PR DESCRIPTION
I added the globals option in the constructor for set $globals when we create a new environment instance or if we declare a new service and we want the globals option to be passed as arguments.

I also added the addGlobals method which calls the addGlobal method if we want to add an array of globals directly.