### PR TITLE
fix(CoreExtension twig_escape_filter) custom filter for empty string

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1031,10 +1031,6 @@ function twig_escape_filter(Environment $env, $string, $strategy = 'html', $char
         }
     }
 
-    if ('' === $string) {
-        return '';
-    }
-
     if (null === $charset) {
         $charset = $env->getCharset();
     }
@@ -1063,6 +1059,10 @@ function twig_escape_filter(Environment $env, $string, $strategy = 'html', $char
                 'ISO8859-5' => true, 'ISO-8859-5' => true, 'MACROMAN' => true,
             ];
 
+            if ('' === $string) {
+                return '';
+            }
+
             if (isset($htmlspecialcharsCharsets[$charset])) {
                 return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
             }
@@ -1080,6 +1080,10 @@ function twig_escape_filter(Environment $env, $string, $strategy = 'html', $char
             return twig_convert_encoding($string, $charset, 'UTF-8');
 
         case 'js':
+            if ('' === $string) {
+                return '';
+            }
+
             // escape all non-alphanumeric characters
             // into their \x or \uHHHH representations
             if ('UTF-8' !== $charset) {
@@ -1099,6 +1103,10 @@ function twig_escape_filter(Environment $env, $string, $strategy = 'html', $char
             return $string;
 
         case 'css':
+            if ('' === $string) {
+                return '';
+            }
+
             if ('UTF-8' !== $charset) {
                 $string = twig_convert_encoding($string, 'UTF-8', $charset);
             }
@@ -1116,6 +1124,10 @@ function twig_escape_filter(Environment $env, $string, $strategy = 'html', $char
             return $string;
 
         case 'html_attr':
+            if ('' === $string) {
+                return '';
+            }
+
             if ('UTF-8' !== $charset) {
                 $string = twig_convert_encoding($string, 'UTF-8', $charset);
             }


### PR DESCRIPTION
custom filters should be able to decide by themselves if they want to process
empty strings or not ... for example:

->getExtension('core')->setEscaper('json', function($twigEnv, $string, $charset) {
    return json_encode($string);
});

template:
[{{value1}},{{value2}}]
=> empty strings need to be run through json_encode() too

this was working up to "v1.33.2", upgrading to "v1.42.4" for php7.4 compatibility introduced this issue