### PR TITLE
Fix typos

### DIFF
--- a/doc/filters/country_name.rst
+++ b/doc/filters/country_name.rst
@@ -29,7 +29,7 @@ By default, the filter uses the current locale. You can pass it explicitly:
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/filters/currency_name.rst
+++ b/doc/filters/currency_name.rst
@@ -32,7 +32,7 @@ By default, the filter uses the current locale. You can pass it explicitly:
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/filters/currency_symbol.rst
+++ b/doc/filters/currency_symbol.rst
@@ -32,7 +32,7 @@ By default, the filter uses the current locale. You can pass it explicitly:
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/filters/data_uri.rst
+++ b/doc/filters/data_uri.rst
@@ -32,7 +32,7 @@ The ``data_uri`` filter generates a URL using the data scheme as defined in RFC
         $ composer req twig/html-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Html\HtmlExtension;
 

--- a/doc/filters/format_currency.rst
+++ b/doc/filters/format_currency.rst
@@ -60,7 +60,7 @@ By default, the filter uses the current locale. You can pass it explicitly:
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/filters/format_date.rst
+++ b/doc/filters/format_date.rst
@@ -17,7 +17,7 @@ the ``format_datetime`` filter, but without the time.
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/filters/format_datetime.rst
+++ b/doc/filters/format_datetime.rst
@@ -52,7 +52,7 @@ By default, the filter uses the current locale. You can pass it explicitly:
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/filters/format_number.rst
+++ b/doc/filters/format_number.rst
@@ -103,7 +103,7 @@ By default, the filter uses the current locale. You can pass it explicitly:
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/filters/format_time.rst
+++ b/doc/filters/format_time.rst
@@ -17,7 +17,7 @@ the ``format_datetime`` filter, but without the date.
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/filters/html_to_markdown.rst
+++ b/doc/filters/html_to_markdown.rst
@@ -44,7 +44,7 @@ You can also use the filter on an included file:
         $ composer req twig/markdown-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Markdown\MarkdownExtension;
 

--- a/doc/filters/inky_to_html.rst
+++ b/doc/filters/inky_to_html.rst
@@ -32,7 +32,7 @@ You can also use the filter on an included file:
         $ composer req twig/inky-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Inky\InkyExtension;
 

--- a/doc/filters/inline_css.rst
+++ b/doc/filters/inline_css.rst
@@ -56,7 +56,7 @@ Note that the CSS inliner works on an entire HTML document, not a fragment.
         $ composer req twig/cssinliner-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\CssInliner\CssInlinerExtension;
 

--- a/doc/filters/language_name.rst
+++ b/doc/filters/language_name.rst
@@ -32,7 +32,7 @@ By default, the filter uses the current locale. You can pass it explicitly:
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/filters/locale_name.rst
+++ b/doc/filters/locale_name.rst
@@ -32,7 +32,7 @@ By default, the filter uses the current locale. You can pass it explicitly:
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/filters/markdown_to_html.rst
+++ b/doc/filters/markdown_to_html.rst
@@ -43,7 +43,7 @@ You can also use the filter on an included file:
         $ composer req twig/markdown-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Markdown\MarkdownExtension;
 

--- a/doc/filters/timezone_name.rst
+++ b/doc/filters/timezone_name.rst
@@ -31,7 +31,7 @@ By default, the filter uses the current locale. You can pass it explicitly:
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/functions/country_timezones.rst
+++ b/doc/functions/country_timezones.rst
@@ -22,7 +22,7 @@ with a given country code:
         $ composer req twig/intl-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Intl\IntlExtension;
 

--- a/doc/functions/html_classes.rst
+++ b/doc/functions/html_classes.rst
@@ -25,7 +25,7 @@ names together:
         $ composer req twig/html-extra
 
     Then, use the ``twig/extra-bundle`` on Symfony projects or add the extension
-    explictly on the Twig environment::
+    explicitly on the Twig environment::
 
         use Twig\Extra\Html\HtmlExtension;
 

--- a/doc/tags/macro.rst
+++ b/doc/tags/macro.rst
@@ -128,7 +128,7 @@ The scoping rules are the same whether you imported macros via ``import`` or
 Imported macros are always **local** to the current template. It means that
 macros are available in all blocks and other macros defined in the current
 template, but they are not available in included templates or child templates;
-you need to explicitely re-import macros in each template.
+you need to explicitly re-import macros in each template.
 
 When calling ``import`` or ``from`` from a ``block`` tag, the imported macros
 are only defined in the current block and they override macros defined at the

--- a/extra/html-extra/src/HtmlExtension.php
+++ b/extra/html-extra/src/HtmlExtension.php
@@ -41,7 +41,7 @@ final class HtmlExtension extends AbstractExtension
     /**
      * Creates a data URI (RFC 2397).
      *
-     * Length validation is not perfomed on purpose, validation should
+     * Length validation is not performed on purpose, validation should
      * be done before calling this filter.
      *
      * @return string The generated data URI

--- a/src/Extension/EscaperExtension.php
+++ b/src/Extension/EscaperExtension.php
@@ -265,7 +265,7 @@ function twig_escape_filter(Environment $env, $string, $strategy = 'html', $char
 
                 /*
                  * A few characters have short escape sequences in JSON and JavaScript.
-                 * Escape sequences supported only by JavaScript, not JSON, are ommitted.
+                 * Escape sequences supported only by JavaScript, not JSON, are omitted.
                  * \" is also supported but omitted, because the resulting string is not HTML safe.
                  */
                 static $shortMap = [


### PR DESCRIPTION
Hello,

This PR will fix : 

- 1 typo in `doc/filters/country_name.rst`
- 1 typo in `doc/filters/currency_name.rst`
- 1 typo in `doc/filters/currency_symbol.rst`
- 1 typo in `doc/filters/data_uri.rst`
- 1 typo in `doc/filters/format_currency.rst`
- 1 typo in `doc/filters/format_date.rst`
- 1 typo in `doc/filters/format_datetime.rst`
- 1 typo in `doc/filters/format_number.rst`
- 1 typo in `doc/filters/format_time.rst`
- 1 typo in `doc/filters/html_to_markdown.rst`
- 1 typo in `doc/filters/inky_to_html.rst`
- 1 typo in `doc/filters/inline_css.rst`
- 1 typo in `doc/filters/language_name.rst`
- 1 typo in `doc/filters/locale_name.rst`
- 1 typo in `doc/filters/markdown_to_html.rst`
- 1 typo in `doc/filters/timezone_name.rst`
- 1 typo in `doc/functions/country_timezones.rst`
- 1 typo in `doc/functions/html_classes.rst`
- 1 typo in `doc/tags/macro.rst`
- 1 typo in `extra/html-extra/src/HtmlExtension.php`
- 1 typo in `src/Extension/EscaperExtension.php`



Cheers! :robot: