### PR TITLE
Add some return types

### DIFF
--- a/src/Markup.php
+++ b/src/Markup.php
@@ -32,6 +32,9 @@ class Markup implements \Countable
         return $this->content;
     }
 
+    /**
+     * @return int
+     */
     public function count()
     {
         return \function_exists('mb_get_info') ? mb_strlen($this->content, $this->charset) : \strlen($this->content);

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -207,11 +207,17 @@ class Node implements \Twig_NodeInterface
         unset($this->nodes[$name]);
     }
 
+    /**
+     * @return int
+     */
     public function count()
     {
         return \count($this->nodes);
     }
 
+    /**
+     * @return \Traversable
+     */
     public function getIterator()
     {
         return new \ArrayIterator($this->nodes);

--- a/src/Profiler/Profile.php
+++ b/src/Profiler/Profile.php
@@ -153,17 +153,17 @@ class Profile implements \IteratorAggregate, \Serializable
         $this->enter();
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->profiles);
     }
 
-    public function serialize()
+    public function serialize(): string
     {
         return serialize($this->__serialize());
     }
 
-    public function unserialize($data)
+    public function unserialize($data): void
     {
         $this->__unserialize(unserialize($data));
     }
@@ -171,7 +171,7 @@ class Profile implements \IteratorAggregate, \Serializable
     /**
      * @internal
      */
-    public function __serialize()
+    public function __serialize(): array
     {
         return [$this->template, $this->name, $this->type, $this->starts, $this->ends, $this->profiles];
     }
@@ -179,7 +179,7 @@ class Profile implements \IteratorAggregate, \Serializable
     /**
      * @internal
      */
-    public function __unserialize(array $data)
+    public function __unserialize(array $data): void
     {
         list($this->template, $this->name, $this->type, $this->starts, $this->ends, $this->profiles) = $data;
     }


### PR DESCRIPTION
These return types preemptively tell consumers that Twig 4 / PHP 9 might add real return types here.

For `Profile`, we can add the return types right away because the class is `@final`.

Spotted by DebugClassLoader comparing return types of internal PHP base types / magic methods.