### PR TITLE
Fix the compilation of Twig comparison operators

### DIFF
--- a/src/Node/Expression/Binary/EqualBinary.php
+++ b/src/Node/Expression/Binary/EqualBinary.php
@@ -24,11 +24,11 @@ class EqualBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('0 === twig_compare(')
+            ->raw('(0 === twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))
-            ->raw(')')
+            ->raw('))')
         ;
     }
 

--- a/src/Node/Expression/Binary/GreaterBinary.php
+++ b/src/Node/Expression/Binary/GreaterBinary.php
@@ -24,11 +24,11 @@ class GreaterBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('1 === twig_compare(')
+            ->raw('(1 === twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))
-            ->raw(')')
+            ->raw('))')
         ;
     }
 

--- a/src/Node/Expression/Binary/GreaterEqualBinary.php
+++ b/src/Node/Expression/Binary/GreaterEqualBinary.php
@@ -24,11 +24,11 @@ class GreaterEqualBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('0 <= twig_compare(')
+            ->raw('(0 <= twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))
-            ->raw(')')
+            ->raw('))')
         ;
     }
 

--- a/src/Node/Expression/Binary/LessBinary.php
+++ b/src/Node/Expression/Binary/LessBinary.php
@@ -24,11 +24,11 @@ class LessBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('-1 === twig_compare(')
+            ->raw('(-1 === twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))
-            ->raw(')')
+            ->raw('))')
         ;
     }
 

--- a/src/Node/Expression/Binary/LessEqualBinary.php
+++ b/src/Node/Expression/Binary/LessEqualBinary.php
@@ -24,11 +24,11 @@ class LessEqualBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('0 >= twig_compare(')
+            ->raw('(0 >= twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))
-            ->raw(')')
+            ->raw('))')
         ;
     }
 

--- a/src/Node/Expression/Binary/NotEqualBinary.php
+++ b/src/Node/Expression/Binary/NotEqualBinary.php
@@ -24,11 +24,11 @@ class NotEqualBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('0 !== twig_compare(')
+            ->raw('(0 !== twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))
-            ->raw(')')
+            ->raw('))')
         ;
     }
 

--- a/tests/Fixtures/expressions/comparison_precedence.test
+++ b/tests/Fixtures/expressions/comparison_precedence.test
@@ -1,0 +1,14 @@
+--TEST--
+Twig comparison operators precendence
+--TEMPLATE--
+{{ not(1 > 2) }}/{{ not(1 > 1) }}/{{ not(1 >= 2) }}/{{ not(1 >= 1) }}
+{{ not(1 < 2) }}/{{ not(1 < 1) }}/{{ not(1 <= 2) }}/{{ not(1 <= 1) }}
+{{ not(1 == 1) }}/{{ not(1 == 2) }}
+{{ not(1 != 1) }}/{{ not(1 != 2) }}
+--DATA--
+return []
+--EXPECT--
+1/1/1/
+/1//
+/1
+1/


### PR DESCRIPTION
The new compilation implemented in Twig 3 for PHP 7 (to match the comparison semantic of PHP 8) was missing the surrounding braces (which are part of the AsbtractBinary compilation). This caused issues when the full expression would involve other operators (like the not operator), as things would then rely on having the correct precedence in PHP (which would not be the case).

Closes #3318 