### PR TITLE
[RFC] Avoid `strto(low|upp)er` due to special case in the `tr_TR` locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,17 @@ language: php
 
 dist: trusty
 
-sudo: true
+sudo: false
 
 cache:
     directories:
         - vendor
         - $HOME/.composer/cache/files
 
+addons:
+    apt:
+        packages:
+            - locales
 
 env:
     global:
@@ -22,7 +26,6 @@ install:
     - travis_retry composer install
 
 before_script:
-    - sudo locale-gen tr_TR.UTF-8
     - locale -a
     - if [ "$TWIG_EXT" == "yes" ]; then sh -c "cd ext/twig && phpize && ./configure --enable-twig && make && make install"; fi
     - if [ "$TWIG_EXT" == "yes" ]; then echo "extension=twig.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ install:
     - travis_retry composer install
 
 before_script:
-    - sudo locale-gen tr_TR.UTF-8 && locale -a | grep -q tr_TR.utf8
+    - sudo locale-gen tr_TR.UTF-8
+    - locale -a
     - if [ "$TWIG_EXT" == "yes" ]; then sh -c "cd ext/twig && phpize && ./configure --enable-twig && make && make install"; fi
     - if [ "$TWIG_EXT" == "yes" ]; then echo "extension=twig.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,10 @@ language: php
 
 dist: trusty
 
-sudo: false
-
 cache:
     directories:
         - vendor
         - $HOME/.composer/cache/files
-
-addons:
-    apt:
-        packages:
-            - locales
 
 env:
     global:
@@ -26,6 +19,7 @@ install:
     - travis_retry composer install
 
 before_script:
+    - sudo apt-get install -y locales
     - locale -a
     - if [ "$TWIG_EXT" == "yes" ]; then sh -c "cd ext/twig && phpize && ./configure --enable-twig && make && make install"; fi
     - if [ "$TWIG_EXT" == "yes" ]; then echo "extension=twig.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 dist: trusty
 
-sudo: false
+sudo: true
 
 cache:
     directories:
@@ -22,6 +22,7 @@ install:
     - travis_retry composer install
 
 before_script:
+    - sudo locale-gen tr_TR.UTF-8 && locale -a | grep -q tr_TR.utf8
     - if [ "$TWIG_EXT" == "yes" ]; then sh -c "cd ext/twig && phpize && ./configure --enable-twig && make && make install"; fi
     - if [ "$TWIG_EXT" == "yes" ]; then echo "extension=twig.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     - travis_retry composer install
 
 before_script:
-    - sudo locale-gen tr_TR.UTF-8
+    - sudo locale-gen tr_TR tr_TR.UTF-8
     - locale -a
     - if [ "$TWIG_EXT" == "yes" ]; then sh -c "cd ext/twig && phpize && ./configure --enable-twig && make && make install"; fi
     - if [ "$TWIG_EXT" == "yes" ]; then echo "extension=twig.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     - travis_retry composer install
 
 before_script:
-    - sudo apt-get install -y locales
+    - sudo locale-gen tr_TR.UTF-8
     - locale -a
     - if [ "$TWIG_EXT" == "yes" ]; then sh -c "cd ext/twig && phpize && ./configure --enable-twig && make && make install"; fi
     - if [ "$TWIG_EXT" == "yes" ]; then echo "extension=twig.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -299,6 +299,7 @@ class Parser implements \Twig_ParserInterface
             $this->reservedMacroNames = [];
             $r = new \ReflectionClass($this->env->getBaseTemplateClass());
             foreach ($r->getMethods() as $method) {
+                // TODO here?
                 $methodName = strtolower($method->getName());
 
                 if ('get' === substr($methodName, 0, 3) && isset($methodName[3])) {
@@ -307,6 +308,7 @@ class Parser implements \Twig_ParserInterface
             }
         }
 
+        // TODO here
         return \in_array(strtolower($name), $this->reservedMacroNames);
     }
 

--- a/src/Sandbox/SecurityPolicy.php
+++ b/src/Sandbox/SecurityPolicy.php
@@ -51,6 +51,7 @@ class SecurityPolicy implements SecurityPolicyInterface
     {
         $this->allowedMethods = [];
         foreach ($methods as $class => $m) {
+            // TODO Here
             $this->allowedMethods[$class] = array_map('strtolower', \is_array($m) ? $m : [$m]);
         }
     }
@@ -93,6 +94,7 @@ class SecurityPolicy implements SecurityPolicyInterface
         }
 
         $allowed = false;
+        // TODO here
         $method = strtolower($method);
         foreach ($this->allowedMethods as $class => $methods) {
             if ($obj instanceof $class) {

--- a/src/Template.php
+++ b/src/Template.php
@@ -628,7 +628,7 @@ abstract class Template implements \Twig_TemplateInterface
 
                 foreach ($ref->getMethods(\ReflectionMethod::IS_PUBLIC) as $refMethod) {
                     // Accessing the environment from templates is forbidden to prevent untrusted changes to the environment
-                    if ('getenvironment' !== strtolower($refMethod->name)) {
+                    if ('getenvironment' !== self::lowerAscii($refMethod->name)) {
                         $methods[] = $refMethod->name;
                     }
                 }
@@ -642,7 +642,7 @@ abstract class Template implements \Twig_TemplateInterface
 
             foreach ($methods as $method) {
                 $cache[$method] = $method;
-                $cache[$lcName = strtolower($method)] = $method;
+                $cache[$lcName = self::lowerAscii($method)] = $method;
 
                 if ('g' === $lcName[0] && 0 === strpos($lcName, 'get')) {
                     $name = substr($method, 3);
@@ -670,7 +670,7 @@ abstract class Template implements \Twig_TemplateInterface
         $call = false;
         if (isset(self::$cache[$class][$item])) {
             $method = self::$cache[$class][$item];
-        } elseif (isset(self::$cache[$class][$lcItem = strtolower($item)])) {
+        } elseif (isset(self::$cache[$class][$lcItem = self::lowerAscii($item)])) {
             $method = self::$cache[$class][$lcItem];
         } elseif (isset(self::$cache[$class]['__call'])) {
             $method = $item;
@@ -727,6 +727,11 @@ abstract class Template implements \Twig_TemplateInterface
         }
 
         return $ret;
+    }
+
+    private static function lowerAscii($str)
+    {
+        return strtolower(str_replace('I', 'i', $str));
     }
 }
 

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -260,6 +260,7 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetAttribute($defined, $value, $object, $item, $arguments, $type)
     {
+        setlocale(LC_ALL, 'tr_TR');
         $template = new TemplateForTest(new Environment($this->createMock('\Twig\Loader\LoaderInterface')));
 
         $this->assertEquals($value, $template->getAttribute($object, $item, $arguments, $type));


### PR DESCRIPTION
This is a weird issue that I do not really know how to best address.

When the `tr_TR` Turkish locale is active, `strtolower('I') !== 'i'` and `strtoupper('i') !== 'I'`. In Turkish, there are two special "i" characters, namely the "lowercase i without dot" and the "uppercase I with dot". See http://www.i18nguy.com/unicode/turkish-i18n.html for a really neat writeup.

Because `strtolower()` is used when scanning classes for attributes and methods, template markup like `{{ object.id }}` does no longer match a `function getId()` when the `tr_TR` locale is active.

On the one hand, I think it's a bug if a working Twig template suddenly fails due to a locale switch. On the other hand, I don't know how people how use `tr_TR` on a daily basis handle this... changing Twig behaviour in this regard might be a BC issue for them.

For now, I'll just try to modify the Travis setup and a test method to show that the issue exists.

What you you think how we should approach this?
