### PR TITLE
Store TemplateClass in compiled includes

### DIFF
--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -156,7 +156,8 @@ class ModuleNode extends Node
                 ->write("use Twig\Sandbox\SecurityNotAllowedFilterError;\n")
                 ->write("use Twig\Sandbox\SecurityNotAllowedFunctionError;\n")
                 ->write("use Twig\Source;\n")
-                ->write("use Twig\Template;\n\n")
+                ->write("use Twig\Template;\n")
+                ->write("use Twig\TemplateClass;\n\n")
             ;
         }
         $compiler

--- a/src/Template.php
+++ b/src/Template.php
@@ -321,6 +321,10 @@ abstract class Template
                 return $template;
             }
 
+            if ($template instanceof TemplateClass) {
+                return $this->env->loadClass($template->class, $template->name, $index);
+            }
+
             if ($template === $this->getTemplateName()) {
                 $class = static::class;
                 if (false !== $pos = strrpos($class, '___', -1)) {

--- a/src/TemplateClass.php
+++ b/src/TemplateClass.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Twig;
+
+/**
+ * Template name with its pre-generated class name.
+ *
+ * @internal
+ */
+class TemplateClass
+{
+    /**
+     * @readonly
+     */
+    public $name;
+
+    /**
+     * @readonly
+     */
+    public $class;
+
+    /**
+     * @param string $class
+     * @param string $name
+     */
+    public function __construct($class, $name)
+    {
+        $this->class = $class;
+        $this->name = $name;
+    }
+}

--- a/tests/Node/ModuleTest.php
+++ b/tests/Node/ModuleTest.php
@@ -71,6 +71,7 @@ use Twig\Sandbox\SecurityNotAllowedFilterError;
 use Twig\Sandbox\SecurityNotAllowedFunctionError;
 use Twig\Source;
 use Twig\Template;
+use Twig\TemplateClass;
 
 /* foo.twig */
 class __TwigTemplate_%x extends \Twig\Template
@@ -104,7 +105,7 @@ class __TwigTemplate_%x extends \Twig\Template
 
     public function getDebugInfo()
     {
-        return array (  37 => 1,);
+        return array (  38 => 1,);
     }
 
     public function getSourceContext()
@@ -135,6 +136,7 @@ use Twig\Sandbox\SecurityNotAllowedFilterError;
 use Twig\Sandbox\SecurityNotAllowedFunctionError;
 use Twig\Source;
 use Twig\Template;
+use Twig\TemplateClass;
 
 /* foo.twig */
 class __TwigTemplate_%x extends \Twig\Template
@@ -180,7 +182,7 @@ class __TwigTemplate_%x extends \Twig\Template
 
     public function getDebugInfo()
     {
-        return array (  43 => 1,  41 => 2,  34 => 1,);
+        return array (  44 => 1,  42 => 2,  35 => 1,);
     }
 
     public function getSourceContext()
@@ -216,6 +218,7 @@ use Twig\Sandbox\SecurityNotAllowedFilterError;
 use Twig\Sandbox\SecurityNotAllowedFunctionError;
 use Twig\Source;
 use Twig\Template;
+use Twig\TemplateClass;
 
 /* foo.twig */
 class __TwigTemplate_%x extends \Twig\Template
@@ -260,7 +263,7 @@ class __TwigTemplate_%x extends \Twig\Template
 
     public function getDebugInfo()
     {
-        return array (  43 => 2,  41 => 4,  34 => 2,);
+        return array (  44 => 2,  42 => 4,  35 => 2,);
     }
 
     public function getSourceContext()


### PR DESCRIPTION
Trying to optimize calls to `hash` function (#3588), I found that the template classes could be cached inside the calling templates.

Example with the following template
```twig
{% include '@ResponsiveFront/home/views/metas.html.twig' with { Metadata } only %}
```

Compiled version:
```php
$this->loadTemplate(new TemplateClass("__TwigTemplate_c834197862571e35dc19b42e4a40c8f9826e712d24a46a6b8d08ffee77eab1bc", "@ResponsiveFront/home/views/metas.html.twig"), "@ResponsiveFront/home/views/home.html.twig", 22)->display(twig_to_array(["Metadata" => ($context["Metadata"] ?? null)]));
```

Previous compiled version:
```php
$this->loadTemplate("@ResponsiveFront/home/views/metas.html.twig", "@ResponsiveFront/home/views/home.html.twig", 22)->display(twig_to_array(["Metadata" => ($context["Metadata"] ?? null)]));
```

If the direction is OK, I'd continue with all other types of template calls (extends, embed, use, macro ...)