### PR TITLE
Add full stacktrace log to null $str given to twig_replace_filter

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -312,6 +312,7 @@ namespace {
     use Twig\Source;
     use Twig\Template;
     use Twig\TemplateWrapper;
+    use Twig\Util\StacktraceLogger;
 
 /**
  * Cycles over a value.
@@ -514,6 +515,9 @@ function twig_replace_filter($str, $from)
 {
     if (!twig_test_iterable($from)) {
         throw new RuntimeError(sprintf('The "replace" filter expects an array or "Traversable" as replace values, got "%s".', \is_object($from) ? \get_class($from) : \gettype($from)));
+    }
+    if (!is_string($str)) {
+        StacktraceLogger::log('PHP Deprecated: $str in twig_replace_filter should be a string. ' . var_export($str, true) . ' given');
     }
 
     return strtr($str, twig_to_array($from));

--- a/src/Util/StacktraceLogger.php
+++ b/src/Util/StacktraceLogger.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Util;
+
+/**
+ * @author Koala Yeung <koalay@gmail.com>
+ */
+final class StacktraceLogger
+{
+    /**
+     * Log message with stacktrace to server log.
+     *
+     * With error_log, tell server admin something they need to know with full stacktrace.
+     *
+     * @param string  $message  The message to log with the backtrace.
+     * @param integer $offset   The number of top layers of the stack to ignore.
+     * @param integer $options  The $options parameter passed to debug_backtrace().
+     * @param integer $limit    The $limit parameter passed to debug_backtrace().
+     *
+     * @return void
+     */
+    public static function log(string $message, int $offset = 0, int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT, int $limit = 0)
+    {
+        // generate stack, then remove the layer created from
+        // this function.
+        if ($limit !== 0) $limit += 1;
+        $stack = \debug_backtrace($options, $limit);
+        if ($offset > sizeof($stack)) return '';
+        array_splice($stack, 0, $offset+1);
+
+        // format the message.
+        $backtrace_str = StacktraceLogger::formatBacktrace($stack);
+        $top = array_shift($stack);
+        error_log("{$message} in {$top['file']}:{$top['line']}\nStacktrace:\n{$backtrace_str}");
+    }
+
+    /**
+     * Fomrats a debug_backtrace output.
+     *
+     * Mimicing the output of debug_print_backtrace() without actually calling it.
+     *
+     * @param array $stack Supposedly the debug_backtrace() output.
+     *
+     * @return string The formatted message.
+     */
+    private static function formatBacktrace(array $stack): string
+    {
+        return implode("\n", array_map(function ($num, $layer) {
+            return "#{$num} {$layer['function']}() called at [{$layer['file']}:{$layer['line']}]";
+        }, array_keys($stack), array_values($stack))) ?? '';
+    }
+}


### PR DESCRIPTION
Another take on #3557.

* Add a utility class to log message to server log with full stacktrace for debug.
* Use StacktraceLogger to log null or other non-string value given to $str in twig_replace_filter, with full stacktrace for debug.

This is an attempt to address PHP future plan [to make passing null to string parameter as a TypeError](https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg). Deprecated messages are generated in 8.1 for the "bad" cases.

Because the nature of twig extensions, the error is far too deep in the library when the deprecated message occur. And since deprecated message does not have stacktrace, the apparent log message is unhelpful for tracking down the culprit(s) in template file.