### PR TITLE
[2.x] initialize property with empty array for fix error: Parameter must be…

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -41,7 +41,7 @@ class Parser
     private $visitors;
     private $expressionParser;
     private $blocks;
-    private $blockStack;
+    private $blockStack = [];
     private $macros;
     private $env;
     private $importedSymbols;


### PR DESCRIPTION
Parameter must be an array or an object that implements Countable
method Parser::peekBlockStack() rise error if blockStack is not inialized