### PR TITLE
Fix versionadded in doc

### DIFF
--- a/doc/functions/block.rst
+++ b/doc/functions/block.rst
@@ -1,10 +1,10 @@
 ``block``
 =========
 
-.. versionadded: 1.28
+.. versionadded:: 1.28
     Using ``block`` with the ``defined`` test was added in Twig 1.28.
 
-.. versionadded: 1.28
+.. versionadded:: 1.28
     Support for the template argument was added in Twig 1.28.
 
 When a template uses inheritance and if you want to print a block multiple

--- a/doc/functions/constant.rst
+++ b/doc/functions/constant.rst
@@ -1,10 +1,10 @@
 ``constant``
 ============
 
-.. versionadded: 1.12.1
+.. versionadded:: 1.12.1
     constant now accepts object instances as the second argument.
 
-.. versionadded: 1.28
+.. versionadded:: 1.28
     Using ``constant`` with the ``defined`` test was added in Twig 1.28.
 
 ``constant`` returns the constant value for a given string:

--- a/doc/tests/constant.rst
+++ b/doc/tests/constant.rst
@@ -1,7 +1,7 @@
 ``constant``
 ============
 
-.. versionadded: 1.13.1
+.. versionadded:: 1.13.1
     constant now accepts object instances as the second argument.
 
 ``constant`` checks if a variable has the exact same value as a constant. You


### PR DESCRIPTION
I think those versionadded blocks don't show because they have a typo.