### PR TITLE
Optimize Environment::resolveTemplate() to be much faster when template overrides do not exist

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -501,6 +501,7 @@ class Environment
             $names = [$names];
         }
 
+        $count = \count($names);
         foreach ($names as $name) {
             if ($name instanceof Template) {
                 return $name;
@@ -509,10 +510,15 @@ class Environment
                 return $name;
             }
 
+            // Optimization: Avoid throwing an exception when it would be ignored anyway.
+            if (1 !== $count && !$this->getLoader()->exists($name)) {
+                continue;
+            }
+
             try {
                 return $this->loadTemplate($name);
             } catch (LoaderError $e) {
-                if (1 === \count($names)) {
+                if (1 === $count) {
                     throw $e;
                 }
             }

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -515,13 +515,8 @@ class Environment
                 continue;
             }
 
-            try {
-                return $this->loadTemplate($name);
-            } catch (LoaderError $e) {
-                if (1 === $count) {
-                    throw $e;
-                }
-            }
+            // Throws LoaderError: Unable to find template "%s".
+            return $this->loadTemplate($name);
         }
 
         throw new LoaderError(sprintf('Unable to find one of the following templates: "%s".', implode('", "', $names)));


### PR DESCRIPTION
Fixes partially #3595.

You can test this by adding an object into the context which implements `__debugInfo()` with a counter in it. Make a template with

```twig
{% include ['missing_template1', 'missing_template2', 'missing_template3', 'missing_template4', 'missing_template5'] %}
```

And check how many times an exception was thrown by reading the counter. The issue gets exponentially worse if you have nested templates with overrides in each of them.
