### PR TITLE
IntlExtension > Handle MissingResourceException

### DIFF
--- a/extra/intl-extra/src/IntlExtension.php
+++ b/extra/intl-extra/src/IntlExtension.php
@@ -13,6 +13,7 @@ namespace Twig\Extra\Intl;
 
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\Intl\Currencies;
+use Symfony\Component\Intl\Exception\MissingResourceException;
 use Symfony\Component\Intl\Languages;
 use Symfony\Component\Intl\Locales;
 use Symfony\Component\Intl\Timezones;
@@ -156,37 +157,65 @@ final class IntlExtension extends AbstractExtension
 
     public function getCountryName(string $country, string $locale = null): string
     {
-        return Countries::getName($country, $locale);
+        try {
+            return Countries::getName($country, $locale);
+        } catch (MissingResourceException $exception) {
+            return $country;
+        }
     }
 
     public function getCurrencyName(string $currency, string $locale = null): string
     {
-        return Currencies::getName($currency, $locale);
+        try {
+            return Currencies::getName($currency, $locale);
+        } catch (MissingResourceException $exception) {
+            return $currency;
+        }
     }
 
     public function getCurrencySymbol(string $currency, string $locale = null): string
     {
-        return Currencies::getSymbol($currency, $locale);
+        try {
+            return Currencies::getSymbol($currency, $locale);
+        } catch (MissingResourceException $exception) {
+            return $currency;
+        }
     }
 
     public function getLanguageName(string $language, string $locale = null): string
     {
-        return Languages::getName($language, $locale);
+        try {
+            return Languages::getName($language, $locale);
+        } catch (MissingResourceException $exception) {
+            return $language;
+        }
     }
 
     public function getLocaleName(string $data, string $locale = null): string
     {
-        return Locales::getName($data, $locale);
+        try {
+            return Locales::getName($data, $locale);
+        } catch (MissingResourceException $exception) {
+            return $data;
+        }
     }
 
     public function getTimezoneName(string $timezone, string $locale = null): string
     {
-        return Timezones::getName($timezone, $locale);
+        try {
+            return Timezones::getName($timezone, $locale);
+        } catch (MissingResourceException $exception) {
+            return $timezone;
+        }
     }
 
     public function getCountryTimezones(string $country): array
     {
-        return Timezones::forCountryCode($country);
+        try {
+            return Timezones::forCountryCode($country);
+        } catch (MissingResourceException $exception) {
+            return [];
+        }
     }
 
     public function formatCurrency($amount, string $currency, array $attrs = [], string $locale = null): string

--- a/extra/intl-extra/tests/Fixtures/country_name.test
+++ b/extra/intl-extra/tests/Fixtures/country_name.test
@@ -1,6 +1,7 @@
 --TEST--
 "country_name" filter
 --TEMPLATE--
+{{ 'UNKNOWN'|country_name }}
 {{ 'FR'|country_name }}
 {{ 'US'|country_name }}
 {{ 'US'|country_name('fr') }}
@@ -8,6 +9,7 @@
 --DATA--
 return [];
 --EXPECT--
+UNKNOWN
 France
 United States
 États-Unis

--- a/extra/intl-extra/tests/Fixtures/country_timezones.test
+++ b/extra/intl-extra/tests/Fixtures/country_timezones.test
@@ -1,10 +1,12 @@
 --TEST--
 "country_timezones" function
 --TEMPLATE--
+{{ country_timezones('UNKNOWN')|length }}
 {{ country_timezones('FR')|join(', ') }}
 {{ country_timezones('US')|join(', ') }}
 --DATA--
 return [];
 --EXPECT--
