### PR TITLE
Allow null for `nl2br`

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -213,7 +213,7 @@ final class CoreExtension extends AbstractExtension
             // formatting filters
             new TwigFilter('date', 'twig_date_format_filter', ['needs_environment' => true]),
             new TwigFilter('date_modify', 'twig_date_modify_filter', ['needs_environment' => true]),
-            new TwigFilter('format', 'sprintf'),
+            new TwigFilter('format', 'twig_sprintf'),
             new TwigFilter('replace', 'twig_replace_filter'),
             new TwigFilter('number_format', 'twig_number_format_filter', ['needs_environment' => true]),
             new TwigFilter('abs', 'abs'),
@@ -229,9 +229,9 @@ final class CoreExtension extends AbstractExtension
             new TwigFilter('capitalize', 'twig_capitalize_string_filter', ['needs_environment' => true]),
             new TwigFilter('upper', 'twig_upper_filter', ['needs_environment' => true]),
             new TwigFilter('lower', 'twig_lower_filter', ['needs_environment' => true]),
-            new TwigFilter('striptags', 'strip_tags'),
+            new TwigFilter('striptags', 'twig_striptags'),
             new TwigFilter('trim', 'twig_trim_filter'),
-            new TwigFilter('nl2br', 'nl2br', ['pre_escape' => 'html', 'is_safe' => ['html']]),
+            new TwigFilter('nl2br', 'twig_nl2br', ['pre_escape' => 'html', 'is_safe' => ['html']]),
             new TwigFilter('spaceless', 'twig_spaceless', ['is_safe' => ['html']]),
 
             // array helpers
@@ -479,6 +479,19 @@ function twig_date_modify_filter(Environment $env, $date, $modifier)
     $date = twig_date_converter($env, $date, false);
 
     return $date->modify($modifier);
+}
+
+/**
+ * Returns a formatted string.
+ *
+ * @param string|null $format
+ * @param ...$values
+ *
+ * @return string
+ */
+function twig_sprintf($format, ...$values)
+{
+    return sprintf($format ?? '', ...$values);
 }
 
 /**
@@ -997,6 +1010,18 @@ function twig_trim_filter($string, $characterMask = null, $side = 'both')
 }
 
 /**
+ * Inserts HTML line breaks before all newlines in a string.
+ *
+ * @param string|null $string
+ *
+ * @return string
+ */
+function twig_nl2br($string)
+{
+    return nl2br($string ?? '');
+}
+
+/**
  * Removes whitespaces between HTML tags.
  *
  * @param string|null $string
@@ -1078,6 +1103,19 @@ function twig_upper_filter(Environment $env, $string)
 function twig_lower_filter(Environment $env, $string)
 {
     return mb_strtolower($string ?? '', $env->getCharset());
+}
+
+/**
+ * Strips HTML and PHP tags from a string.
+ *
+ * @param string|null $string
+ * @param string[]|string|null $string
+ *
+ * @return string
+ */
+function twig_striptags($string, $allowable_tags = null)
+{
+    return strip_tags($string ?? '', $allowable_tags);
 }
 
 /**

--- a/tests/Fixtures/filters/format.test
+++ b/tests/Fixtures/filters/format.test
@@ -2,7 +2,11 @@
 "format" filter
 --TEMPLATE--
 {{ string|format(foo, 3) }}
+*{{ ""|format(foo, 3) }}*
+*{{ null|format(foo, 3) }}*
 --DATA--
 return ['string' => '%s/%d', 'foo' => 'bar']
 --EXPECT--
 bar/3
+**
+**

--- a/tests/Fixtures/filters/nl2br.test
+++ b/tests/Fixtures/filters/nl2br.test
@@ -3,6 +3,8 @@
 --TEMPLATE--
 {{ "I like Twig.\nYou will like it too.\n\nEverybody like it!"|nl2br }}
 {{ text|nl2br }}
+*{{ ''|nl2br }}*
+*{{ null|nl2br }}*
 --DATA--
 return ['text' => "If you have some <strong>HTML</strong>\nit will be escaped."]
 --EXPECT--
@@ -12,3 +14,5 @@ You will like it too.<br />
 Everybody like it!
 If you have some &lt;strong&gt;HTML&lt;/strong&gt;<br />
 it will be escaped.
+**
+**

--- a/tests/Fixtures/filters/striptags.test
+++ b/tests/Fixtures/filters/striptags.test
@@ -1,0 +1,16 @@
+--TEST--
+"striptags" filter
+--TEMPLATE--
+{{ "Hello, <strong>World</strong>!"|striptags }}
+{{ text|striptags }}
+{{ text|striptags('<strong>')|raw }}
+*{{ ''|striptags }}*
+*{{ null|striptags }}*
+--DATA--
+return ['text' => "<p>Hello, <strong>World</strong>!</p>"]
+--EXPECT--
+Hello, World!
+Hello, World!
+Hello, <strong>World</strong>!
+**
+**

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -229,7 +229,7 @@ class TwigTestExtension extends AbstractExtension
     {
         // not secure if $value contains html tags (not only entities)
         // don't use
-        return str_replace("\n", "$sep\n", $value);
+        return str_replace("\n", "$sep\n", $value ?? '');
     }
 
     public function dynamic_path($element, $item)


### PR DESCRIPTION
Same as https://github.com/twigphp/Twig/pull/3617
Fixes `Passing null to parameter #1 ($string) of type string is deprecated` on PHP 8.1