### PR TITLE
[Minor] Correct return type of twig_date_converter

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -459,7 +459,7 @@ function twig_date_modify_filter(Environment $env, $date, $modifier)
  * @param \DateTime|\DateTimeInterface|string|null $date     A date
  * @param \DateTimeZone|string|false|null          $timezone The target timezone, null to use the default, false to leave unchanged
  *
- * @return \DateTime
+ * @return \DateTimeInterface
  */
 function twig_date_converter(Environment $env, $date = null, $timezone = null)
 {


### PR DESCRIPTION
if a `\DateTimeImmutable` is passed to `twig_date_converter` it will return a `\DateTimeImmutable`, not a `\DateTime`.