### PR TITLE
Tweaking phpdoc above Environment

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -35,7 +35,7 @@ use Twig\RuntimeLoader\RuntimeLoaderInterface;
 use Twig\TokenParser\TokenParserInterface;
 
 /**
- * Stores the Twig configuration.
+ * Stores the Twig configuration and renders templates.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */


### PR DESCRIPTION
Super minor. This description is displayed in Symfony's `debug:autowiring` command. It occurred to me that the current description doesn't describe the "thing" that most people would be looking for - that it *renders* templates.

Thanks!