### PR TITLE
[intl-extra] Add test showing currency behaviour

### DIFF
--- a/extra/intl-extra/src/IntlExtension.php
+++ b/extra/intl-extra/src/IntlExtension.php
@@ -409,11 +409,15 @@ final class IntlExtension extends AbstractExtension
         }
 
         foreach ($textAttrs as $name => $value) {
-            $this->numberFormatters[$hash]->setTextAttribute(self::NUMBER_TEXT_ATTRIBUTES[$name], $value);
+            if (false === strpos($value, '¤')) {
+                $this->numberFormatters[$hash]->setTextAttribute(self::NUMBER_TEXT_ATTRIBUTES[$name], $value);
+            }
         }
 
         foreach ($symbols as $name => $value) {
-            $this->numberFormatters[$hash]->setSymbol(self::NUMBER_SYMBOLS[$name], $value);
+            if (false === strpos($value, '¤')) {
+                $this->numberFormatters[$hash]->setSymbol(self::NUMBER_SYMBOLS[$name], $value);
+            }
         }
 
         return $this->numberFormatters[$hash];

--- a/extra/intl-extra/tests/IntlExtensionTest.php
+++ b/extra/intl-extra/tests/IntlExtensionTest.php
@@ -29,19 +29,28 @@ class IntlExtensionTest extends TestCase
     /**
      * @dataProvider getCurrencyData
      */
-    public function testFormatterProtoWithCurrency(string $locale, string $expectedCurrency)
+    public function testFormatterProtoWithCurrency(string $locale, string $currency, string $expectedCurrency)
     {
         $numberFormatterProto = new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
         $numberFormatterProto->setAttribute(\NumberFormatter::FRACTION_DIGITS, 1);
         $ext = new IntlExtension(null, $numberFormatterProto);
-        $this->assertSame($expectedCurrency, $ext->formatCurrency('12.3456', 'EUR'));
+        $this->assertSame($expectedCurrency, $this->fixSpace($ext->formatCurrency('12.3456', $currency, [], $locale)));
     }
 
     public function getCurrencyData()
     {
         return [
-            ['en', '€12.3'],
-            ['fr', '12,3 €'],
+            ['en', 'EUR', '€12.3'],
+            ['fr', 'EUR', '12,3 €'],
+            ['jp', 'YEN', 'YEN 12.3'],
         ];
+    }
+
+    private function fixSpace(string $string): string
+    {
+        $string = mb_convert_encoding($string, 'HTML-ENTITIES', 'UTF-8');
+        $stringWithoutSpaces = str_replace('&nbsp;', ' ', $string);
+
+        return html_entity_decode($stringWithoutSpaces);
     }
 }

--- a/extra/intl-extra/tests/IntlExtensionTest.php
+++ b/extra/intl-extra/tests/IntlExtensionTest.php
@@ -25,4 +25,23 @@ class IntlExtensionTest extends TestCase
         $ext = new IntlExtension($dateFormatterProto, $numberFormatterProto);
         $this->assertSame('++12,3', $ext->formatNumber('12.3456'));
     }
+
+    /**
+     * @dataProvider getCurrencyData
+     */
+    public function testFormatterProtoWithCurrency(string $locale, string $expectedCurrency)
+    {
+        $numberFormatterProto = new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
+        $numberFormatterProto->setAttribute(\NumberFormatter::FRACTION_DIGITS, 1);
+        $ext = new IntlExtension(null, $numberFormatterProto);
+        $this->assertSame($expectedCurrency, $ext->formatCurrency('12.3456', 'EUR'));
+    }
+
+    public function getCurrencyData()
+    {
+        return [
+            ['en', '€12.3'],
+            ['fr', '12,3 €'],
+        ];
+    }
 }


### PR DESCRIPTION
This is just to show some weird behaviour that I have no idea how to fix it.

What I've found so far is that the problem seems to occur when the currency symbol `¤` is involved in the text attributes:

https://github.com/twigphp/Twig/blob/e3bca056f1331cf017893c2248d1d4951c165162/extra/intl-extra/src/IntlExtension.php#L411-L413

When `numberFormatterProto` is created with `en` locale these are its properties before (in red) and after (in green) going through the `IntlExtension`:
```diff
2,3c2,3
<   locale: "en"
<   pattern: "¤#,##0.0"
---
>   locale: "en_US"
>   pattern: "'¤'#,##0.0;'-¤'#,##0.0"
18c18
<     FORMAT_WIDTH: false
---
>     FORMAT_WIDTH: 0
```
In case of `fr` locale are these:

```diff
2,3c2,3
<   locale: "fr"
<   pattern: "#,##0.0 ¤"
---
>   locale: "en_US"
>   pattern: "#,##0.0 '¤';'-'#,##0.0 '¤'"
18c18
<     FORMAT_WIDTH: false
---
>     FORMAT_WIDTH: 0
```

Looks like it escapes the symbol and does not change it to the local currency.

And this is the PHPUnit output:

```
Testing Twig\Extra\Intl\Tests\IntlExtensionTest
FF                                                                  2 / 2 (100%)

Time: 121 ms, Memory: 6.00 MB

There were 2 failures:

1) Twig\Extra\Intl\Tests\IntlExtensionTest::testFormatterProtoWithCurrency with data set #0 ('en', '€12.3')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'€12.3'
+'¤12.3'

/intl-extra/tests/IntlExtensionTest.php:37

2) Twig\Extra\Intl\Tests\IntlExtensionTest::testFormatterProtoWithCurrency with data set #1 ('fr', '12,3 €')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'12,3 €'
+'12,3 ¤'

/intl-extra/tests/IntlExtensionTest.php:37

FAILURES!
Tests: 2, Assertions: 2, Failures: 2.
```