### PR TITLE
[TwigExtraBundle] Add the return type information in getConfigTreeBuilder()

### DIFF
--- a/extra/twig-extra-bundle/DependencyInjection/Configuration.php
+++ b/extra/twig-extra-bundle/DependencyInjection/Configuration.php
@@ -17,6 +17,9 @@ use Twig\Extra\TwigExtraBundle\Extensions;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('twig_extra');


### PR DESCRIPTION
Moved from https://github.com/twigphp/twig-extra-bundle/pull/5

-----

This will fix the following deprecation:

```
  1x: Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "Twig\Extra\TwigExtraBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AddUserCommandTest::testCreateUserNonInteractive from App\Tests\Command
```