### PR TITLE
[extra-bundle] add integration tests

### DIFF
--- a/extra/twig-extra-bundle/.gitignore
+++ b/extra/twig-extra-bundle/.gitignore
@@ -1,4 +1,5 @@
 vendor/
+var/
 composer.lock
 phpunit.xml
 .phpunit.result.cache

--- a/extra/twig-extra-bundle/Tests/Fixture/Kernel.php
+++ b/extra/twig-extra-bundle/Tests/Fixture/Kernel.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Twig\Extra\TwigExtraBundle\Tests\Fixture;
+
+use League\CommonMark\Extension\Strikethrough\StrikethroughExtension;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Twig\Extra\TwigExtraBundle\TwigExtraBundle;
+
+class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        yield new FrameworkBundle();
+        yield new TwigBundle();
+        yield new TwigExtraBundle();
+    }
+
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
+    {
+        $c->loadFromExtension('framework', [
+            'secret' => 'S3CRET',
+            'test' => true,
+        ]);
+
+        $c->loadFromExtension('twig', [
+            'default_path' => __DIR__.'/views',
+        ]);
+
+        $c->register(StrikethroughExtension::class)->addTag('twig.markdown.league_extension');
+    }
+
+    protected function configureRoutes($routes): void
+    {
+    }
+}

--- a/extra/twig-extra-bundle/Tests/Fixture/views/markdown_to_html.html.twig
+++ b/extra/twig-extra-bundle/Tests/Fixture/views/markdown_to_html.html.twig
@@ -1,0 +1,3 @@
+{% apply markdown_to_html %}
+# Hello ~~World~~
+{% endapply %}

--- a/extra/twig-extra-bundle/Tests/IntegrationTest.php
+++ b/extra/twig-extra-bundle/Tests/IntegrationTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Twig\Extra\TwigExtraBundle\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class IntegrationTest extends KernelTestCase
+{
+    public function testCommonMarkRendering()
+    {
+        self::bootKernel();
+
+        $container = method_exists(self::class, 'getContainer') ? self::getContainer() : self::$container;
+        $rendered = $container->get('twig')->render('markdown_to_html.html.twig');
+
+        $this->assertStringContainsString('<h1>Hello <del>World</del></h1>', $rendered);
+    }
+}

--- a/extra/twig-extra-bundle/phpunit.xml.dist
+++ b/extra/twig-extra-bundle/phpunit.xml.dist
@@ -10,6 +10,8 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <server name="KERNEL_CLASS" value="Twig\Extra\TwigExtraBundle\Tests\Fixture\Kernel" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
Should hopefully prevent a repeat of the #3559 fiasco ;)

I chose to just add integration tests for markdown (and registering custom extensions). The others are pretty straight forward but can add tests for these if desired.