### PR TITLE
Template Wrapper Interface

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -266,7 +266,7 @@ class Environment
     /**
      * Renders a template.
      *
-     * @param string|TemplateWrapper $name The template name
+     * @param string|TemplateWrapperInterface $name The template name
      *
      * @throws LoaderError  When the template cannot be found
      * @throws SyntaxError  When an error occurred during compilation
@@ -280,7 +280,7 @@ class Environment
     /**
      * Displays a template.
      *
-     * @param string|TemplateWrapper $name The template name
+     * @param string|TemplateWrapperInterface $name The template name
      *
      * @throws LoaderError  When the template cannot be found
      * @throws SyntaxError  When an error occurred during compilation
@@ -294,15 +294,15 @@ class Environment
     /**
      * Loads a template.
      *
-     * @param string|TemplateWrapper $name The template name
+     * @param string|TemplateWrapperInterface $name The template name
      *
      * @throws LoaderError  When the template cannot be found
      * @throws RuntimeError When a previously generated cache is corrupted
      * @throws SyntaxError  When an error occurred during compilation
      */
-    public function load($name): TemplateWrapper
+    public function load($name): TemplateWrapperInterface
     {
-        if ($name instanceof TemplateWrapper) {
+        if ($name instanceof TemplateWrapperInterface) {
             return $name;
         }
 
@@ -380,7 +380,7 @@ class Environment
      * @throws LoaderError When the template cannot be found
      * @throws SyntaxError When an error occurred during compilation
      */
-    public function createTemplate(string $template, string $name = null): TemplateWrapper
+    public function createTemplate(string $template, string $name = null): TemplateWrapperInterface
     {
         $hash = hash('sha256', $template, false);
         if (null !== $name) {
@@ -422,12 +422,12 @@ class Environment
      * Similar to load() but it also accepts instances of \Twig\Template and
      * \Twig\TemplateWrapper, and an array of templates where each is tried to be loaded.
      *
-     * @param string|TemplateWrapper|array $names A template or an array of templates to try consecutively
+     * @param string|TemplateWrapperInterface|array $names A template or an array of templates to try consecutively
      *
      * @throws LoaderError When none of the templates can be found
      * @throws SyntaxError When an error occurred during compilation
      */
-    public function resolveTemplate($names): TemplateWrapper
+    public function resolveTemplate($names): TemplateWrapperInterface
     {
         if (!\is_array($names)) {
             return $this->load($names);

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -311,7 +311,7 @@ namespace {
     use Twig\Markup;
     use Twig\Source;
     use Twig\Template;
-    use Twig\TemplateWrapper;
+    use Twig\TemplateWrapperInterface;
 
 /**
  * Cycles over a value.
@@ -1246,7 +1246,7 @@ function twig_include(Environment $env, $context, $template, $variables = [], $w
 
         foreach ((\is_array($template) ? $template : [$template]) as $name) {
             // if a Template instance is passed, it might have been instantiated outside of a sandbox, check security
-            if ($name instanceof TemplateWrapper || $name instanceof Template) {
+            if ($name instanceof TemplateWrapperInterface || $name instanceof Template) {
                 $name->unwrap()->checkSecurity();
             }
         }

--- a/src/Extension/DebugExtension.php
+++ b/src/Extension/DebugExtension.php
@@ -36,7 +36,7 @@ final class DebugExtension extends AbstractExtension
 namespace {
 use Twig\Environment;
 use Twig\Template;
-use Twig\TemplateWrapper;
+use Twig\TemplateWrapperInterface;
 
 function twig_var_dump(Environment $env, $context, ...$vars)
 {
@@ -49,7 +49,7 @@ function twig_var_dump(Environment $env, $context, ...$vars)
     if (!$vars) {
         $vars = [];
         foreach ($context as $key => $value) {
-            if (!$value instanceof Template && !$value instanceof TemplateWrapper) {
+            if (!$value instanceof Template && !$value instanceof TemplateWrapperInterface) {
                 $vars[$key] = $value;
             }
         }

--- a/src/Extension/StringLoaderExtension.php
+++ b/src/Extension/StringLoaderExtension.php
@@ -25,7 +25,7 @@ final class StringLoaderExtension extends AbstractExtension
 
 namespace {
 use Twig\Environment;
-use Twig\TemplateWrapper;
+use Twig\TemplateWrapperInterface;
 
 /**
  * Loads a template from a string.
@@ -35,7 +35,7 @@ use Twig\TemplateWrapper;
  * @param string $template A template as a string or object implementing __toString()
  * @param string $name     An optional name of the template to be used in error messages
  */
-function twig_template_from_string(Environment $env, $template, string $name = null): TemplateWrapper
+function twig_template_from_string(Environment $env, $template, string $name = null): TemplateWrapperInterface
 {
     return $env->createTemplate((string) $template, $name);
 }

--- a/src/Template.php
+++ b/src/Template.php
@@ -74,7 +74,7 @@ abstract class Template
      * This method is for internal use only and should never be called
      * directly.
      *
-     * @return Template|TemplateWrapper|false The parent template or false if there is no parent
+     * @return Template|TemplateWrapperInterface|false The parent template or false if there is no parent
      */
     public function getParent(array $context)
     {
@@ -89,7 +89,7 @@ abstract class Template
                 return false;
             }
 
-            if ($parent instanceof self || $parent instanceof TemplateWrapper) {
+            if ($parent instanceof self || $parent instanceof TemplateWrapperInterface) {
                 return $this->parents[$parent->getSourceContext()->getName()] = $parent;
             }
 
@@ -297,7 +297,7 @@ abstract class Template
     }
 
     /**
-     * @return Template|TemplateWrapper
+     * @return Template|TemplateWrapperInterface
      */
     protected function loadTemplate($template, $templateName = null, $line = null, $index = null)
     {
@@ -306,7 +306,7 @@ abstract class Template
                 return $this->env->resolveTemplate($template);
             }
 
-            if ($template instanceof self || $template instanceof TemplateWrapper) {
+            if ($template instanceof self || $template instanceof TemplateWrapperInterface) {
                 return $template;
             }
 

--- a/src/TemplateWrapper.php
+++ b/src/TemplateWrapper.php
@@ -16,7 +16,7 @@ namespace Twig;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class TemplateWrapper
+final class TemplateWrapper implements TemplateWrapperInterface
 {
     private $env;
     private $template;

--- a/src/TemplateWrapperInterface.php
+++ b/src/TemplateWrapperInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig;
+
+/**
+ * Exposes a template to userland.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface TemplateWrapperInterface
+{
+    public function render(array $context = []): string;
+
+    public function display(array $context = []);
+
+    public function hasBlock(string $name, array $context = []): bool;
+
+    /**
+     * @return string[] An array of defined template block names
+     */
+    public function getBlockNames(array $context = []): array;
+
+    public function renderBlock(string $name, array $context = []): string;
+
+    public function displayBlock(string $name, array $context = []);
+
+    public function getSourceContext(): Source;
+
+    public function getTemplateName(): string;
+
+    /**
+     * @internal
+     *
+     * @return Template
+     */
+    public function unwrap();
+}


### PR DESCRIPTION
Adds an interface for `TemplateWrapper`, as the public interface for templates, to facilitate mocking.

Currently if mocking `Twig\Environment` the `load` method returns a `TemplateWrapper`, which is `final`. Creating an instance of this object requires mimicking it's internal behaviour, which is not desirable.

Have I missed a more obvious way of doing this? Or is this not intended usage?

Any pointers appreciated, thanks.