### PR TITLE
[Documentation] Fix url_encode missing func call

### DIFF
--- a/doc/filters/url_encode.rst
+++ b/doc/filters/url_encode.rst
@@ -17,6 +17,7 @@ or an array as query string:
 
 .. note::
 
-    Internally, Twig uses the PHP ``rawurlencode``.
+    Internally, Twig uses the PHP `rawurlencode`_ or the `http_build_query`_ function.
 
 .. _`rawurlencode`: https://secure.php.net/rawurlencode
+.. _`http_build_query`: https://secure.php.net/http_build_query


### PR DESCRIPTION
Hi,

On [`url_encode` documentation](https://twig.symfony.com/doc/3.x/filters/url_encode.html) there is a missing function.

As you can see in https://github.com/twigphp/Twig/blob/3.x/src/Extension/CoreExtension.php#L578-L585, we use `http_build_query` when the input is an array.

This PR adds this missing function call for `2.x` branch (`1.x` is ok, this issue is on `2.x` and `3.x`)