### PR TITLE
Update .gitattributes file with more export-ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
-/extra/** export-ignore
-/tests export-ignore
-/phpunit.xml.dist export-ignore
+.editorconfig    export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+.php_cs.dist     export-ignore
+.travis.yml      export-ignore
+phpunit.xml.dist export-ignore
+/doc             export-ignore
+/extra           export-ignore
+/tests           export-ignore


### PR DESCRIPTION
Added more `.gitattributes` `export-ignore` rules to ignore the remaining build files such as Travis CI configuration file, PHP CS, etc. 

It also adds `./doc` directory to ignore, which might been seen negative. I think `prefer-dist` consumables should be as small as possible, and anyone who wants to read the docs will be referring to the git repository, or use a `prefer-source`, which includes everything from test files to docs.

Thank you.