### PR TITLE
fix file permissions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /tests export-ignore
 /phpunit.xml.dist export-ignore
+./drupal_test.sh export-ignore


### PR DESCRIPTION
`drupal_test.sh` was executable and when installing the plugin with `composer` it retains these permissions.

Better to call this script as `bash ./drupal_test.sh` and have `100644` as permissions.

I could only find one reference to this script and it was commented out.
Updated it anyway as it might be revived at some point.