### PR TITLE
Fix missing delimiter for preg_quote in lexer

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -117,7 +117,7 @@ class Lexer implements \Twig_LexerInterface
             // #}
             'lex_comment' => '{
                 (?:'.
-                    preg_quote($this->options['whitespace_trim']).preg_quote($this->options['tag_comment'][1], '#').'\s*\n?'. // -#}\s*\n?
+                    preg_quote($this->options['whitespace_trim'].$this->options['tag_comment'][1], '#').'\s*\n?'. // -#}\s*\n?
                     '|'.
                     preg_quote($this->options['whitespace_line_trim'].$this->options['tag_comment'][1], '#').'['.$this->options['whitespace_line_chars'].']*'. // ~#}[ \t\0\x0B]*
                     '|'.


### PR DESCRIPTION
It is a really edge case (PHP < 7.3 and '#' as whitespace_trim symbol), but for the sake of consistency here's a proper fix.