### PR TITLE
Fix transform call to Michelf\MarkdownExtra

### DIFF
--- a/extra/markdown-extra/src/MichelfMarkdown.php
+++ b/extra/markdown-extra/src/MichelfMarkdown.php
@@ -29,6 +29,6 @@ class MichelfMarkdown implements MarkdownInterface
 
     public function convert(string $body): string
     {
-        return $this->converter->defaultTransform($body);
+        return $this->converter->transform($body);
     }
 }


### PR DESCRIPTION
As per the documentation here:

  https://michelf.ca/projects/php-markdown/configuration/#configure

Calling defaultTransform() will use the default options, thus ignoring
the "hard_wrap" option. Calling transform() instead, which takes the
options into account.