### PR TITLE
Twig2 PHP 8.1 beta compatibility

### DIFF
--- a/src/Markup.php
+++ b/src/Markup.php
@@ -35,6 +35,7 @@ class Markup implements \Countable, \JsonSerializable
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return mb_strlen($this->content, $this->charset);

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -161,6 +161,7 @@ class Node implements \Countable, \IteratorAggregate
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return \count($this->nodes);
@@ -169,6 +170,7 @@ class Node implements \Countable, \IteratorAggregate
     /**
      * @return \Traversable
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->nodes);

--- a/src/Profiler/Profile.php
+++ b/src/Profiler/Profile.php
@@ -157,6 +157,7 @@ class Profile implements \IteratorAggregate, \Serializable
         $this->enter();
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->profiles);

--- a/tests/Extension/CoreTest.php
+++ b/tests/Extension/CoreTest.php
@@ -262,7 +262,7 @@ final class CoreTestIteratorAggregate implements \IteratorAggregate
         $this->iterator = new CoreTestIterator($array, $keys, $allowAccess, $maxPosition);
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return $this->iterator;
     }
@@ -277,7 +277,7 @@ final class CoreTestIteratorAggregateAggregate implements \IteratorAggregate
         $this->iterator = new CoreTestIteratorAggregate($array, $keys, $allowValueAccess, $maxPosition);
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return $this->iterator;
     }
@@ -300,11 +300,12 @@ final class CoreTestIterator implements \Iterator
         $this->maxPosition = false === $maxPosition ? \count($values) + 1 : $maxPosition;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if ($this->allowValueAccess) {
@@ -314,12 +315,13 @@ final class CoreTestIterator implements \Iterator
         throw new \LogicException('Code should only use the keys, not the values provided by iterator.');
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->arrayKeys[$this->position];
     }
 
-    public function next()
+    public function next(): void
     {
         ++$this->position;
         if ($this->position === $this->maxPosition) {
@@ -327,7 +329,7 @@ final class CoreTestIterator implements \Iterator
         }
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->arrayKeys[$this->position]);
     }

--- a/tests/Fixtures/tags/for/objects.test
+++ b/tests/Fixtures/tags/for/objects.test
@@ -19,11 +19,13 @@
 class ItemsIterator implements \Iterator
 {
   protected $values = ['foo' => 'bar', 'bar' => 'foo'];
+  #[\ReturnTypeWillChange]
   public function current() { return current($this->values); }
+  #[\ReturnTypeWillChange]
   public function key() { return key($this->values); }
-  public function next() { return next($this->values); }
-  public function rewind() { return reset($this->values); }
-  public function valid() { return false !== current($this->values); }
+  public function next(): void { next($this->values); }
+  public function rewind(): void { reset($this->values); }
+  public function valid(): bool { return false !== current($this->values); }
 }
 return ['items' => new ItemsIterator()]
 --EXPECT--

--- a/tests/Fixtures/tags/for/objects_countable.test
+++ b/tests/Fixtures/tags/for/objects_countable.test
@@ -20,12 +20,14 @@
 class ItemsIteratorCountable implements \Iterator, \Countable
 {
   protected $values = ['foo' => 'bar', 'bar' => 'foo'];
+  #[\ReturnTypeWillChange]
   public function current() { return current($this->values); }
+  #[\ReturnTypeWillChange]
   public function key() { return key($this->values); }
-  public function next() { return next($this->values); }
-  public function rewind() { return reset($this->values); }
-  public function valid() { return false !== current($this->values); }
-  public function count() { return count($this->values); }
+  public function next(): void { next($this->values); }
+  public function rewind(): void { reset($this->values); }
+  public function valid(): bool { return false !== current($this->values); }
+  public function count(): int { return count($this->values); }
 }
 return ['items' => new ItemsIteratorCountable()]
 --EXPECT--

--- a/tests/Fixtures/tests/empty.test
+++ b/tests/Fixtures/tests/empty.test
@@ -25,7 +25,7 @@ return [
     'value_null' => null, 'value_false' => false, 'value_int_zero' => 0,
     'array_empty' => [], 'array_not_empty' => [1, 2],
     'magically_callable' => new \Twig\Tests\MagicCallStub(),
-    'countable_empty' => new \Twig\Tests\CountableStub([]), 'countable_not_empty' => new \Twig\Tests\CountableStub([1, 2]),
+    'countable_empty' => new \Twig\Tests\CountableStub(0), 'countable_not_empty' => new \Twig\Tests\CountableStub(2),
     'tostring_empty' => new \Twig\Tests\ToStringStub(''), 'tostring_not_empty' => new \Twig\Tests\ToStringStub('0' /* edge case of using "0" as the string */),
     'markup_empty' => new \Twig\Markup('', 'UTF-8'), 'markup_not_empty' => new \Twig\Markup('test', 'UTF-8'),
     'iterator' => $iter = new \ArrayIterator(['bar', 'foo']),

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -99,27 +99,29 @@ class TwigTestFoo implements \Iterator
         return strtolower($value);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->array[$this->position];
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return 'a';
     }
 
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->array[$this->position]);
     }
