### PR TITLE
Extension::spaceless: Use better spaceless algorithm.

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1030,7 +1030,19 @@ function twig_trim_filter($string, $characterMask = null, $side = 'both')
  */
 function twig_spaceless($content)
 {
-    return trim(preg_replace('/>\s+</', '><', $content));
+    $content = (string) preg_replace_callback(
+        '#[ \t\r\n]+|<(/)?(textarea|pre|script)(?=\W)#si',
+        static function ($m) {
+            if (empty($m[2])) {
+                return ' ';
+            }
+
+            return $m[0];
+        },
+        $content
+    );
+
+    return trim($content);
 }
 
 function twig_convert_encoding($string, $to, $from)


### PR DESCRIPTION
In case of template:

```html
{% block content %}
{% apply spaceless %}
<p>
    Open <a href="{{ url }}">Google</a> <strong>for more</strong> info.
</p>
{% endapply %}
{% endblock %}
```

Final old render is:

```html
<p>
    Open <a href="https://google.cz">Google</a><strong>for more</strong> info.
</p>
```

New algorithms will return:

```html
<p> Open <a href="https://google.cz">Google</a> <strong>for more</strong> info. </p>
```

But it breaks space between words.

![Snímek obrazovky 2021-10-14 v 15 31 06](https://user-images.githubusercontent.com/4738758/137330078-47771134-8798-4d07-9651-6dec3ca3003f.png)

I think more better algorithm should be inspired from Latte engine: https://github.com/nette/latte/blob/53e5da9aa2ec20e6e7e4149448e5d0ad2af282ba/src/Latte/Runtime/Filters.php#L309

Thanks.