### PR TITLE
Allow trailing commas in macros + functions + filters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 # 1.43.1 (2020-XX-XX)
 
- * n/a
+ * Allow trailing commas in argument lists (in calls as well as definitions)
 
 # 1.43.0 (2020-07-05)
 

--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -598,6 +598,11 @@ class ExpressionParser
         while (!$stream->test(Token::PUNCTUATION_TYPE, ')')) {
             if (!empty($args)) {
                 $stream->expect(Token::PUNCTUATION_TYPE, ',', 'Arguments must be separated by a comma');
+
+                // if the comma above was a trailing comma, early exit the argument parse loop
+                if ($stream->test(/* Token::PUNCTUATION_TYPE */ 9, ')')) {
+                    break;
+                }
             }
 
             if ($definition) {

--- a/tests/Fixtures/filters/trailing_commas.test
+++ b/tests/Fixtures/filters/trailing_commas.test
@@ -1,0 +1,8 @@
+--TEST--
+filters allow trailing commas in their argument list
+--TEMPLATE--
+{{ 42.55|round(1, 'floor',) }}
+--DATA--
+return []
+--EXPECT--
+42.5

--- a/tests/Fixtures/functions/trailing_commas.test
+++ b/tests/Fixtures/functions/trailing_commas.test
@@ -1,0 +1,8 @@
+--TEST--
+functions allow trailing commas in their argument list
+--TEMPLATE--
+{{ max(1, 2, 3,) }}
+--DATA--
+return []
+--EXPECT--
+3

--- a/tests/Fixtures/macros/trailing_commas.test
+++ b/tests/Fixtures/macros/trailing_commas.test
@@ -1,0 +1,25 @@
+--TEST--
+macros allow trailing commas in their argument and parameter list
+--TEMPLATE--
+{% import _self as test %}
+
+{% macro test(a, b,) -%}
+    {{ a|default('a') }}<br />
+    {{- b|default('b') }}<br />
+{%- endmacro %}
+{% macro test2(a, b) -%}
+    {{ a|default('a') }}<br />
+    {{- b|default('b') }}<br />
+{%- endmacro %}
+
+{{ test.test(1, 2,) }}
+{{ test.test(3, 4) }}
+{{ test.test2(5, 6,) }}
+{{ test.test2(7, 8) }}
+--DATA--
+return []
+--EXPECT--
+1<br />2<br />
+3<br />4<br />
+5<br />6<br />
+7<br />8<br />


### PR DESCRIPTION
I implemented support for trailing commas in

- function calls
- filter arguments
- macro parameters + arguments (so call + definition)

Lists + maps are already supported https://twigfiddle.com/6atiz3

Is something missing?