### PR TITLE
Fix: A template name cannot be an absolute path

### DIFF
--- a/src/Loader/FilesystemLoader.php
+++ b/src/Loader/FilesystemLoader.php
@@ -292,6 +292,10 @@ class FilesystemLoader implements LoaderInterface, ExistsLoaderInterface, Source
             throw new LoaderError('A template name cannot contain NUL bytes.');
         }
 
+        if ($this->isAbsolutePath($name)) {
+            throw new LoaderError(sprintf('A template name cannot be an absolute path (%s).', $name));
+        }
+
         $name = ltrim($name, '/');
         $parts = explode('/', $name);
         $level = 0;

--- a/tests/Loader/FilesystemTest.php
+++ b/tests/Loader/FilesystemTest.php
@@ -32,11 +32,13 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
     {
         $loader = new FilesystemLoader([__DIR__.'/../Fixtures']);
 
+        $this->expectException(LoaderError::class);
         try {
             $loader->getCacheKey($template);
-            $this->fail();
         } catch (LoaderError $e) {
             $this->assertStringNotContainsString('Unable to find template', $e->getMessage());
+
+            throw $e;
         }
     }
 
@@ -62,6 +64,14 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
             ['filters\\\\..\\\\..\\\\AutoloaderTest.php'],
             ['filters\\//../\\/\\..\\AutoloaderTest.php'],
             ['/../AutoloaderTest.php'],
+            ['/AutoloaderTest.php'],
+            ['\\AutoloaderTest.php'],
+            ['//AutoloaderTest.php'],
+            ['\\\\AutoloaderTest.php'],
+            ['/./AutoloaderTest.php'],
+            ['\\.\\AutoloaderTest.php'],
+            ['C:/AutoloaderTest.php'],
+            ['C:\\AutoloaderTest.php'],
         ];
     }
 


### PR DESCRIPTION
fixes #3209, https://github.com/PrestaShop/PrestaShop/issues/20709

The source of this is in https://github.com/twigphp/Twig/blob/v3.3.0/src/Loader/FilesystemLoader.php#L212 which NEVER accepts an absolute name (path is always prefixed with path). As discussed in https://github.com/twigphp/Twig/issues/3209#issuecomment-814816613.

The original code emits php warning when `open_basedir` is set on Windows on NTS PHP build (because of PHP inconsistency between TS and NTS, see https://bugs.php.net/bug.php?id=78939). This PR fixes this issue and no warning is emitted.

This fix is important as Symfony relies on exception when absolute path is given in https://github.com/symfony/symfony/blob/v3.4.47/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php#L82.

Please merge and issue a bugfix release for every major Twig version.