### PR TITLE
Throw exception in case non-Traversable data is passed to "filter"

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1695,6 +1695,10 @@ function twig_array_batch($items, $size, $fill = null, $preserveKeys = true)
 
 function twig_array_filter($array, $arrow)
 {
+    if (!twig_test_iterable($array)) {
+        throw new RuntimeError(sprintf('The "filter" filter expects an array or "Traversable", got "%s".', \is_object($array) ? \get_class($array) : \gettype($array)));
+    }
+
     if (\is_array($array)) {
         if (\PHP_VERSION_ID >= 50600) {
             return array_filter($array, $arrow, \ARRAY_FILTER_USE_BOTH);


### PR DESCRIPTION
In PHP 7.4 passing for example null to |filter generates TypeError. I was unsure how to proceed from there as filter could silently fall back to empty result, but instead I went with throwing RuntimeExceptions to be consistent with |batch and |column.

I got confused in structure of tests here, so if that should have some kind of test please push me in the right direction and I'll gladly add it.