### PR TITLE
Fix strtr call in twig_replace_filter for PHP 8.1

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -516,7 +516,7 @@ function twig_replace_filter($str, $from)
         throw new RuntimeError(sprintf('The "replace" filter expects an array or "Traversable" as replace values, got "%s".', \is_object($from) ? \get_class($from) : \gettype($from)));
     }
 
-    return strtr($str, twig_to_array($from));
+    return strtr((string) $str, twig_to_array($from));
 }
 
 /**


### PR DESCRIPTION
* twig_replace_filter, although documented $str to be string type,
  does not enforce that in typehint. There's chance that null is
  passed into $str. Then it would trigger a "Deprecated: strtr():
  Passing null to parameter 1 ($string) of type string is
  deprecated" warning.

* Cast the $str as string before passing to strtr should fix the
   issue.