### PR TITLE
Allow symfony/translation-contracts:^3

### DIFF
--- a/extra/string-extra/composer.json
+++ b/extra/string-extra/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/string": "^5.0|^6.0",
-        "symfony/translation-contracts": "^1.1|^2",
+        "symfony/translation-contracts": "^1.1|^2|^3",
         "twig/twig": "^2.7|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
However, 
I am just wondering why this dependency is required since it's not used anywhere in `twig/string-extra`? Or I am wrong ?

Closing https://github.com/twigphp/Twig/issues/3607