### PR TITLE
html_attr: do not escape colons

### DIFF
--- a/src/Runtime/EscaperRuntime.php
+++ b/src/Runtime/EscaperRuntime.php
@@ -259,7 +259,7 @@ final class EscaperRuntime implements RuntimeExtensionInterface
                     throw new RuntimeError('The string to escape is not a valid UTF-8 string.');
                 }
 
-                $string = preg_replace_callback('#[^a-zA-Z0-9,\.\-_]#Su', function ($matches) {
+                $string = preg_replace_callback('#[^a-zA-Z0-9,\.\-_:]#Su', function ($matches) {
                     /**
                      * This function is adapted from code coming from Zend Framework.
                      *

--- a/tests/Runtime/EscaperRuntimeTest.php
+++ b/tests/Runtime/EscaperRuntimeTest.php
@@ -38,6 +38,7 @@ class EscaperRuntimeTest extends TestCase
         '.' => '.',
         '-' => '-',
         '_' => '_',
+        ':' => ':',
         /* Basic alnums excluded */
         'a' => 'a',
         'A' => 'A',
@@ -300,7 +301,7 @@ class EscaperRuntimeTest extends TestCase
 
     public function testHtmlAttributeEscapingEscapesOwaspRecommendedRanges()
     {
-        $immune = [',', '.', '-', '_']; // Exceptions to escaping ranges
+        $immune = [',', '.', '-', '_', ':']; // Exceptions to escaping ranges
         for ($chr = 0; $chr < 0xFF; ++$chr) {
             if ($chr >= 0x30 && $chr <= 0x39
             || $chr >= 0x41 && $chr <= 0x5A


### PR DESCRIPTION
Is it necessary to escape the `:` in `html_attr` context?

For example in this code:
```twig
{% for key, value in attributes %}
    {{ key|escape('html_attr') }}="{{ value }}"
{% endfor %}
```

I think it should be allowed to use attribute keys like `v-on:submit.prevent`.