@@ -327,7 +329,7 @@ class CountableStub implements \Countable
         $this->count = $count;
     }
 
-    public function count()
+    public function count(): int
     {
         return $this->count;
     }
@@ -350,7 +352,7 @@ class IteratorAggregateStub implements \IteratorAggregate
         $this->data = $data;
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->data);
     }
@@ -361,27 +363,29 @@ class SimpleIteratorForTesting implements \Iterator
     private $data = [1, 2, 3, 4, 5, 6, 7];
     private $key = 0;
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->key;
     }
 
-    public function next()
+    public function next(): void
     {
         ++$this->key;
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->key;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->data[$this->key]);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->key = 0;
     }

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -471,21 +471,22 @@ class TemplateArrayAccessObject implements \ArrayAccess
         '+4' => '+4',
     ];
 
-    public function offsetExists($name)
+    public function offsetExists($name) : bool
     {
         return \array_key_exists($name, $this->attributes);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($name)
     {
         return \array_key_exists($name, $this->attributes) ? $this->attributes[$name] : null;
     }
 
-    public function offsetSet($name, $value)
+    public function offsetSet($name, $value) : void
     {
     }
 
-    public function offsetUnset($name)
+    public function offsetUnset($name) : void
     {
     }
 }
@@ -542,7 +543,7 @@ class TemplatePropertyObject
 
 class TemplatePropertyObjectAndIterator extends TemplatePropertyObject implements \IteratorAggregate
 {
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator(['foo', 'bar']);
     }
@@ -560,21 +561,22 @@ class TemplatePropertyObjectAndArrayAccess extends TemplatePropertyObject implem
         'baf' => 'baf',
     ];
 
-    public function offsetExists($offset)
+    public function offsetExists($offset) : bool
     {
         return \array_key_exists($offset, $this->data);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->data[$offset] : 'n/a';
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value) : void
     {
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset) : void
     {
     }
 }
@@ -708,22 +710,23 @@ class TemplateArrayAccess implements \ArrayAccess
     ];
     private $children = [];
 
-    public function offsetExists($offset)
+    public function offsetExists($offset) : bool
     {
         return \array_key_exists($offset, $this->children);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->children[$offset];
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value) : void
     {
         $this->children[$offset] = $value;
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset) : void
     {
         unset($this->children[$offset]);
     }

--- a/tests/Util/DeprecationCollectorTest.php
+++ b/tests/Util/DeprecationCollectorTest.php
@@ -40,7 +40,7 @@ class DeprecationCollectorTest extends TestCase
 
 class Twig_Tests_Util_Iterator implements \IteratorAggregate
 {
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator([
             'ok.twig' => '{{ foo }}',


### PR DESCRIPTION
PHP 8.1 adds deprecation warnings for \IteratorAggregate \Countable and \ArrayAccess and Twig 2 (and 3) need to be updated for this.