### PR TITLE
Explicitly specify the encoding for mb_ord in JS escaper

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1237,7 +1237,7 @@ function _twig_escape_js_callback($matches)
         return $shortMap[$char];
     }
 
-    $codepoint = mb_ord($char);
+    $codepoint = mb_ord($char, 'UTF-8');
     if (0x10000 > $codepoint) {
         return sprintf('\u%04X', $codepoint);
     }

--- a/tests/escapingTest.php
+++ b/tests/escapingTest.php
@@ -177,6 +177,22 @@ class escapingTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    public function testJavascriptEscapingConvertsSpecialCharsWithInternalEncoding()
+    {
+        $twig = new Environment($this->createMock(LoaderInterface::class));
+        $previousInternalEncoding = mb_internal_encoding();
+        try {
+            mb_internal_encoding('ISO-8859-1');
+            foreach ($this->jsSpecialChars as $key => $value) {
+                $this->assertEquals($value, twig_escape_filter($twig, $key, 'js'), 'Failed to escape: ' . $key);
+            }
+        } finally {
+            if ($previousInternalEncoding !== false) {
+                mb_internal_encoding($previousInternalEncoding);
+            }
+        }
+    }
+
     public function testJavascriptEscapingReturnsStringIfZeroLength()
     {
         $this->assertEquals('', twig_escape_filter($this->env, '', 'js'));


### PR DESCRIPTION
`mb_ord` should be called with the specified UTF-8 encoding to make it independent of `mb_internal_encoding`.

Related to https://github.com/twigphp/Twig/pull/3397