### PR TITLE
Start experiment with 'literal-string' type

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -377,6 +377,9 @@ class Environment
      * @param string $template The template source
      * @param string $name     An optional name of the template to be used in error messages
      *
+     * @phpstan-param literal-string $template
+     * @psalm-param   literal-string $template
+     *
      * @throws LoaderError When the template cannot be found
      * @throws SyntaxError When an error occurred during compilation
      */


### PR DESCRIPTION
Both [Psalm 4.8](https://github.com/vimeo/psalm/releases/tag/4.8.0) and [PHPStan 0.12.97](https://github.com/phpstan/phpstan/releases/tag/0.12.97) have recently introduced the `literal-string` type.

This allows Twig to note that certain methods expect a `string` to be created by the developer (defined in the source code), so mistakes that lead to a typical Injection Vulnerability can be identified, e.g.

```php
$_GET['name'] = '<script>alert(1)</script>';

$html = $twig->createTemplate('<p>Hi ' . $_GET['name'] . '</p>')->render(); // INSECURE

$html = $twig->createTemplate('<p>Hi {{ name }}</p>')->render(['name' => $_GET['name']]);
```

By setting the `$template` parameter in `createTemplate()` to `literal-string`, for those using use Psalm (level 3 or stricter) or PHPStan (level 5 or stricter), we can check the `$template` HTML does not contain unsafe user data (a mistake often created by junior developers making a "quick edit").

And `literal-string` is quite forgiving, in that it works with variables, and allows string concatenation (assuming both are `literal-string` values), so code like the following works well, e.g.

```php
$template = '<p>Hi ' . ($name ? '<strong>{{ name }}</strong>' : '<span>Guest</span>') . '</p>';

$html = $twig->createTemplate($template)->render(['name' => $name]);
```

That said, I still want to be cautious (I don't want to create issues for the users of Twig). Which is why I'd only like to try this with `->createTemplate()`, so we can see what feedback we get (I'm happy to help with that), and if we get a positive response, we can see what other methods might benefit from this.