### PR TITLE
Add param annotation for value in \Twig\Node\Expression\ConstantExpression

### DIFF
--- a/src/Node/Expression/ConstantExpression.php
+++ b/src/Node/Expression/ConstantExpression.php
@@ -16,6 +16,9 @@ use Twig\Compiler;
 
 class ConstantExpression extends AbstractExpression
 {
+    /**
+     * @param string|int|bool|null $value
+     */
     public function __construct($value, int $lineno)
     {
         parent::__construct([], ['value' => $value], $lineno);


### PR DESCRIPTION
Hello there :wave: 

Since the update of PHPStan to 0.12.4 it is complaining in our project ([example](https://github.com/shopware/platform/blob/6.1/src/Storefront/Framework/Twig/TokenParser/IconTokenParser.php#L40)) that the constructor parameter `$value` has to be an array and passing a string is not allowed. This happens because in the grandparent class `\Twig\Node\Node` the first constructor parameter is an array. 

This might be an error in PHPStan ([see issue](https://github.com/phpstan/phpstan/issues/2819)), but it could be fixed by specifying the parameter with an annotation. 

Beside the possible error in PHPStan, I think it still might be a good idea to add this annotation. Searching the source of Twig itself, `string|int|bool|null` are the right possible types for `$value`. If I missed something here, let me know and I will add it :blush: 

Thanks for the all the good work, you all have done here!

Best regards from Germany 

PS: this is my first PR for Twig, if I have done something wrong, please let me know :blush: 