### PR TITLE
Use faster hash algorithm (xxh128) on PHP 8.1+

### DIFF
--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -35,7 +35,7 @@ class FilesystemCache implements CacheInterface
 
     public function generateKey($name, $className)
     {
-        $hash = hash('sha256', $className);
+        $hash = hash(\PHP_VERSION_ID < 80100 ? 'sha256' : 'xxh128', $className);
 
         return $this->directory.$hash[0].$hash[1].'/'.$hash.'.php';
     }

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -298,7 +298,7 @@ class Environment
     {
         $key = $this->getLoader()->getCacheKey($name).$this->optionsHash;
 
-        return $this->templateClassPrefix.hash('sha256', $key).(null === $index ? '' : '___'.$index);
+        return $this->templateClassPrefix.hash(\PHP_VERSION_ID < 80100 ? 'sha256' : 'xxh128', $key).(null === $index ? '' : '___'.$index);
     }
 
     /**
@@ -445,7 +445,7 @@ class Environment
      */
     public function createTemplate($template, string $name = null)
     {
-        $hash = hash('sha256', $template, false);
+        $hash = hash(\PHP_VERSION_ID < 80100 ? 'sha256' : 'xxh128', $template, false);
         if (null !== $name) {
             $name = sprintf('%s (string template %s)', $name, $hash);
         } else {

--- a/src/Profiler/NodeVisitor/ProfilerNodeVisitor.php
+++ b/src/Profiler/NodeVisitor/ProfilerNodeVisitor.php
@@ -33,7 +33,7 @@ final class ProfilerNodeVisitor extends AbstractNodeVisitor
     public function __construct(string $extensionName)
     {
         $this->extensionName = $extensionName;
-        $this->varName = sprintf('__internal_%s', hash('sha256', $extensionName));
+        $this->varName = sprintf('__internal_%s', hash(\PHP_VERSION_ID < 80100 ? 'sha256' : 'xxh128', $extensionName));
     }
 
     protected function doEnterNode(Node $node, Environment $env)

--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -186,7 +186,7 @@ abstract class IntegrationTestCase extends TestCase
             // avoid using the same PHP class name for different cases
             $p = new \ReflectionProperty($twig, 'templateClassPrefix');
             $p->setAccessible(true);
-            $p->setValue($twig, '__TwigTemplate_'.hash('sha256', uniqid(mt_rand(), true), false).'_');
+            $p->setValue($twig, '__TwigTemplate_'.hash(\PHP_VERSION_ID < 80100 ? 'sha256' : 'xxh128', uniqid(mt_rand(), true), false).'_');
 
             $deprecations = [];
             try {

--- a/tests/Cache/FilesystemTest.php
+++ b/tests/Cache/FilesystemTest.php
@@ -23,7 +23,7 @@ class FilesystemTest extends TestCase
 
     protected function setUp(): void
     {
-        $nonce = hash('sha256', uniqid(mt_rand(), true));
+        $nonce = hash(\PHP_VERSION_ID < 80100 ? 'sha256' : 'xxh128', uniqid(mt_rand(), true));
         $this->classname = '__Twig_Tests_Cache_FilesystemTest_Template_'.$nonce;
         $this->directory = sys_get_temp_dir().'/twig-test';
         $this->cache = new FilesystemCache($this->directory);

--- a/tests/Fixtures/functions/template_from_string_error_php80.test
+++ b/tests/Fixtures/functions/template_from_string_error_php80.test
@@ -1,10 +1,10 @@
 --TEST--
 "template_from_string" function
 --CONDITION--
-PHP_VERSION_ID >= 80100
+PHP_VERSION_ID < 80100
 --TEMPLATE--
 {% include template_from_string("{{ not a Twig template ", "foo.twig") %}
 --DATA--
 return []
 --EXCEPTION--
-Twig\Error\SyntaxError: Unclosed "variable" in "foo.twig (string template 85e7b092afbbcd36f11981c2ef8f1569)" at line 1.
+Twig\Error\SyntaxError: Unclosed "variable" in "foo.twig (string template 4900163d56b1af4b704c6b0afee7f98ba53418ce7a93d37a3af1882735baf9cd)" at line 1.


### PR DESCRIPTION
Twig uses the `hash` function at runtime to convert template paths class names, each time a template is loaded. In a large project with a high granularity of templates (hundreds of `include` per page), this can become the most time consuming function as reported by Blackfire:
<img src="https://user-images.githubusercontent.com/400034/140626949-c4876b7d-c91c-4e07-b2f4-8ebbcaa72f61.png" width="220">

To optimise this use-case, [PHP 8.1 supports the xxHash hash algorithms](https://php.watch/versions/8.1/xxHash). `xxh128` is 60x faster that `sha256` according to the [benchmarks](https://php.watch/articles/php-hash-benchmark), and guarantee a very [low risk of collision](http://cyan4973.github.io/xxHash/).

I'm not able to test with PHP 8.1 for now. Before going further I would like to validate performance impact on a large list of file names.