### PR TITLE
IntlExtension > Return empty string when input is null

### DIFF
--- a/extra/intl-extra/src/IntlExtension.php
+++ b/extra/intl-extra/src/IntlExtension.php
@@ -155,8 +155,12 @@ final class IntlExtension extends AbstractExtension
         ];
     }
 
-    public function getCountryName(string $country, string $locale = null): string
+    public function getCountryName(?string $country, string $locale = null): string
     {
+        if ($country === null) {
+            return '';
+        }
+
         try {
             return Countries::getName($country, $locale);
         } catch (MissingResourceException $exception) {
@@ -164,8 +168,12 @@ final class IntlExtension extends AbstractExtension
         }
     }
 
-    public function getCurrencyName(string $currency, string $locale = null): string
+    public function getCurrencyName(?string $currency, string $locale = null): string
     {
+        if ($currency === null) {
+            return '';
+        }
+
         try {
             return Currencies::getName($currency, $locale);
         } catch (MissingResourceException $exception) {
@@ -173,8 +181,12 @@ final class IntlExtension extends AbstractExtension
         }
     }
 
-    public function getCurrencySymbol(string $currency, string $locale = null): string
+    public function getCurrencySymbol(?string $currency, string $locale = null): string
     {
+        if ($currency === null) {
+            return '';
+        }
+
         try {
             return Currencies::getSymbol($currency, $locale);
         } catch (MissingResourceException $exception) {
@@ -182,8 +194,12 @@ final class IntlExtension extends AbstractExtension
         }
     }
 
-    public function getLanguageName(string $language, string $locale = null): string
+    public function getLanguageName(?string $language, string $locale = null): string
     {
+        if ($language === null) {
+            return '';
+        }
+
         try {
             return Languages::getName($language, $locale);
         } catch (MissingResourceException $exception) {
@@ -191,8 +207,12 @@ final class IntlExtension extends AbstractExtension
         }
     }
 
-    public function getLocaleName(string $data, string $locale = null): string
+    public function getLocaleName(?string $data, string $locale = null): string
     {
+        if ($data === null) {
+            return '';
+        }
+
         try {
             return Locales::getName($data, $locale);
         } catch (MissingResourceException $exception) {
@@ -200,8 +220,12 @@ final class IntlExtension extends AbstractExtension
         }
     }
 
-    public function getTimezoneName(string $timezone, string $locale = null): string
+    public function getTimezoneName(?string $timezone, string $locale = null): string
     {
+        if ($timezone === null) {
+            return '';
+        }
+
         try {
             return Timezones::getName($timezone, $locale);
         } catch (MissingResourceException $exception) {

--- a/extra/intl-extra/tests/Fixtures/country_name.test
+++ b/extra/intl-extra/tests/Fixtures/country_name.test
@@ -2,6 +2,7 @@
 "country_name" filter
 --TEMPLATE--
 {{ 'UNKNOWN'|country_name }}
+{{ null|country_name }}
 {{ 'FR'|country_name }}
 {{ 'US'|country_name }}
 {{ 'US'|country_name('fr') }}
@@ -10,6 +11,7 @@
 return [];
 --EXPECT--
 UNKNOWN
+
 France
 United States
 États-Unis

--- a/extra/intl-extra/tests/Fixtures/currency_name.test
+++ b/extra/intl-extra/tests/Fixtures/currency_name.test
@@ -2,6 +2,7 @@
 "currency_name" filter
 --TEMPLATE--
 {{ 'UNKNOWN'|currency_name }}
+{{ null|currency_name }}
 {{ 'EUR'|currency_name }}
 {{ 'JPY'|currency_name }}
 {{ 'EUR'|currency_name('fr') }}
@@ -10,6 +11,7 @@
 return [];
 --EXPECT--
 UNKNOWN
+
 Euro
 Japanese Yen
 euro

--- a/extra/intl-extra/tests/Fixtures/currency_symbol.test
+++ b/extra/intl-extra/tests/Fixtures/currency_symbol.test
@@ -2,11 +2,13 @@
 "currency_symbol" filter
 --TEMPLATE--
 {{ 'UNKNOWN'|currency_symbol }}
+{{ null|currency_symbol }}
 {{ 'EUR'|currency_symbol }}
 {{ 'JPY'|currency_symbol }}
 --DATA--
 return [];
 --EXPECT--
 UNKNOWN
+
 €
 ¥

--- a/extra/intl-extra/tests/Fixtures/language_name.test
+++ b/extra/intl-extra/tests/Fixtures/language_name.test
@@ -2,6 +2,7 @@
 "language_name" filter
 --TEMPLATE--
 {{ 'UNKNOWN'|language_name }}
+{{ null|language_name }}
 {{ 'de'|language_name }}
 {{ 'fr'|language_name }}
 {{ 'de'|language_name('fr') }}
@@ -11,6 +12,7 @@
 return [];
 --EXPECT--
 UNKNOWN
+
 German
 French
 allemand

--- a/extra/intl-extra/tests/Fixtures/locale_name.test
+++ b/extra/intl-extra/tests/Fixtures/locale_name.test
@@ -2,6 +2,7 @@
 "locale_name" filter
 --TEMPLATE--
 {{ 'UNKNOWN'|locale_name }}
+{{ null|locale_name }}
 {{ 'de'|locale_name }}
 {{ 'fr'|locale_name }}
 {{ 'de'|locale_name('fr') }}
@@ -11,6 +12,7 @@
 return [];
 --EXPECT--
 UNKNOWN
+
 German
 French
 allemand

--- a/extra/intl-extra/tests/Fixtures/timezone_name.test
+++ b/extra/intl-extra/tests/Fixtures/timezone_name.test
@@ -2,6 +2,7 @@
 "timezone_name" filter
 --TEMPLATE--
 {{ 'UNKNOWN'|timezone_name }}
+{{ null|timezone_name }}
 {{ 'Europe/Paris'|timezone_name }}
 {{ 'America/Los_Angeles'|timezone_name }}
 {{ 'America/Los_Angeles'|timezone_name('fr') }}
@@ -9,6 +10,7 @@
 return [];
 --EXPECT--
 UNKNOWN
+
 Central European Time (Paris)
 Pacific Time (Los Angeles)
 heure du Pacifique nord-américain (Los Angeles)


### PR DESCRIPTION
```twig
{{ inputCountry | country_name('en') }}
```
When `inputCountry` is `null` it will give this error:
```
Argument 1 passed to Twig\Extra\Intl\IntlExtension::getCountryName() must be of the type string, null given
```

With this change, an empty string will be returned instead.

See discussion in https://github.com/twigphp/Twig/pull/3257#issuecomment-585740408