### PR TITLE
An error in format_number.rst. "format_number" invalid usage

### DIFF
--- a/doc/filters/format_number.rst
+++ b/doc/filters/format_number.rst
@@ -78,10 +78,10 @@ You can pass attributes to tweak the output:
 .. code-block:: twig
 
     {# €12.34 #}
-    {{ '12.345'|format_number('EUR', {rounding_mode: 'floor'}) }}
+    {{ '12.345'|format_currency('EUR', {rounding_mode: 'floor'}) }}
 
     {# €1,000,000.0000 #}
-    {{ '1000000'|format_number('EUR', {fraction_digit: 4}) }}
+    {{ '1000000'|format_currency('EUR', {fraction_digit: 4}) }}
 
 By default, the filter uses the current locale. You can pass it explicitly:
 


### PR DESCRIPTION
format_number does not accept second argument as a string, so I believe "format_currency" is the correct extension in this case