### PR TITLE
Update u.rst

### DIFF
--- a/doc/filters/u.rst
+++ b/doc/filters/u.rst
@@ -27,6 +27,9 @@ Truncating a string:
 
     {{ 'Lorem ipsum'|u.truncate(8, '...') }}
     Lorem...
+    
+    {{ 'Lorem ipsum'|u.truncate(8, '...', false) }}
+    Lorem ipsum...
 
 Converting a string to *snake* case or *camelCase*:
 


### PR DESCRIPTION
Explained the third argument of the truncate filter (the last word before the cut is kept even if that generates a string longer than the desired length)