### PR TITLE
Replace implicit dependence on ext/iconv in JS escaper

### DIFF
--- a/src/Extension/EscaperExtension.php
+++ b/src/Extension/EscaperExtension.php
@@ -282,15 +282,18 @@ function twig_escape_filter(Environment $env, $string, $strategy = 'html', $char
                     return $shortMap[$char];
                 }
 
-                // \uHHHH
-                $char = twig_convert_encoding($char, 'UTF-16BE', 'UTF-8');
-                $char = strtoupper(bin2hex($char));
-
-                if (4 >= \strlen($char)) {
-                    return sprintf('\u%04s', $char);
+                $codepoint = mb_ord($char);
+                if (0x10000 > $codepoint) {
+                    return sprintf('\u%04X', $codepoint);
                 }
 
-                return sprintf('\u%04s\u%04s', substr($char, 0, -4), substr($char, -4));
+                // Split characters outside the BMP into surrogate pairs
+                // https://tools.ietf.org/html/rfc2781.html#section-2.1
+                $u    = $codepoint - 0x10000;
+                $high = 0xD800 | ($u >> 10);
+                $low  = 0xDC00 | ($u & 0x3FF);
+
+                return sprintf('\u%04X\u%04X', $high, $low);
             }, $string);
 
             if ('UTF-8' !== $charset) {


### PR DESCRIPTION
Twig's JS escaper fails on non-word characters if `ext/iconv` isn't available. That's because it uses iconv to replace characters with their hex codepoints and split characters outside the Basic Multilingual Plane into surrogate pairs. `symfony/polyfill-iconv` does not support the UTF-16BE conversion and cannot be used as a replacement.

This PR splits the surrogates using native PHP, after obtaining the codepoint via `mb_ord()` which is provided either natively or via `symfony/polyfill-mbstring`, which is already part of Twig's requirements.