### PR TITLE
Syntax error in doc

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -660,7 +660,7 @@ An extension is a class that implements the following interface::
 
 To keep your extension class clean and lean, inherit from the built-in
 ``\Twig\Extension\AbstractExtension`` class instead of implementing the interface as it provides
-empty implementations for all methods:
+empty implementations for all methods::
 
     class Project_Twig_Extension extends \Twig\Extension\AbstractExtension
     {


### PR DESCRIPTION
This code sample in advanced.rst is not highlighted in php because the second semicolon is missing