### PR TITLE
Rename variables used in map method

### DIFF
--- a/doc/filters/map.rst
+++ b/doc/filters/map.rst
@@ -27,7 +27,7 @@ The arrow function also receives the key as a second argument:
         "Alice": "Dupond",
     } %}
 
-    {{ people|map((last, first) => "#{first} #{last}")|join(', ') }}
+    {{ people|map((value, key) => "#{value} #{key}")|join(', ') }}
     {# outputs Bob Smith, Alice Dupond #}
 
 Note that the arrow function has access to the current context.


### PR DESCRIPTION
As most people (including me) are lazy people to read text and mostly looks just at the code. Using `key` and `value` as variable make the map faster to understand which argument is which one :) 