### PR TITLE
lower php requirement

### DIFF
--- a/extra/string-extra/composer.json
+++ b/extra/string-extra/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.9",
+        "php": "^7.2.5",
         "symfony/string": "^5.0",
         "twig/twig": "^2.4|^3.0"
     },


### PR DESCRIPTION
This PR adjusts the minimum PHP version to `7.2.5+` which is the version that is also required by Symfony 5.