### PR TITLE
Add ReturnTypeWillChange to JsonSerializable implementation

### DIFF
--- a/src/Markup.php
+++ b/src/Markup.php
@@ -40,6 +40,7 @@ class Markup implements \Countable, \JsonSerializable
         return mb_strlen($this->content, $this->charset);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->content;


### PR DESCRIPTION
On PHP 8.1, implementations of `JsonSerializable` should declare a return type.

In order to avoid a deprecation warning and maintain backwards compatibility, I've added the `ReturnTypeWillChange` attribute to declare that our implementation will add the necessary return type in a future release.