### PR TITLE
Add needs_source to twig function

### DIFF
--- a/src/Node/Expression/CallExpression.php
+++ b/src/Node/Expression/CallExpression.php
@@ -79,6 +79,14 @@ abstract class CallExpression extends AbstractExpression
             $first = false;
         }
 
+        if ($this->hasAttribute('needs_source') && $this->getAttribute('needs_source')) {
+            if (!$first) {
+                $compiler->raw(', ');
+            }
+            $compiler->raw('$this->source');
+            $first = false;
+        }
+
         if ($this->hasAttribute('arguments')) {
             foreach ($this->getAttribute('arguments') as $argument) {
                 if (!$first) {
@@ -257,6 +265,9 @@ abstract class CallExpression extends AbstractExpression
             array_shift($parameters);
         }
         if ($this->hasAttribute('needs_context') && $this->getAttribute('needs_context')) {
+            array_shift($parameters);
+        }
+        if ($this->hasAttribute('needs_source') && $this->getAttribute('needs_source')) {
             array_shift($parameters);
         }
         if ($this->hasAttribute('arguments') && null !== $this->getAttribute('arguments')) {

--- a/src/Node/Expression/FilterExpression.php
+++ b/src/Node/Expression/FilterExpression.php
@@ -31,6 +31,7 @@ class FilterExpression extends CallExpression
         $this->setAttribute('type', 'filter');
         $this->setAttribute('needs_environment', $filter->needsEnvironment());
         $this->setAttribute('needs_context', $filter->needsContext());
+        $this->setAttribute('needs_source', $filter->needsSource());
         $this->setAttribute('arguments', $filter->getArguments());
         $this->setAttribute('callable', $filter->getCallable());
         $this->setAttribute('is_variadic', $filter->isVariadic());

--- a/src/Node/Expression/FunctionExpression.php
+++ b/src/Node/Expression/FunctionExpression.php
@@ -30,6 +30,7 @@ class FunctionExpression extends CallExpression
         $this->setAttribute('type', 'function');
         $this->setAttribute('needs_environment', $function->needsEnvironment());
         $this->setAttribute('needs_context', $function->needsContext());
+        $this->setAttribute('needs_source', $function->needsSource());
         $this->setAttribute('arguments', $function->getArguments());
         $callable = $function->getCallable();
         if ('constant' === $name && $this->getAttribute('is_defined_test')) {

--- a/src/TwigFilter.php
+++ b/src/TwigFilter.php
@@ -38,6 +38,7 @@ final class TwigFilter
         $this->options = array_merge([
             'needs_environment' => false,
             'needs_context' => false,
+            'needs_source' => false,
             'is_variadic' => false,
             'is_safe' => null,
             'is_safe_callback' => null,
@@ -87,6 +88,11 @@ final class TwigFilter
     public function needsContext(): bool
     {
         return $this->options['needs_context'];
+    }
+
+    public function needsSource(): bool
+    {
+        return $this->options['needs_source'];
     }
 
     public function getSafe(Node $filterArgs): ?array

--- a/src/TwigFunction.php
+++ b/src/TwigFunction.php
@@ -38,6 +38,7 @@ final class TwigFunction
         $this->options = array_merge([
             'needs_environment' => false,
             'needs_context' => false,
+            'needs_source' => false,
             'is_variadic' => false,
             'is_safe' => null,
             'is_safe_callback' => null,
@@ -85,6 +86,11 @@ final class TwigFunction
     public function needsContext(): bool
     {
         return $this->options['needs_context'];
+    }
+
+    public function needsSource(): bool
+    {
+        return $this->options['needs_source'];
     }
 
     public function getSafe(Node $functionArgs): ?array


### PR DESCRIPTION
Hey,

We want to limit the functionality of a twig function in which template it has been used. Currently, it seems not possible to access the current twig file name.

This PR would be made it possible to access the source where the file name is there.

Would you like to have such a thing in Twig? This PR is currently wip as it doesn't have tests or docs. I would provide them if it would be accepted