### PR TITLE
Updated spaceless deprecation to point to `apply` tag, as the `filter` tag is now deprecated too

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,7 @@
   <php>
     <ini name="error_reporting" value="-1" />
     <ini name="xdebug.overload_var_dump" value="0" />
+    <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
   </php>
 
   <listeners>

--- a/src/TokenParser/SpacelessTokenParser.php
+++ b/src/TokenParser/SpacelessTokenParser.php
@@ -24,7 +24,7 @@ use Twig\Token;
  *   {% endspaceless %}
  *   {# output will be <div><strong>foo</strong></div> #}
  *
- * @deprecated since Twig 2.7, to be removed in 3.0 (use the spaceless filter instead)
+ * @deprecated since Twig 2.7, to be removed in 3.0 (use the "spaceless" filter with the "apply" tag instead)
  */
 final class SpacelessTokenParser extends AbstractTokenParser
 {
@@ -33,7 +33,7 @@ final class SpacelessTokenParser extends AbstractTokenParser
         $stream = $this->parser->getStream();
         $lineno = $token->getLine();
 
-        @trigger_error(sprintf('The spaceless tag in "%s" at line %d is deprecated since Twig 2.7, use the spaceless filter instead.', $stream->getSourceContext()->getName(), $lineno), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The spaceless tag in "%s" at line %d is deprecated since Twig 2.7, use the "spaceless" filter with the "apply" tag instead.', $stream->getSourceContext()->getName(), $lineno), E_USER_DEPRECATED);
 
         $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
         $body = $this->parser->subparse([$this, 'decideSpacelessEnd'], true);

--- a/tests/Fixtures/tags/block/capturing_block.test
+++ b/tests/Fixtures/tags/block/capturing_block.test
@@ -1,7 +1,7 @@
 --TEST--
 capturing "block" tag
 --DEPRECATION--
-The spaceless tag in "index.twig" at line 4 is deprecated since Twig 2.7, use the spaceless filter instead.
+The spaceless tag in "index.twig" at line 4 is deprecated since Twig 2.7, use the "spaceless" filter with the "apply" tag instead.
 --TEMPLATE--
 {% set foo %}{% block foo %}FOO{% endblock %}{% endset %}
 {{ foo }}

--- a/tests/Fixtures/tags/spaceless/root_level_in_child.legacy.test
+++ b/tests/Fixtures/tags/spaceless/root_level_in_child.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "spaceless" tag in the root level of a child template
 --DEPRECATION--
-The spaceless tag in "index.twig" at line 3 is deprecated since Twig 2.7, use the spaceless filter instead.
+The spaceless tag in "index.twig" at line 3 is deprecated since Twig 2.7, use the "spaceless" filter with the "apply" tag instead.
 Using the spaceless tag at the root level of a child template in "index.twig" at line 3 is deprecated since Twig 2.5.0 and will become a syntax error in 3.0.
 Nesting a block definition under a non-capturing node in "index.twig" at line 4 is deprecated since Twig 2.5.0 and will become a syntax error in 3.0.
 --TEMPLATE--

--- a/tests/Fixtures/tags/spaceless/simple.test
+++ b/tests/Fixtures/tags/spaceless/simple.test
@@ -1,7 +1,7 @@
 --TEST--
 "spaceless" tag removes whites between HTML tags
 --DEPRECATION--
-The spaceless tag in "index.twig" at line 2 is deprecated since Twig 2.7, use the spaceless filter instead.
+The spaceless tag in "index.twig" at line 2 is deprecated since Twig 2.7, use the "spaceless" filter with the "apply" tag instead.
 --TEMPLATE--
 {% spaceless %}
 


### PR DESCRIPTION
Title says it all.  No reason to chase our tail if we find a random `spaceless` tag yet.