### PR TITLE
Drop PHP 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
 
 env:
     global:
-        - TWIG_EXT=no
         - SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1
         - SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE=1
 
@@ -21,21 +20,11 @@ before_install:
 install:
     - travis_retry composer install
 
-before_script:
-    - if [ "$TWIG_EXT" == "yes" ]; then sh -c "cd ext/twig && phpize && ./configure --enable-twig && make && make install"; fi
-    - if [ "$TWIG_EXT" == "yes" ]; then echo "extension=twig.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
-
 script: ./vendor/bin/simple-phpunit
 
 jobs:
     fast_finish: true
     include:
-        - php: 5.5
-        - php: 5.5
-          env: TWIG_EXT=yes
-        - php: 5.6
-        - php: 5.6
-          env: TWIG_EXT=yes
         - php: 7.0
         - php: 7.1
         - php: 7.2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
-# 1.42.6 (2020-XX-XX)
+# 1.43.0 (2020-XX-XX)
 
+ * Drop PHP 5.5 and 5.6 support
  * Fix ambiguous syntax parsing
 
 # 1.42.5 (2020-02-11)

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.0",
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.42-dev"
+            "dev-master": "1.43-dev"
         }
     }
 }

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -41,11 +41,11 @@ use Twig\TokenParser\TokenParserInterface;
  */
 class Environment
 {
-    const VERSION = '1.42.6-DEV';
-    const VERSION_ID = 14206;
+    const VERSION = '1.43.0-DEV';
+    const VERSION_ID = 14300;
     const MAJOR_VERSION = 1;
-    const MINOR_VERSION = 42;
-    const RELEASE_VERSION = 6;
+    const MINOR_VERSION = 43;
+    const RELEASE_VERSION = 0;
     const EXTRA_VERSION = 'DEV';
 
     protected $charset;


### PR DESCRIPTION
PHP 5.6 has been unsopported for 2.5 years now and bumping min version to 7.0 will ease supporting PHP 8.0.
