### PR TITLE
Replace secure.php.net with www.php.net

### DIFF
--- a/doc/filters/abs.rst
+++ b/doc/filters/abs.rst
@@ -15,4 +15,4 @@ The ``abs`` filter returns the absolute value.
 
     Internally, Twig uses the PHP `abs`_ function.
 
-.. _`abs`: https://secure.php.net/abs
+.. _`abs`: https://www.php.net/abs

--- a/doc/filters/convert_encoding.rst
+++ b/doc/filters/convert_encoding.rst
@@ -25,5 +25,5 @@ Arguments
 * ``to``:   The output charset
 * ``from``: The input charset
 
-.. _`iconv`:    https://secure.php.net/iconv
-.. _`mbstring`: https://secure.php.net/mbstring
+.. _`iconv`:    https://www.php.net/iconv
+.. _`mbstring`: https://www.php.net/mbstring

--- a/doc/filters/date.rst
+++ b/doc/filters/date.rst
@@ -93,8 +93,8 @@ Arguments
 * ``format``:   The date format
 * ``timezone``: The date timezone
 
-.. _`strtotime`:            https://secure.php.net/strtotime
-.. _`DateTime`:             https://secure.php.net/DateTime
-.. _`DateInterval`:         https://secure.php.net/DateInterval
-.. _`date`:                 https://secure.php.net/date
-.. _`DateInterval::format`: https://secure.php.net/DateInterval.format
+.. _`strtotime`:            https://www.php.net/strtotime
+.. _`DateTime`:             https://www.php.net/DateTime
+.. _`DateInterval`:         https://www.php.net/DateInterval
+.. _`date`:                 https://www.php.net/date
+.. _`DateInterval::format`: https://www.php.net/DateInterval.format

--- a/doc/filters/date_modify.rst
+++ b/doc/filters/date_modify.rst
@@ -20,5 +20,5 @@ Arguments
 
 * ``modifier``: The modifier
 
-.. _`strtotime`: https://secure.php.net/strtotime
-.. _`DateTime`:  https://secure.php.net/DateTime
+.. _`strtotime`: https://www.php.net/strtotime
+.. _`DateTime`:  https://www.php.net/DateTime

--- a/doc/filters/escape.rst
+++ b/doc/filters/escape.rst
@@ -126,4 +126,4 @@ Arguments
 * ``strategy``: The escaping strategy
 * ``charset``:  The string charset
 
-.. _`htmlspecialchars`: https://secure.php.net/htmlspecialchars
+.. _`htmlspecialchars`: https://www.php.net/htmlspecialchars

--- a/doc/filters/first.rst
+++ b/doc/filters/first.rst
@@ -23,4 +23,4 @@ a string:
 
     It also works with objects implementing the `Traversable`_ interface.
 
-.. _`Traversable`: https://secure.php.net/manual/en/class.traversable.php
+.. _`Traversable`: https://www.php.net/manual/en/class.traversable.php

