### PR TITLE
Return the object property that is actually accessible.

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1450,7 +1450,10 @@ function twig_get_attribute(Environment $env, Source $source, $object, $item, ar
                 $env->getExtension(SandboxExtension::class)->checkPropertyAllowed($object, $item, $lineno, $source);
             }
 
-            return $object->$item;
+            if (isset($object->$item)) {
+                return $object->$item;
+            }
+            return ((array) $object)[(string) $item];
         }
     }
 


### PR DESCRIPTION
Since there is a check for two types of property, we should also return the one we found.

Without this, cases where a property is accessed that exists in the cast of the object, but not directly, will not be available and will throw notices and end up with NULL.

We noticed this in our project because of using a DateTimeInterface's date property (which I wouldn't recommend, but still). The if check will respond `true` because if you cast a DateTimeImmutable to an array it has a  'date' key, but trying to access it directly does not actually work (at least not in PHP 7.4. It apparently worked before as the code had been running fine before we upgraded.)

My proposed change should work in all situations.