### PR TITLE
Allowing compat with Twig 2 by conditionally calling method

### DIFF
--- a/extra/twig-extra-bundle/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
+++ b/extra/twig-extra-bundle/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
@@ -14,17 +14,23 @@ namespace Twig\Extra\TwigExtraBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Twig\Environment;
 
 class MissingExtensionSuggestorPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
         if ($container->getParameter('kernel.debug')) {
-            $container->getDefinition('twig')
+            $twigDefinition = $container->getDefinition('twig');
+            $twigDefinition
                 ->addMethodCall('registerUndefinedFilterCallback', [[new Reference('twig.missing_extension_suggestor'), 'suggestFilter']])
                 ->addMethodCall('registerUndefinedFunctionCallback', [[new Reference('twig.missing_extension_suggestor'), 'suggestFunction']])
-                ->addMethodCall('registerUndefinedTokenParserCallback', [[new Reference('twig.missing_extension_suggestor'), 'suggestTag']])
             ;
+
+            // this method was added in Twig 3.2
+            if (method_exists(Environment::class, 'registerUndefinedTokenParserCallback')) {
+                $twigDefinition->addMethodCall('registerUndefinedTokenParserCallback', [[new Reference('twig.missing_extension_suggestor'), 'suggestTag']]);
+            }
         }
     }
 }

--- a/extra/twig-extra-bundle/composer.json
+++ b/extra/twig-extra-bundle/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1.3|^8.0",
         "symfony/framework-bundle": "^4.3|^5.0",
         "symfony/twig-bundle": "^4.3|^5.0",
-        "twig/twig": "^3.2"
+        "twig/twig": "^2.4|^3.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.4.9|^5.0.9",


### PR DESCRIPTION
This is an annoying, edge-case issue. The original fix was #3463. The problem, discovered by MakerBundle's tests (I'm not sure why it didn't pop up sooner) is if you're using PHP 7.1... for example with Symfony 4.4 LTS. In that situation, if you run:

```
composer require symfony/twig-pack
```

You will get:

* `twig/twig` v2 (since v3 required PHP 7.2)
* `twig/twig-extra-bundle` 3.2.0 (3.2.1 doesn't allow `twig/twig` v2, but 3.2.0 does).

The result is the container explodes:

```
!!  
!!  [critical] Uncaught Error: Call to undefined method Twig\Environment::registerUndefinedTokenParserCallback()
!!  
!!  
!!  In srcApp_KernelDevDebugContainer.php line 1176:
!!                                                                                 
!!    Attempted to call an undefined method named "registerUndefinedTokenParserCa  
!!    llback" of class "Twig\Environment".                                         
!!    Did you mean to call e.g. "registerUndefinedFilterCallback" or "registerUnd  
!!    efinedFunctionCallback"?   
```

Is this worth fixing? If not, we'll need to work around in the MakerBundle tests.

Thanks!