--- a/doc/filters/format.rst
+++ b/doc/filters/format.rst
@@ -11,7 +11,7 @@ The ``format`` filter formats a given string by replacing the placeholders
     {# outputs I like foo and bar
        if the foo parameter equals to the foo string. #}
 
-.. _`sprintf`: https://secure.php.net/sprintf
+.. _`sprintf`: https://www.php.net/sprintf
 
 .. seealso::
 

--- a/doc/filters/json_encode.rst
+++ b/doc/filters/json_encode.rst
@@ -19,5 +19,5 @@ Arguments
   Combine constants using :ref:`bitwise operators<template_logic>`:
   ``{{ data|json_encode(constant('JSON_PRETTY_PRINT') b-or constant('JSON_HEX_QUOT')) }}``
 
-.. _`json_encode`: https://secure.php.net/json_encode
-.. _`json_encode options`: https://secure.php.net/manual/en/json.constants.php
+.. _`json_encode`: https://www.php.net/json_encode
+.. _`json_encode options`: https://www.php.net/manual/en/json.constants.php

--- a/doc/filters/last.rst
+++ b/doc/filters/last.rst
@@ -23,4 +23,4 @@ a string:
 
     It also works with objects implementing the `Traversable`_ interface.
 
-.. _`Traversable`: https://secure.php.net/manual/en/class.traversable.php
+.. _`Traversable`: https://www.php.net/manual/en/class.traversable.php

--- a/doc/filters/merge.rst
+++ b/doc/filters/merge.rst
@@ -45,4 +45,4 @@ overridden.
     Internally, Twig uses the PHP `array_merge`_ function. It supports
     Traversable objects by transforming those to arrays.
 
-.. _`array_merge`: https://secure.php.net/array_merge
+.. _`array_merge`: https://www.php.net/array_merge

--- a/doc/filters/number_format.rst
+++ b/doc/filters/number_format.rst
@@ -52,4 +52,4 @@ Arguments
 * ``decimal_point``: The character(s) to use for the decimal point
 * ``thousand_sep``:   The character(s) to use for the thousands separator
 
-.. _`number_format`: https://secure.php.net/number_format
+.. _`number_format`: https://www.php.net/number_format

--- a/doc/filters/reverse.rst
+++ b/doc/filters/reverse.rst
@@ -45,4 +45,4 @@ Arguments
 
 * ``preserve_keys``: Preserve keys when reversing a mapping or a sequence.
 
-.. _`Traversable`: https://secure.php.net/Traversable
+.. _`Traversable`: https://www.php.net/Traversable

--- a/doc/filters/slice.rst
+++ b/doc/filters/slice.rst
@@ -66,7 +66,7 @@ Arguments
 * ``length``:        The size of the slice
 * ``preserve_keys``: Whether to preserve key or not (when the input is an array)
 
-.. _`Traversable`: https://secure.php.net/manual/en/class.traversable.php
-.. _`array_slice`: https://secure.php.net/array_slice
-.. _`mb_substr`:   https://secure.php.net/mb-substr
-.. _`substr`:      https://secure.php.net/substr
+.. _`Traversable`: https://www.php.net/manual/en/class.traversable.php
+.. _`array_slice`: https://www.php.net/array_slice
+.. _`mb_substr`:   https://www.php.net/mb-substr
+.. _`substr`:      https://www.php.net/substr

--- a/doc/filters/sort.rst
+++ b/doc/filters/sort.rst
@@ -15,4 +15,4 @@ The ``sort`` filter sorts an array:
     association. It supports Traversable objects by transforming
     those to arrays.
 
-.. _`asort`: https://secure.php.net/asort
+.. _`asort`: https://www.php.net/asort

--- a/doc/filters/split.rst
+++ b/doc/filters/split.rst
@@ -50,5 +50,5 @@ Arguments
 * ``delimiter``: The delimiter
 * ``limit``:     The limit argument
 
-.. _`explode`:   https://secure.php.net/explode
-.. _`str_split`: https://secure.php.net/str_split
+.. _`explode`:   https://www.php.net/explode
+.. _`str_split`: https://www.php.net/str_split

--- a/doc/filters/striptags.rst
+++ b/doc/filters/striptags.rst
@@ -26,4 +26,4 @@ Arguments
 
 * ``allowable_tags``: Tags which should not be stripped
 
-.. _`strip_tags`: https://secure.php.net/strip_tags
+.. _`strip_tags`: https://www.php.net/strip_tags

--- a/doc/filters/trim.rst
+++ b/doc/filters/trim.rst
@@ -42,6 +42,6 @@ Arguments
 * ``side``: The default is to strip from the left and the right (`both`) sides, but `left`
   and `right` will strip from either the left side or right side only
 
-.. _`trim`: https://secure.php.net/trim
-.. _`ltrim`: https://secure.php.net/ltrim
-.. _`rtrim`: https://secure.php.net/rtrim
+.. _`trim`: https://www.php.net/trim
+.. _`ltrim`: https://www.php.net/ltrim
+.. _`rtrim`: https://www.php.net/rtrim

--- a/doc/filters/url_encode.rst
+++ b/doc/filters/url_encode.rst
@@ -31,6 +31,6 @@ or an array as query string:
     that as of Twig 1.16.0, ``urlencode`` **always** uses ``rawurlencode`` (the
     ``raw`` argument was removed.)
 
-.. _`urlencode`:        https://secure.php.net/urlencode
-.. _`rawurlencode`:     https://secure.php.net/rawurlencode
-.. _`http_build_query`: https://secure.php.net/http_build_query
+.. _`urlencode`:        https://www.php.net/urlencode
+.. _`rawurlencode`:     https://www.php.net/rawurlencode
+.. _`http_build_query`: https://www.php.net/http_build_query

--- a/doc/functions/date.rst
+++ b/doc/functions/date.rst
@@ -52,4 +52,4 @@ Arguments
 * ``date``:     The date
 * ``timezone``: The timezone
 
-.. _`date and time formats`: https://secure.php.net/manual/en/datetime.formats.php
+.. _`date and time formats`: https://www.php.net/manual/en/datetime.formats.php

--- a/doc/functions/dump.rst
+++ b/doc/functions/dump.rst
@@ -67,4 +67,4 @@ Arguments
 * ``context``: The context to dump
 
 .. _`XDebug`:   https://xdebug.org/docs/display
-.. _`var_dump`: https://secure.php.net/var_dump
+.. _`var_dump`: https://www.php.net/var_dump

--- a/doc/functions/range.rst
+++ b/doc/functions/range.rst
@@ -55,4 +55,4 @@ Arguments
 * ``high``: The highest possible value of the sequence.
 * ``step``: The increment between elements of the sequence.
 
-.. _`range`: https://secure.php.net/range
+.. _`range`: https://www.php.net/range

--- a/doc/recipes.rst
+++ b/doc/recipes.rst
@@ -565,4 +565,4 @@ include in your templates:
             'tag_variable' => ['{[', ']}'],
         ]));
 
