### PR TITLE
Fix logic for refreshing the cache

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -338,7 +338,7 @@ class Environment
         if (!class_exists($cls, false)) {
             $key = $this->cache->generateKey($name, $mainCls);
 
-            if (!$this->isAutoReload() || $this->isTemplateFresh($name, $this->cache->getTimestamp($key))) {
+            if (!$this->isAutoReload() && $this->isTemplateFresh($name, $this->cache->getTimestamp($key))) {
                 $this->cache->load($key);
             }
 


### PR DESCRIPTION
The logic for refreshing the cache is not working properly and always loads from the cache if AutoReload is false. `isTemplateFresh` never gets called. The logic should be:

<table>
<thead>
<tr><th>autoreload</th><th>cache fresh</th><th>action</th></tr>
</thead>
<tbody>
<tr><td>true</td><td>true</td><td>re-generate</td></tr>
<tr><td>true</td><td>false</td><td>re-generate</td></tr>
<tr><td>false</td><td>true</td><td>load from cache</td></tr>
<tr><td>false</td><td>false</td><td>re-generate</td></tr>
</tbody>
</table>