### PR TITLE
Fix implicit float to int casts

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -349,7 +349,7 @@ function twig_cycle($values, $position)
 function twig_random(Environment $env, $values = null, $max = null)
 {
     if (null === $values) {
-        return null === $max ? mt_rand() : mt_rand(0, $max);
+        return null === $max ? mt_rand() : mt_rand(0, (int) $max);
     }
 
     if (\is_int($values) || \is_float($values)) {
@@ -366,7 +366,7 @@ function twig_random(Environment $env, $values = null, $max = null)
             $max = $max;
         }
 
-        return mt_rand($min, $max);
+        return mt_rand((int) $min, (int) $max);
     }
 
     if (\is_string($values)) {

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -11,6 +11,7 @@ namespace Twig\Tests;
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
 use Twig\Environment;
 use Twig\Error\RuntimeError;
 use Twig\Extension\SandboxExtension;
@@ -23,7 +24,7 @@ use Twig\Sandbox\SecurityError;
 use Twig\Sandbox\SecurityPolicy;
 use Twig\Template;
 
-class TemplateTest extends \PHPUnit\Framework\TestCase
+class TemplateTest extends TestCase
 {
     public function testDisplayBlocksAcceptTemplateOnlyAsBlocks()
     {
@@ -238,9 +239,15 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame('Zero', $array[false]);
         $this->assertSame('One', $array[true]);
-        $this->assertSame('One', $array[1.5]);
+        if (\PHP_VERSION_ID < 80100) {
+            // This line will trigger a deprecation warning on PHP 8.1.
+            $this->assertSame('One', $array[1.5]);
+        }
         $this->assertSame('One', $array['1']);
-        $this->assertSame('MinusOne', $array[-1.5]);
+        if (\PHP_VERSION_ID < 80100) {
+            // This line will trigger a deprecation warning on PHP 8.1.
+            $this->assertSame('MinusOne', $array[-1.5]);
+        }
         $this->assertSame('FloatButString', $array['1.5']);
         $this->assertSame('IntegerButStringWithLeadingZeros', $array['01']);
         $this->assertSame('EmptyString', $array[null]);


### PR DESCRIPTION
PHP 8.1 is picky about implicit float-to-int casts if we lose precision because of that cast. This PR attempts to fix all issues on the 1.x branch.