### PR TITLE
Macro not available in embed tags

### DIFF
--- a/doc/tags/macro.rst
+++ b/doc/tags/macro.rst
@@ -130,6 +130,9 @@ macros are available in all blocks and other macros defined in the current
 template, but they are not available in included templates or child templates;
 you need to explicitly re-import macros in each template.
 
+Imported macros are not available in the body of the ``embed`` tag. you need
+to explicitly re-import macros inside the tag.
+
 When calling ``import`` or ``from`` from a ``block`` tag, the imported macros
 are only defined in the current block and they override macros defined at the
 template level with the same names.


### PR DESCRIPTION
Macro imported globally in a template via `import` or `from` are not available inside `embed` tags.
This behavior is present since Twig v2.0.0. I think it needs to be documented. Feel free to suggest an other text.

Here is some example : 

- If the macro is imported globally, it's not available inside the `embed` tag, we get an error : https://twigfiddle.com/jwtwm3
```twig
{% import 'macro.twig' as macro %}
{% embed 'embed.twig' %}
    {% block content %}
        {{ macro.sayhello('Jérôme') }}
    {% endblock %}
{% endembed %}
```
- Whereas is the macro is imported inside the `embed` tag, it's available in its `block` tags : https://twigfiddle.com/jwtwm3/2
```twig
{% embed 'embed.twig' %}
    {% import 'macro.twig' as macro %}
    {% block content %}
        {{ macro.sayhello('Jérôme') }}
    {% endblock %}
{% endembed %}
```