### PR TITLE
Allow CommonMark extensions to easily be added

### DIFF
--- a/doc/filters/markdown_to_html.rst
+++ b/doc/filters/markdown_to_html.rst
@@ -29,7 +29,7 @@ You can also use the filter on an included file or a variable:
 .. code-block:: twig
 
     {{ include('some_template.markdown.twig')|markdown_to_html }}
-    
+
     {{ changelog|markdown_to_html }}
 
 .. note::
@@ -67,6 +67,13 @@ You can also use the filter on an included file or a variable:
                 }
             }
         });
-       
+
     Afterwards you need to install a markdown library of your choice. Some of them are
     mentioned in the ``require-dev`` section of the ``twig/markdown-extra`` package.
+
+.. note::
+
+    If using Symfony (full-stack), ``twig/extra-bundle`` with ``league/commonmark`` as
+    your Markdown library you can configure CommonMark extensions. Register the desired
+    extension(s) as a service, then tag the service with
+    ``twig.markdown.league_extension``.

--- a/extra/markdown-extra/composer.json
+++ b/extra/markdown-extra/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0",
         "erusev/parsedown": "^1.7",
-        "league/commonmark": "^1.0",
+        "league/commonmark": "^1.0|^2.0",
         "league/html-to-markdown": "^4.8|^5.0",
         "michelf/php-markdown": "^1.8"
     },

--- a/extra/twig-extra-bundle/DependencyInjection/TwigExtraExtension.php
+++ b/extra/twig-extra-bundle/DependencyInjection/TwigExtraExtension.php
@@ -11,6 +11,7 @@
 
 namespace Twig\Extra\TwigExtraBundle\DependencyInjection;
 
+use League\CommonMark\CommonMarkConverter;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -36,6 +37,10 @@ class TwigExtraExtension extends Extension
             if ($this->isConfigEnabled($container, $config[$extension])) {
                 $loader->load($extension.'.php');
             }
+        }
+
+        if (\class_exists(CommonMarkConverter::class)) {
+            $loader->load('markdown_league.php');
         }
     }
 }

--- a/extra/twig-extra-bundle/LeagueCommonMarkConverterFactory.php
+++ b/extra/twig-extra-bundle/LeagueCommonMarkConverterFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Extra\TwigExtraBundle;
+
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Extension\ExtensionInterface;
+
+/**
+ * @internal
+ */
+final class LeagueCommonMarkConverterFactory
+{
+    private $extensions;
+
+    /**
+     * @param ExtensionInterface[] $extensions
+     */
+    public function __construct(iterable $extensions)
+    {
+        $this->extensions = $extensions;
+    }
+
+    public function __invoke(): CommonMarkConverter
+    {
+        $converter = new CommonMarkConverter();
+
+        foreach ($this->extensions as $extension) {
+            $converter->getEnvironment()->addExtension($extension);
+        }
+
+        return $converter;
+    }
+}

--- a/extra/twig-extra-bundle/Resources/config/markdown_league.php
+++ b/extra/twig-extra-bundle/Resources/config/markdown_league.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use League\CommonMark\CommonMarkConverter;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Twig\Extra\Markdown\LeagueMarkdown;
+use Twig\Extra\TwigExtraBundle\LeagueCommonMarkConverterFactory;
+
+return static function (ContainerConfigurator $container) {
+    $service = \function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\service') ? 'Symfony\Component\DependencyInjection\Loader\Configurator\service' : 'Symfony\Component\DependencyInjection\Loader\Configurator\ref';
+    $container->services()
+        ->set('twig.markdown.league_common_mark_converter_factory', LeagueCommonMarkConverterFactory::class)
+        ->args([new TaggedIteratorArgument('twig.markdown.league_extension')])
+
+        ->set('twig.markdown.league_common_mark_converter', CommonMarkConverter::class)
+        ->factory([$service('twig.markdown.league_common_mark_converter_factory')])
+
+        ->set('twig.markdown.default', LeagueMarkdown::class)
+        ->args([$service('twig.markdown.league_common_mark_converter')])
+    ;
+};

--- a/extra/twig-extra-bundle/Tests/DependencyInjection/TwigExtraExtensionTest.php
+++ b/extra/twig-extra-bundle/Tests/DependencyInjection/TwigExtraExtensionTest.php
@@ -14,6 +14,7 @@ namespace Twig\Extra\TwigExtraBundle\Tests\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Twig\Extra\Markdown\LeagueMarkdown;
 use Twig\Extra\TwigExtraBundle\DependencyInjection\TwigExtraExtension;
 use Twig\Extra\TwigExtraBundle\Extensions;
 
@@ -34,5 +35,7 @@ class TwigExtraExtensionTest extends TestCase
         foreach (Extensions::getClasses() as $name => $class) {
             $this->assertEquals($class, $container->getDefinition('twig.extension.'.$name)->getClass());
         }
+
+        $this->assertSame(LeagueMarkdown::class, $container->getDefinition('twig.markdown.default')->getClass());
     }
 }

--- a/extra/twig-extra-bundle/composer.json
+++ b/extra/twig-extra-bundle/composer.json
@@ -21,6 +21,7 @@
         "twig/twig": "^2.4|^3.0"
     },
     "require-dev": {
+        "league/commonmark": "^1.0|^2.0",
         "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0",
         "twig/cache-extra": "^3.0",
         "twig/cssinliner-extra": "^2.12|^3.0",


### PR DESCRIPTION
1. I discovered that commonmark 2 works just fine with `markdown-extra` so I added to the `require-dev` of `markdown-extra`'s `composer.json`
2. Added `LeagueMarkdownFactory` to `markdown-extra` as discussed in #3558
3. In `twig-extra-bundle`, if commonmark (and the above factory) is available, wire up the factory with extensions added via the `twig.markdown.league_extension` DI tag

If this PR would be acceptable, I can add some tests.

(closes #3558)