### PR TITLE
Replace strtolower() with strtr() when dealing with method names

### DIFF
--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -657,7 +657,7 @@ class ExpressionParser
                 $stream->expect(Token::NAME_TYPE, null, 'Only variables can be assigned to');
             }
             $value = $token->getValue();
-            if (\in_array(strtolower($value), ['true', 'false', 'none', 'null'])) {
+            if (\in_array(strtr($value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), ['true', 'false', 'none', 'null'])) {
                 throw new SyntaxError(sprintf('You cannot assign a value to "%s".', $value), $token->getLine(), $stream->getSourceContext());
             }
             $targets[] = new AssignNameExpression($value, $token->getLine());

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -299,7 +299,7 @@ class Parser implements \Twig_ParserInterface
             $this->reservedMacroNames = [];
             $r = new \ReflectionClass($this->env->getBaseTemplateClass());
             foreach ($r->getMethods() as $method) {
-                $methodName = strtolower($method->getName());
+                $methodName = strtr($method->getName(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
 
                 if ('get' === substr($methodName, 0, 3) && isset($methodName[3])) {
                     $this->reservedMacroNames[] = substr($methodName, 3);
@@ -307,7 +307,7 @@ class Parser implements \Twig_ParserInterface
             }
         }
 
-        return \in_array(strtolower($name), $this->reservedMacroNames);
+        return \in_array(strtr($name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), $this->reservedMacroNames);
     }
 
     public function addTrait($trait)

--- a/src/Sandbox/SecurityPolicy.php
+++ b/src/Sandbox/SecurityPolicy.php
@@ -51,7 +51,7 @@ class SecurityPolicy implements SecurityPolicyInterface
     {
         $this->allowedMethods = [];
         foreach ($methods as $class => $m) {
-            $this->allowedMethods[$class] = array_map('strtolower', \is_array($m) ? $m : [$m]);
+            $this->allowedMethods[$class] = array_map(function ($value) { return strtr($value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'); }, \is_array($m) ? $m : [$m]);
         }
     }
 
@@ -93,7 +93,7 @@ class SecurityPolicy implements SecurityPolicyInterface
         }
 
         $allowed = false;
-        $method = strtolower($method);
+        $method = strtr($method, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
         foreach ($this->allowedMethods as $class => $methods) {
             if ($obj instanceof $class) {
                 $allowed = \in_array($method, $methods);

--- a/src/Template.php
+++ b/src/Template.php
@@ -628,7 +628,7 @@ abstract class Template implements \Twig_TemplateInterface
 
                 foreach ($ref->getMethods(\ReflectionMethod::IS_PUBLIC) as $refMethod) {
                     // Accessing the environment from templates is forbidden to prevent untrusted changes to the environment
-                    if ('getenvironment' !== strtolower($refMethod->name)) {
+                    if ('getenvironment' !== strtr($refMethod->name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')) {
                         $methods[] = $refMethod->name;
                     }
                 }
@@ -642,7 +642,7 @@ abstract class Template implements \Twig_TemplateInterface
 
             foreach ($methods as $method) {
                 $cache[$method] = $method;
-                $cache[$lcName = strtolower($method)] = $method;
+                $cache[$lcName = strtr($method, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')] = $method;
 
                 if ('g' === $lcName[0] && 0 === strpos($lcName, 'get')) {
                     $name = substr($method, 3);
@@ -670,7 +670,7 @@ abstract class Template implements \Twig_TemplateInterface
         $call = false;
         if (isset(self::$cache[$class][$item])) {
             $method = self::$cache[$class][$item];
-        } elseif (isset(self::$cache[$class][$lcItem = strtolower($item)])) {
+        } elseif (isset(self::$cache[$class][$lcItem = strtr($item, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')])) {
             $method = self::$cache[$class][$lcItem];
         } elseif (isset(self::$cache[$class]['__call'])) {
             $method = $item;


### PR DESCRIPTION
This is to improve consistency with the implementation of case-insensitivity for method names etc. in the Zend Engine: In fact, the ZE does not apply the internal `strtolower` implementation, but just maps ASCII `A-Z` to `a-z`.

This was done in https://github.com/php/php-src/commit/582514d4c7b216dbdc7a8429962cf3e5776206f0 to fix issues like https://bugs.php.net/bug.php?id=18556.

Additionally, `strtok` might give a tiny (measurable?) performance gain over `strtolower`, plus it is not locale-dependant.