### PR TITLE
POC: disable output buffering

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0",
+        "azjezz/psl": "2.0.x"
     },
     "autoload": {
         "psr-4" : {

--- a/example/cache/d5/d50ab5cf4a53125f625aef8b750fe3891fbff83c183df5ad12e3811781643423.php
+++ b/example/cache/d5/d50ab5cf4a53125f625aef8b750fe3891fbff83c183df5ad12e3811781643423.php
@@ -1,0 +1,81 @@
+<?php
+
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Extension\SandboxExtension;
+use Twig\Markup;
+use Twig\Sandbox\SecurityError;
+use Twig\Sandbox\SecurityNotAllowedTagError;
+use Twig\Sandbox\SecurityNotAllowedFilterError;
+use Twig\Sandbox\SecurityNotAllowedFunctionError;
+use Twig\Source;
+use Twig\Template;
+
+/* layout.html.twig */
+class __TwigTemplate_cb71be85d233d3167e83b28319e1477d3231df5ac48b54a2ffe85d288d906f93 extends Template
+{
+    private $source;
+    private $macros = [];
+
+    public function __construct(Environment $env)
+    {
+        parent::__construct($env);
+
+        $this->source = $this->getSourceContext();
+
+        $this->parent = false;
+
+        $this->blocks = [
+            'content' => [$this, 'block_content'],
+        ];
+    }
+
+    protected function doRender(array $context, array $blocks = [])
+    {
+        $macros = $this->macros;
+        $content = '';
+        // line 1
+        $content .="<Layout>
+    <Greeting>Hello, ";
+        // line 2
+        $content .=twig_escape_filter($this->env, twig_get_attribute($this->env, $this->source, twig_get_attribute($this->env, $this->source, ($context["account"] ?? null), "user", [], "any", false, false, false, 2), "username", [], "any", false, false, false, 2), "html", null, true);
+        $content .="</Greeting>
+    
+    ";
+        // line 4
+        $content .= $this->renderBlock('content', $context, $blocks);
+        // line 5
+        $content .="</Layout>
+";
+        return $content;
+    }
+
+    // line 4
+    public function block_content($context, array $blocks = [])
+    {
+        $macros = $this->macros;
+        $content = '';
+        return $content;
+    }
+
+    public function getTemplateName()
+    {
+        return "layout.html.twig";
+    }
+
+    public function isTraitable()
+    {
+        return false;
+    }
+
+    public function getDebugInfo()
+    {
+        return array (  55 => 4,  49 => 5,  47 => 4,  42 => 2,  39 => 1,);
+    }
+
+    public function getSourceContext()
+    {
+        return new Source("", "layout.html.twig", "/home/azjezz/Projects/Twig/example/templates/layout.html.twig");
+    }
+}

--- a/example/cache/f4/f40ae9d7f8cf94532b2d68f48ef90c7273b51eb4207e5233c8df7892c752e7b2.php
+++ b/example/cache/f4/f40ae9d7f8cf94532b2d68f48ef90c7273b51eb4207e5233c8df7892c752e7b2.php
@@ -1,0 +1,91 @@
+<?php
+
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Extension\SandboxExtension;
+use Twig\Markup;
+use Twig\Sandbox\SecurityError;
+use Twig\Sandbox\SecurityNotAllowedTagError;
+use Twig\Sandbox\SecurityNotAllowedFilterError;
+use Twig\Sandbox\SecurityNotAllowedFunctionError;
+use Twig\Source;
+use Twig\Template;
+
+/* user.html.twig */
+class __TwigTemplate_767d3b3faf3da245e2a0ec328ec3095a6a3018dae112f85032fcf2cef9be89b6 extends Template
+{
+    private $source;
+    private $macros = [];
+
+    public function __construct(Environment $env)
+    {
+        parent::__construct($env);
+
+        $this->source = $this->getSourceContext();
+
+        $this->blocks = [
+            'content' => [$this, 'block_content'],
+        ];
+    }
+
+    protected function doGetParent(array $context)
+    {
+        // line 1
+        return "layout.html.twig";
+    }
+
+    protected function doRender(array $context, array $blocks = [])
+    {
+        $macros = $this->macros;
+        $content = '';
+        $this->parent = $this->loadTemplate("layout.html.twig", "user.html.twig", 1);
+        $content .= $this->parent->render($context, array_merge($this->blocks, $blocks));
+        return $content;
+    }
+
+    // line 3
+    public function block_content($context, array $blocks = [])
+    {
+        $macros = $this->macros;
+        $content = '';
+        // line 4
+        $content .="    <Content>
+    ";
+        // line 5
+        $context['_parent'] = $context;
+        $context['_seq'] = twig_ensure_traversable(twig_get_attribute($this->env, $this->source, ($context["account"] ?? null), "things", [], "any", false, false, false, 5));
+        foreach ($context['_seq'] as $context["_key"] => $context["something"]) {
+            // line 6
+            $content .="        <Thing />
+    ";
+        }
+        $_parent = $context['_parent'];
+        unset($context['_seq'], $context['_iterated'], $context['_key'], $context['something'], $context['_parent'], $context['loop']);
+        $context = array_intersect_key($context, $_parent) + $_parent;
+        // line 8
+        $content .="    </Content>
+";
+        return $content;
+    }
+
+    public function getTemplateName()
+    {
+        return "user.html.twig";
+    }
+
+    public function isTraitable()
+    {
+        return false;
+    }
+
+    public function getDebugInfo()
+    {
+        return array (  67 => 8,  60 => 6,  56 => 5,  53 => 4,  48 => 3,  35 => 1,);
+    }
+
+    public function getSourceContext()
+    {
+        return new Source("", "user.html.twig", "/home/azjezz/Projects/Twig/example/templates/user.html.twig");
+    }
+}

--- a/example/main.php
+++ b/example/main.php
@@ -41,9 +41,6 @@ $twig->setCache($cache);
 
 $account = new Account();
 
-echo $twig->render('user.html.twig', ['account' => $account]);
-die();
-
 [$a, $b, $c, $d] = Async\parallel([
     static fn() => $twig->render('user.html.twig', ['account' => $account]),
     static fn() => $twig->render('user.html.twig', ['account' => $account]),

--- a/example/main.php
+++ b/example/main.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Psl\Async;
+use Twig\Cache\FilesystemCache;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+final class User
+{
+    public function getUsername(): string
+    {
+        return 'azjezz';
+    }
+}
+
+final class Account
+{
+    public function getUser(): User
+    {
+        // simulate a lazy query, the database driver is non-blocking
+        Async\sleep(0.02);
+        return new User();
+    }
+
+    public function getThings(): array
+    {
+        // simulate a lazy query, the database driver is non-blocking
+        Async\sleep(0.02);
+        return ['One Thing!', 'Two Things!'];
+    }
+}
+
+$loader = new FilesystemLoader(__DIR__ . '/templates');
+$cache = new FilesystemCache(__DIR__ . '/cache');
+$twig = new Environment($loader);
+$twig->setCache($cache);
+
+$account = new Account();
+
+echo $twig->render('user.html.twig', ['account' => $account]);
+die();
+
+[$a, $b, $c, $d] = Async\parallel([
+    static fn() => $twig->render('user.html.twig', ['account' => $account]),
+    static fn() => $twig->render('user.html.twig', ['account' => $account]),
+    static fn() => $twig->render('user.html.twig', ['account' => $account]),
+    static fn() => $twig->render('user.html.twig', ['account' => $account]),
+]);
+
+var_dump($a, $b, $c, $d);
+
+return 0;

--- a/example/templates/layout.html.twig
+++ b/example/templates/layout.html.twig
@@ -1,0 +1,5 @@
+<Layout>
+    <Greeting>Hello, {{ account.user.username }}</Greeting>
+    
+    {% block content %}{% endblock %}
+</Layout>

--- a/example/templates/user.html.twig
+++ b/example/templates/user.html.twig
@@ -1,0 +1,9 @@
+{% extends 'layout.html.twig' %}
+
+{% block content %}
+    <Content>
+    {% for something in account.things %}
+        <Thing />
+    {% endfor %}
+    </Content>
+{% endblock %}

--- a/src/Node/BlockNode.php
+++ b/src/Node/BlockNode.php
@@ -33,10 +33,12 @@ class BlockNode extends Node
             ->write(sprintf("public function block_%s(\$context, array \$blocks = [])\n", $this->getAttribute('name')), "{\n")
             ->indent()
             ->write("\$macros = \$this->macros;\n")
+            ->write("\$content = '';\n")
         ;
 
         $compiler
             ->subcompile($this->getNode('body'))
+            ->write('return $content;'."\n")
             ->outdent()
             ->write("}\n\n")
         ;

--- a/src/Node/BlockReferenceNode.php
+++ b/src/Node/BlockReferenceNode.php
@@ -30,7 +30,7 @@ class BlockReferenceNode extends Node implements NodeOutputInterface
     {
         $compiler
             ->addDebugInfo($this)
-            ->write(sprintf("\$this->displayBlock('%s', \$context, \$blocks);\n", $this->getAttribute('name')))
+            ->write(sprintf("\$content .= \$this->renderBlock('%s', \$context, \$blocks);\n", $this->getAttribute('name')))
         ;
     }
 }

--- a/src/Node/Expression/BlockReferenceExpression.php
+++ b/src/Node/Expression/BlockReferenceExpression.php
@@ -40,8 +40,9 @@ class BlockReferenceExpression extends AbstractExpression
             if ($this->getAttribute('output')) {
                 $compiler->addDebugInfo($this);
 
+                $compiler->raw('$content .= ');
                 $this
-                    ->compileTemplateCall($compiler, 'displayBlock')
+                    ->compileTemplateCall($compiler, 'renderBlock')
                     ->raw(";\n");
             } else {
                 $this->compileTemplateCall($compiler, 'renderBlock');

--- a/src/Node/Expression/ParentExpression.php
+++ b/src/Node/Expression/ParentExpression.php
@@ -31,7 +31,7 @@ class ParentExpression extends AbstractExpression
         if ($this->getAttribute('output')) {
             $compiler
                 ->addDebugInfo($this)
-                ->write('$this->displayParentBlock(')
+                ->write('$content .= $this->renderParentBlock(')
                 ->string($this->getAttribute('name'))
                 ->raw(", \$context, \$blocks);\n")
             ;

--- a/src/Node/IncludeNode.php
+++ b/src/Node/IncludeNode.php
@@ -58,7 +58,7 @@ class IncludeNode extends Node implements NodeOutputInterface
                 ->write("}\n")
                 ->write(sprintf("if ($%s) {\n", $template))
                 ->indent()
-                ->write(sprintf('$%s->display(', $template))
+                ->write(sprintf('$content .= $%s->render(', $template))
             ;
             $this->addTemplateArguments($compiler);
             $compiler
@@ -67,8 +67,9 @@ class IncludeNode extends Node implements NodeOutputInterface
                 ->write("}\n")
             ;
         } else {
+            $compiler->raw('return ');
             $this->addGetTemplate($compiler);
-            $compiler->raw('->display(');
+            $compiler->raw('->render(');
             $this->addTemplateArguments($compiler);
             $compiler->raw(");\n");
         }

--- a/src/Node/NodeCaptureInterface.php
+++ b/src/Node/NodeCaptureInterface.php
@@ -12,7 +12,7 @@
 namespace Twig\Node;
 
 /**
- * Represents a node that captures any nested displayable nodes.
+ * Represents a node that captures any nested renderable nodes.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Node/NodeOutputInterface.php
+++ b/src/Node/NodeOutputInterface.php
@@ -12,7 +12,7 @@
 namespace Twig\Node;
 
 /**
- * Represents a displayable node in the AST.
+ * Represents a renderable node in the AST.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Node/PrintNode.php
+++ b/src/Node/PrintNode.php
@@ -31,7 +31,7 @@ class PrintNode extends Node implements NodeOutputInterface
     {
         $compiler
             ->addDebugInfo($this)
-            ->write('echo ')
+            ->write('$content .=')
             ->subcompile($this->getNode('expr'))
             ->raw(";\n")
         ;

--- a/src/Node/TextNode.php
+++ b/src/Node/TextNode.php
@@ -30,7 +30,7 @@ class TextNode extends Node implements NodeOutputInterface
     {
         $compiler
             ->addDebugInfo($this)
-            ->write('echo ')
+            ->write('$content .=')
             ->string($this->getAttribute('data'))
             ->raw(";\n")
         ;


### PR DESCRIPTION
closes #3599 

---

I don't think i have enough experience with twig to fix the tests, so some help there would be great :)

This PR removes doDisplay, and replaces it with doRender in the generated templates, the template content is now stored in memory instead of output buffer, which fixes the issue mentioned in #3599 ( colliding buffers ).

This PR also is a BC break, any twig function or extension that previously did "echo" will not work as expected.


Using the script in `example/main.php`, you can see the difference between before and after.

before:

```
string(279) "<Layout>
    <Greeting>Hello, azjezz</Greeting>

        <Content>
    azjezz</Greeting>

        <Content>
    azjezz</Greeting>

        <Content>
    azjezz</Greeting>

        <Content>
            <Thing />
            <Thing />
        </Content>
</Layout>
"
string(99) "<Layout>
    <Greeting>Hello,         <Thing />
            <Thing />
        </Content>
</Layout>
"
string(99) "<Layout>
    <Greeting>Hello,         <Thing />
            <Thing />
        </Content>
</Layout>
"
string(99) "<Layout>
    <Greeting>Hello,         <Thing />
            <Thing />
        </Content>
</Layout>
"

```

after:

```
string(144) "<Layout>
    <Greeting>Hello, azjezz</Greeting>

        <Content>
            <Thing />
            <Thing />
        </Content>
</Layout>
"
string(144) "<Layout>
    <Greeting>Hello, azjezz</Greeting>

        <Content>
            <Thing />
            <Thing />
        </Content>
</Layout>
"
string(144) "<Layout>
    <Greeting>Hello, azjezz</Greeting>

        <Content>
            <Thing />
            <Thing />
        </Content>
</Layout>
"
string(144) "<Layout>
    <Greeting>Hello, azjezz</Greeting>

        <Content>
            <Thing />
            <Thing />
        </Content>
</Layout>
"
```