### PR TITLE
[twig-extra-bundle] only use Commonmark extensions if markdown enabled

### DIFF
--- a/extra/twig-extra-bundle/DependencyInjection/TwigExtraExtension.php
+++ b/extra/twig-extra-bundle/DependencyInjection/TwigExtraExtension.php
@@ -36,11 +36,11 @@ class TwigExtraExtension extends Extension
         foreach (array_keys(Extensions::getClasses()) as $extension) {
             if ($this->isConfigEnabled($container, $config[$extension])) {
                 $loader->load($extension.'.php');
-            }
-        }
 
-        if (\class_exists(CommonMarkConverter::class)) {
-            $loader->load('markdown_league.php');
+                if ('markdown' === $extension && \class_exists(CommonMarkConverter::class)) {
+                    $loader->load('markdown_league.php');
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The feature introduced by #3559 should only be enabled if `markdown-extra` is enabled/available.

Fixes #3620.