### PR TITLE
Improve batch code example

### DIFF
--- a/doc/filters/batch.rst
+++ b/doc/filters/batch.rst
@@ -10,7 +10,7 @@ missing items:
 
 .. code-block:: twig
 
-    {% set items = ['a', 'b', 'c', 'd', 'e', 'f', 'g'] %}
+    {% set items = ['a', 'b', 'c', 'd'] %}
 
     <table>
     {% for row in items|batch(3, 'No item') %}
@@ -34,11 +34,6 @@ The above example will be rendered as:
         </tr>
         <tr>
             <td>d</td>
-            <td>e</td>
-            <td>f</td>
-        </tr>
-        <tr>
-            <td>g</td>
             <td>No item</td>
             <td>No item</td>
         </tr>


### PR DESCRIPTION
The current example uses an array of 7 items, resulting in 3 arrays of 3 items each (with fill). 

This can be misinterpreted at a glance as creating n arrays as opposed to arrays with n items.

We should therefore instead use an example array of 4 items resulting in 2 arrays of 3 items each (with fill). 

I think this would make the functionality less ambiguous.