### PR TITLE
Hashing is not necessary to generate unique variable names during compilation

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -238,7 +238,7 @@ class Compiler
 
     public function getVarName()
     {
-        return sprintf('__internal_%s', hash('sha256', __METHOD__.$this->varNameSalt++));
+        return sprintf('__internal_compile_%d', $this->varNameSalt++);
     }
 }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -56,7 +56,7 @@ class Parser
 
     public function getVarName()
     {
-        return sprintf('__internal_%s', hash('sha256', __METHOD__.$this->stream->getSourceContext()->getCode().$this->varNameSalt++));
+        return sprintf('__internal_parse_%d', $this->varNameSalt++);
     }
 
     public function parse(TokenStream $stream, $test = null, $dropNeedle = false)

--- a/src/Profiler/NodeVisitor/ProfilerNodeVisitor.php
+++ b/src/Profiler/NodeVisitor/ProfilerNodeVisitor.php
@@ -28,10 +28,12 @@ use Twig\Profiler\Profile;
 final class ProfilerNodeVisitor extends AbstractNodeVisitor
 {
     private $extensionName;
+    private $varName;
 
     public function __construct(string $extensionName)
     {
         $this->extensionName = $extensionName;
+        $this->varName = sprintf('__internal_%s', hash('sha256', $extensionName));
     }
 
     protected function doEnterNode(Node $node, Environment $env)
@@ -42,31 +44,23 @@ final class ProfilerNodeVisitor extends AbstractNodeVisitor
     protected function doLeaveNode(Node $node, Environment $env)
     {
         if ($node instanceof ModuleNode) {
-            $varName = $this->getVarName();
-            $node->setNode('display_start', new Node([new EnterProfileNode($this->extensionName, Profile::TEMPLATE, $node->getTemplateName(), $varName), $node->getNode('display_start')]));
-            $node->setNode('display_end', new Node([new LeaveProfileNode($varName), $node->getNode('display_end')]));
+            $node->setNode('display_start', new Node([new EnterProfileNode($this->extensionName, Profile::TEMPLATE, $node->getTemplateName(), $this->varName), $node->getNode('display_start')]));
+            $node->setNode('display_end', new Node([new LeaveProfileNode($this->varName), $node->getNode('display_end')]));
         } elseif ($node instanceof BlockNode) {
-            $varName = $this->getVarName();
             $node->setNode('body', new BodyNode([
-                new EnterProfileNode($this->extensionName, Profile::BLOCK, $node->getAttribute('name'), $varName),
+                new EnterProfileNode($this->extensionName, Profile::BLOCK, $node->getAttribute('name'), $this->varName),
                 $node->getNode('body'),
-                new LeaveProfileNode($varName),
+                new LeaveProfileNode($this->varName),
             ]));
         } elseif ($node instanceof MacroNode) {
-            $varName = $this->getVarName();
             $node->setNode('body', new BodyNode([
-                new EnterProfileNode($this->extensionName, Profile::MACRO, $node->getAttribute('name'), $varName),
+                new EnterProfileNode($this->extensionName, Profile::MACRO, $node->getAttribute('name'), $this->varName),
                 $node->getNode('body'),
-                new LeaveProfileNode($varName),
+                new LeaveProfileNode($this->varName),
             ]));
         }
 
         return $node;
-    }
-
-    private function getVarName(): string
-    {
-        return sprintf('__internal_%s', hash('sha256', $this->extensionName));
     }
 
     public function getPriority()


### PR DESCRIPTION
Trying to optimize calls to `hash` function (#3588), I found that some calls are made during compilation that are not necessary at all.

According to the last commits on this functions (57ff88255ef35ad8da325d0cb0bf140e653b132c & 6ab5fe9b8fd52f810fd902652659605b5fcf39a9), the internal variable names must be unique and deterministic. Using a simple sequence is enough.

This avoid CPU cycles during compilation. Which should not have any impact on production; but still interesting for dev&test.