### PR TITLE
Unify code style

### DIFF
--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -600,7 +600,7 @@ class ExpressionParser
                 $stream->expect(Token::PUNCTUATION_TYPE, ',', 'Arguments must be separated by a comma');
 
                 // if the comma above was a trailing comma, early exit the argument parse loop
-                if ($stream->test(/* Token::PUNCTUATION_TYPE */ 9, ')')) {
+                if ($stream->test(Token::PUNCTUATION_TYPE, ')')) {
                     break;
                 }
             }


### PR DESCRIPTION
I noticed that the code style in `ExpressionParser` changed from v1 to v3. So this PR now fixes it, that the file in v1 looks more clean.

@fabpot this is a small addendum to #3363