### PR TITLE
Update .gitattributes to exclude non-dist files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+/doc/** export-ignore
 /tests export-ignore
 /phpunit.xml.dist export-ignore


### PR DESCRIPTION
resolves #3503 

some extra files can be excluded also:
- changelog
- license
- readme

should this be rebased to 1.x, 2.x?