### PR TITLE
Twig extra bundle now requires twig 3.2

### DIFF
--- a/extra/twig-extra-bundle/composer.json
+++ b/extra/twig-extra-bundle/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1.3|^8.0",
         "symfony/framework-bundle": "^4.3|^5.0",
         "symfony/twig-bundle": "^4.3|^5.0",
-        "twig/twig": "^2.4|^3.0"
+        "twig/twig": "^3.2"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.4.9|^5.0.9",


### PR DESCRIPTION
Updated requirements of composer.json in twig/extra/twig-extra-bundle: 

Due to the addition of `registerUndefinedTokenParserCallback ` in the file `Twig/extra/twig-extra-bundle/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php`, version 3.2 of twig/twig is also required. 
With older versions of twig/twig installed, an error is thrown: 
```
 Attempted to call an undefined method named "registerUndefinedTokenParserCallback" of class "Twig\Environment".                                         
Did you mean to call e.g. "registerUndefinedFilterCallback" or "registerUndefinedFunctionCallback"?      
```                                               