### PR TITLE
Adding link to the SymfonyCasts Twig tutorial

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -23,6 +23,10 @@ Twig is used by many Open-Source projects like Symfony, Drupal8, eZPublish,
 phpBB, Matomo, OroCRM; and many frameworks have support for it as well like
 Slim, Yii, Laravel, and Codeigniter — just to name a few.
 
+.. admonition:: Screencast
+
+    Like to learn from video tutorials? Check out the `SymfonyCasts Twig Tutorial`_!
+
 Prerequisites
 -------------
 
@@ -72,3 +76,5 @@ filesystem loader::
     ]);
 
     echo $twig->render('index.html', ['name' => 'Fabien']);
+
+.. _`SymfonyCasts Twig Tutorial`: https://symfonycasts.com/screencast/twig


### PR DESCRIPTION
Hi!

We have (and have had) for a long time, a really nice Twig screencast on SymfonyCasts with interactive coding challenges so people can play with Twig. I thought a link from Twig's docs might be useful :). I was also thinking a link from https://twig.symfony.com/doc/3.x/ might make sense, but I think this isn't modifiable directly via the docs (but tell me if I'm wrong).

Here's the "look":

<img width="776" alt="Screen Shot 2021-01-13 at 1 07 40 PM" src="https://user-images.githubusercontent.com/121003/104491678-93ef6480-55a0-11eb-9dce-db24c0748267.png">

Thanks!