### PR TITLE
Remove deprecated option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 
 dist: xenial
 
-sudo: false
-
 cache:
     directories:
         - vendor


### PR DESCRIPTION
See: https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments

> If you’re trying to use sudo: false or dist: precise keys in your travis.yml, we recommend you remove them and switch to our current Xenial Linux infrastructure.