-.. _callback: https://secure.php.net/manual/en/function.is-callable.php
+.. _callback: https://www.php.net/manual/en/function.is-callable.php

--- a/doc/tags/flush.rst
+++ b/doc/tags/flush.rst
@@ -15,4 +15,4 @@ The ``flush`` tag tells Twig to flush the output buffer:
 
     Internally, Twig uses the PHP `flush`_ function.
 
-.. _`flush`: https://secure.php.net/flush
+.. _`flush`: https://www.php.net/flush

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -890,7 +890,7 @@ Twig can be extended. If you want to create your own extensions, read the
 .. _`other Twig syntax mode`:     https://github.com/muxx/Twig-HTML.mode
 .. _`Notepad++ Twig Highlighter`: https://github.com/Banane9/notepadplusplus-twig
 .. _`web-mode.el`:                http://web-mode.org/
-.. _`regular expressions`:        https://secure.php.net/manual/en/pcre.pattern.php
+.. _`regular expressions`:        https://www.php.net/manual/en/pcre.pattern.php
 .. _`PHP-twig for atom`:          https://github.com/reesef/php-twig
 .. _`TwigFiddle`:                 https://twigfiddle.com/
 .. _`Twig pack`:                  https://marketplace.visualstudio.com/items?itemName=bajdzis.vscode-twig-pack

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -515,7 +515,7 @@ function twig_date_converter(Environment $env, $date = null, $timezone = null)
  *
  * @param string             $str  String to replace in
  * @param array|\Traversable $from Replace values
- * @param string|null        $to   Replace to, deprecated (@see https://secure.php.net/manual/en/function.strtr.php)
+ * @param string|null        $to   Replace to, deprecated (@see https://www.php.net/manual/en/function.strtr.php)
  *
  * @return string
  */
@@ -1047,7 +1047,7 @@ function twig_escape_filter(Environment $env, $string, $strategy = 'html', $char
 
     switch ($strategy) {
         case 'html':
-            // see https://secure.php.net/htmlspecialchars
+            // see https://www.php.net/htmlspecialchars
 
             // Using a static variable to avoid initializing the array
             // each time the function is called. Moving the declaration on the


### PR DESCRIPTION
It is no longer necessary to use the _secure_ subdomain.

See: https://news-web.php.net/php.internals/104533.

> Instead of having mirrors, we are moving all of PHP.net to HTTPS (and get rid of https://secure.php.net)