+0
 Europe/Paris
 America/Adak, America/Anchorage, America/Boise, America/Chicago, America/Denver, America/Detroit, America/Indiana/Knox, America/Indiana/Marengo, America/Indiana/Petersburg, America/Indiana/Tell_City, America/Indiana/Vevay, America/Indiana/Vincennes, America/Indiana/Winamac, America/Indianapolis, America/Juneau, America/Kentucky/Monticello, America/Los_Angeles, America/Louisville, America/Menominee, America/Metlakatla, America/New_York, America/Nome, America/North_Dakota/Beulah, America/North_Dakota/Center, America/North_Dakota/New_Salem, America/Phoenix, America/Sitka, America/Yakutat, Pacific/Honolulu

--- a/extra/intl-extra/tests/Fixtures/currency_name.test
+++ b/extra/intl-extra/tests/Fixtures/currency_name.test
@@ -1,6 +1,7 @@
 --TEST--
 "currency_name" filter
 --TEMPLATE--
+{{ 'UNKNOWN'|currency_name }}
 {{ 'EUR'|currency_name }}
 {{ 'JPY'|currency_name }}
 {{ 'EUR'|currency_name('fr') }}
@@ -8,6 +9,7 @@
 --DATA--
 return [];
 --EXPECT--
+UNKNOWN
 Euro
 Japanese Yen
 euro

--- a/extra/intl-extra/tests/Fixtures/currency_symbol.test
+++ b/extra/intl-extra/tests/Fixtures/currency_symbol.test
@@ -1,10 +1,12 @@
 --TEST--
 "currency_symbol" filter
 --TEMPLATE--
+{{ 'UNKNOWN'|currency_symbol }}
 {{ 'EUR'|currency_symbol }}
 {{ 'JPY'|currency_symbol }}
 --DATA--
 return [];
 --EXPECT--
+UNKNOWN
 €
 ¥

--- a/extra/intl-extra/tests/Fixtures/language_name.test
+++ b/extra/intl-extra/tests/Fixtures/language_name.test
@@ -1,6 +1,7 @@
 --TEST--
 "language_name" filter
 --TEMPLATE--
+{{ 'UNKNOWN'|language_name }}
 {{ 'de'|language_name }}
 {{ 'fr'|language_name }}
 {{ 'de'|language_name('fr') }}
@@ -9,6 +10,7 @@
 --DATA--
 return [];
 --EXPECT--
+UNKNOWN
 German
 French
 allemand

--- a/extra/intl-extra/tests/Fixtures/locale_name.test
+++ b/extra/intl-extra/tests/Fixtures/locale_name.test
@@ -1,6 +1,7 @@
 --TEST--
 "locale_name" filter
 --TEMPLATE--
+{{ 'UNKNOWN'|locale_name }}
 {{ 'de'|locale_name }}
 {{ 'fr'|locale_name }}
 {{ 'de'|locale_name('fr') }}
@@ -9,6 +10,7 @@
 --DATA--
 return [];
 --EXPECT--
+UNKNOWN
 German
 French
 allemand

--- a/extra/intl-extra/tests/Fixtures/timezone_name.test
+++ b/extra/intl-extra/tests/Fixtures/timezone_name.test
@@ -1,12 +1,14 @@
 --TEST--
 "timezone_name" filter
 --TEMPLATE--
+{{ 'UNKNOWN'|timezone_name }}
 {{ 'Europe/Paris'|timezone_name }}
 {{ 'America/Los_Angeles'|timezone_name }}
 {{ 'America/Los_Angeles'|timezone_name('fr') }}
 --DATA--
 return [];
 --EXPECT--
+UNKNOWN
 Central European Time (Paris)
 Pacific Time (Los Angeles)
 heure du Pacifique nord-américain (Los Angeles)


### PR DESCRIPTION
When you want to get the language name of a language you can type:
```twig
{{ inputLanguage | language_name }}
```

But if `inputLanguage` is not a valid language, a `MissingResourceException` is thrown, blowing up the whole page.

Since in Twig, there is no way to catch this exception, it becomes extremely hard to work with these helpers if you have no control over the input. There is also no way to first check if the language exists before invoking the filter.
