### PR TITLE
Update doc with new escaping behavior on ternary statements

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -416,7 +416,7 @@ The escaping rules are implemented as follows:
         {% set text = "Twig<br />" %}
         {{ text }} {# will be escaped #}
 
-* Expressions which the result is always a literal or a variable marked safe
+* Expressions which the result is a literal or a variable marked safe
   are never automatically escaped:
 
   .. code-block:: twig
@@ -424,13 +424,11 @@ The escaping rules are implemented as follows:
         {{ foo ? "Twig<br />" : "<br />Twig" }} {# won't be escaped #}
 
         {% set text = "Twig<br />" %}
-        {{ foo ? text : "<br />Twig" }} {# will be escaped #}
+        {{ true ? text : "<br />Twig" }} {# will be escaped #}
+        {{ false ? text : "<br />Twig" }} {# won't be escaped #}
 
         {% set text = "Twig<br />" %}
         {{ foo ? text|raw : "<br />Twig" }} {# won't be escaped #}
-
-        {% set text = "Twig<br />" %}
-        {{ foo ? text|escape : "<br />Twig" }} {# the result of the expression won't be escaped #}
 
 * Escaping is applied before printing, after any other filter is applied:
 


### PR DESCRIPTION
According to https://symfony.com/blog/better-white-space-control-in-twig-templates#fine-grained-escaping-on-ternary-expressions