### PR TITLE
Support object initialisation shortcut {a} == {a:a} from ES2015

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -568,6 +568,10 @@ exist:
     {# keys as integer #}
     { 2: 'foo', 4: 'bar' }
 
+    {# keys get the variable name when omitted #}
+    {% set foo = 'foo' %}
+    { foo }
+
     {# keys as expressions (the expression must be enclosed into parentheses) -- as of Twig 1.5 #}
     {% set foo = 'foo' %}
     { (foo): 'foo', (1 + 1): 'bar', (foo ~ 'b'): 'baz' }

--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -376,7 +376,16 @@ class ExpressionParser
             //  * a string -- 'a'
             //  * a name, which is equivalent to a string -- a
             //  * an expression, which must be enclosed in parentheses -- (1 + 2)
-            if (($token = $stream->nextIf(Token::STRING_TYPE)) || ($token = $stream->nextIf(Token::NAME_TYPE)) || $token = $stream->nextIf(Token::NUMBER_TYPE)) {
+            if ($token = $stream->nextIf(Token::NAME_TYPE)) {
+                $key = new ConstantExpression($token->getValue(), $token->getLine());
+
+                // {a} is a shortcut for {a:a}
+                if ($stream->test(Token::PUNCTUATION_TYPE, [',', '}'])) {
+                    $value = new NameExpression($key->getAttribute('value'), $key->getTemplateLine());
+                    $node->addElement($value, $key);
+                    continue;
+                }
+            } elseif (($token = $stream->nextIf(Token::STRING_TYPE)) || $token = $stream->nextIf(Token::NUMBER_TYPE)) {
                 $key = new ConstantExpression($token->getValue(), $token->getLine());
             } elseif ($stream->test(Token::PUNCTUATION_TYPE, '(')) {
                 $key = $this->parseExpression();

--- a/tests/ExpressionParserTest.php
+++ b/tests/ExpressionParserTest.php
@@ -83,6 +83,7 @@ class ExpressionParserTest extends \PHPUnit\Framework\TestCase
         return [
             ['{{ [1, "a": "b"] }}'],
             ['{{ {"a": "b", 2} }}'],
+            ['{{ {"a"} }}'],
         ];
     }
 
@@ -159,6 +160,12 @@ class ExpressionParserTest extends \PHPUnit\Framework\TestCase
                   new ConstantExpression('c', 1),
                 ], 1),
             ],
+            ['{{ {a, b} }}', new ArrayExpression([
+                new ConstantExpression('a', 1),
+                new NameExpression('a', 1),
+                new ConstantExpression('b', 1),
+                new NameExpression('b', 1),
+            ], 1)]
         ];
     }
 


### PR DESCRIPTION
Object declaration in Twig is very close to the Javascript syntax and is targeting the same profil of developers. In order to provide a smooth developer experience, Twig should implement some new feature of ECMAScript.

Since ECMAScript 2015, a short syntax can be used to declare an object when the key is identical to a defined variable (see [MDN doc](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Object_initializer))

```js
// Shorthand property names (ES2015)
let a = 'foo', b = 42, c = {};
let o = {a, b, c}
```

This PR adds the same syntax to Twig.
This can be very useful for `include ... with ... only` :
```twig
{% set title = "My title" %}
{% set image = "image.jpg" %}
{{ include("template.twig", {title, image}, false) }}
# instead of 
{{ include("template.twig", {'title': title, 'image': image}, false) }}
```