### PR TITLE
Add the ability to search attributes deeply.

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1354,9 +1354,9 @@ function twig_array_batch($items, $size, $fill = null, $preserveKeys = true)
 
     return $result;
 }
-
+    
 /**
- * Returns the attribute value for a given array/object.
+ * Returns the deeper attribute value for a given array/object.
  *
  * @param mixed  $object            The object or array from where to get the item
  * @param mixed  $item              The item to get from the array or object
@@ -1372,8 +1372,25 @@ function twig_array_batch($items, $size, $fill = null, $preserveKeys = true)
  *
  * @internal
  */
-function twig_get_attribute(Environment $env, Source $source, $object, $item, array $arguments = [], $type = /* Template::ANY_CALL */ 'any', $isDefinedTest = false, $ignoreStrictCheck = false, $sandboxed = false, int $lineno = -1)
+function twig_get_attribute(Environment $env, Source $source, $object, $item, array $arguments = [], $type = /* Template::ANY_CALL */ 'any', $isDefinedTest = false, $ignoreStrictCheck = false, $sandboxed = false, int $lineno = -1, bool $deepSearch = true)
 {
+    // deep attribute
+    list($item, $deepItem) = array_merge($deepSearch ? explode(".", $item, 2) : [$item], [null]);
+    if((bool) $deepItem) {
+        return twig_get_attribute(
+            $env,
+            $source,
+            twig_get_attribute($env, $source, $object, $item, $arguments, $type, $isDefinedTest, $ignoreStrictCheck, $sandboxed, $lineno),
+            $deepItem,
+            $arguments,
+            $type,
+            $isDefinedTest,
+            $ignoreStrictCheck,
+            $sandboxed,
+            $lineno
+        );
+    }
+    
     // array
     if (/* Template::METHOD_CALL */ 'method' !== $type) {
         $arrayItem = \is_bool($item) || \is_float($item) ? (int) $item : $item;

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1376,7 +1376,7 @@ function twig_get_attribute(Environment $env, Source $source, $object, $item, ar
 {
     // deep attribute
     if(\is_string($item)) {
-        list($item, $deepItem) = \array_merge($deepSearch ? \explode("->", $item, 2) : [$item], [null]);
+        list($item, $deepItem) = \array_merge(\explode("->", $item, 2), [null]);
         if((bool) $deepItem) {
             return twig_get_attribute(
                 $env,

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1372,24 +1372,25 @@ function twig_array_batch($items, $size, $fill = null, $preserveKeys = true)
  *
  * @internal
  */
-function twig_get_attribute(Environment $env, Source $source, $object, $item, array $arguments = [], $type = /* Template::ANY_CALL */ 'any', $isDefinedTest = false, $ignoreStrictCheck = false, $sandboxed = false, int $lineno = -1, bool $deepSearch = true)
+function twig_get_attribute(Environment $env, Source $source, $object, $item, array $arguments = [], $type = /* Template::ANY_CALL */ 'any', $isDefinedTest = false, $ignoreStrictCheck = false, $sandboxed = false, int $lineno = -1)
 {
     // deep attribute
-    list($item, $deepItem) = array_merge($deepSearch ? explode("->", $item, 2) : [$item], [null]);
-    if((bool) $deepItem) {
-        return twig_get_attribute(
-            $env,
-            $source,
-            twig_get_attribute($env, $source, $object, $item, $arguments, $type, $isDefinedTest, $ignoreStrictCheck, $sandboxed, $lineno, $deepSearch),
-            $deepItem,
-            $arguments,
-            $type,
-            $isDefinedTest,
-            $ignoreStrictCheck,
-            $sandboxed,
-            $lineno,
-            $deepSearch
-        );
+    if(\is_string($item)) {
+        list($item, $deepItem) = \array_merge($deepSearch ? \explode("->", $item, 2) : [$item], [null]);
+        if((bool) $deepItem) {
+            return twig_get_attribute(
+                $env,
+                $source,
+                twig_get_attribute($env, $source, $object, $item, $arguments, $type, $isDefinedTest, $ignoreStrictCheck, $sandboxed, $lineno),
+                $deepItem,
+                $arguments,
+                $type,
+                $isDefinedTest,
+                $ignoreStrictCheck,
+                $sandboxed,
+                $lineno
+            );
+        }
     }
     
     // array

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1380,14 +1380,15 @@ function twig_get_attribute(Environment $env, Source $source, $object, $item, ar
         return twig_get_attribute(
             $env,
             $source,
-            twig_get_attribute($env, $source, $object, $item, $arguments, $type, $isDefinedTest, $ignoreStrictCheck, $sandboxed, $lineno),
+            twig_get_attribute($env, $source, $object, $item, $arguments, $type, $isDefinedTest, $ignoreStrictCheck, $sandboxed, $lineno, $deepSearch),
             $deepItem,
             $arguments,
             $type,
             $isDefinedTest,
             $ignoreStrictCheck,
             $sandboxed,
-            $lineno
+            $lineno,
+            $deepSearch
         );
     }
     

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1375,7 +1375,7 @@ function twig_array_batch($items, $size, $fill = null, $preserveKeys = true)
 function twig_get_attribute(Environment $env, Source $source, $object, $item, array $arguments = [], $type = /* Template::ANY_CALL */ 'any', $isDefinedTest = false, $ignoreStrictCheck = false, $sandboxed = false, int $lineno = -1, bool $deepSearch = true)
 {
     // deep attribute
-    list($item, $deepItem) = array_merge($deepSearch ? explode(".", $item, 2) : [$item], [null]);
+    list($item, $deepItem) = array_merge($deepSearch ? explode("->", $item, 2) : [$item], [null]);
     if((bool) $deepItem) {
         return twig_get_attribute(
             $env,

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1376,7 +1376,7 @@ function twig_get_attribute(Environment $env, Source $source, $object, $item, ar
 {
     // deep attribute
     if(\is_string($item)) {
-        \list($item, $deepItem) = \array_merge(\explode("->", $item, 2), [null]);
+        list($item, $deepItem) = \array_merge(\explode("->", $item, 2), [null]);
         if((bool) $deepItem) {
             return twig_get_attribute(
                 $env,

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1376,7 +1376,7 @@ function twig_get_attribute(Environment $env, Source $source, $object, $item, ar
 {
     // deep attribute
     if(\is_string($item)) {
-        list($item, $deepItem) = \array_merge(\explode("->", $item, 2), [null]);
+        \list($item, $deepItem) = \array_merge(\explode("->", $item, 2), [null]);
         if((bool) $deepItem) {
             return twig_get_attribute(
                 $env,

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -163,7 +163,7 @@ class TemplateTest extends TestCase
         $twig = new Environment($this->createMock(LoaderInterface::class));
         $template = new TemplateForTest($twig);
 
-        $array = ['Zero', 'One', -1 => 'MinusOne', '' => 'EmptyString', '1.5' => 'FloatButString', '01' => 'IntegerButStringWithLeadingZeros'];
+        $array = ['Zero', 'One', -1 => 'MinusOne', '' => 'EmptyString', '1.5' => 'FloatButString', '01' => 'IntegerButStringWithLeadingZeros', 'I' => ['am' => ['going' => ['deep' => 'deep-node']]];
 
         $this->assertSame('Zero', $array[false]);
         $this->assertSame('One', $array[true]);
@@ -182,6 +182,7 @@ class TemplateTest extends TestCase
         $this->assertSame('FloatButString', twig_get_attribute($twig, $template->getSourceContext(), $array, '1.5'), '"1.5" is treated as-is when accessing an array (equals PHP behavior)');
         $this->assertSame('IntegerButStringWithLeadingZeros', twig_get_attribute($twig, $template->getSourceContext(), $array, '01'), '"01" is treated as-is when accessing an array (equals PHP behavior)');
         $this->assertSame('EmptyString', twig_get_attribute($twig, $template->getSourceContext(), $array, null), 'null is treated as "" when accessing an array (equals PHP behavior)');
+        $this->assertSame('deep-node', twig_get_attribute($twig, $template->getSourceContext(), $array, 'I->am->going->deep'), 'null is treated as "" when accessing an array (equals PHP behavior)');
     }
 
     /**

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -163,7 +163,7 @@ class TemplateTest extends TestCase
         $twig = new Environment($this->createMock(LoaderInterface::class));
         $template = new TemplateForTest($twig);
 
-        $array = ['Zero', 'One', -1 => 'MinusOne', '' => 'EmptyString', '1.5' => 'FloatButString', '01' => 'IntegerButStringWithLeadingZeros', 'I' => ['am' => ['going' => ['deep' => 'deep-node']]];
+        $array = ['Zero', 'One', -1 => 'MinusOne', '' => 'EmptyString', '1.5' => 'FloatButString', '01' => 'IntegerButStringWithLeadingZeros', 'I' => ['am' => ['going' => ['deep' => 'deep-node']]]];
 
         $this->assertSame('Zero', $array[false]);
         $this->assertSame('One', $array[true]);
@@ -182,7 +182,7 @@ class TemplateTest extends TestCase
         $this->assertSame('FloatButString', twig_get_attribute($twig, $template->getSourceContext(), $array, '1.5'), '"1.5" is treated as-is when accessing an array (equals PHP behavior)');
         $this->assertSame('IntegerButStringWithLeadingZeros', twig_get_attribute($twig, $template->getSourceContext(), $array, '01'), '"01" is treated as-is when accessing an array (equals PHP behavior)');
         $this->assertSame('EmptyString', twig_get_attribute($twig, $template->getSourceContext(), $array, null), 'null is treated as "" when accessing an array (equals PHP behavior)');
-        $this->assertSame('deep-node', twig_get_attribute($twig, $template->getSourceContext(), $array, 'I->am->going->deep'), 'null is treated as "" when accessing an array (equals PHP behavior)');
+        $this->assertSame('deep-node', twig_get_attribute($twig, $template->getSourceContext(), $array, 'I->am->going->deep'));
     }
 
     /**


### PR DESCRIPTION
The new feature was set as as default `true`, this could cause problems if someone is trying to search the `index` `"foo.bar"` in an array for example.

#3416