### PR TITLE
Fix call to deprecated "convertToHtml" method

### DIFF
--- a/extra/markdown-extra/LeagueMarkdown.php
+++ b/extra/markdown-extra/LeagueMarkdown.php
@@ -16,14 +16,20 @@ use League\CommonMark\CommonMarkConverter;
 class LeagueMarkdown implements MarkdownInterface
 {
     private $converter;
+    private $legacySupport;
 
     public function __construct(CommonMarkConverter $converter = null)
     {
         $this->converter = $converter ?: new CommonMarkConverter();
+        $this->legacySupport = !method_exists($this->converter, 'convert');
     }
 
     public function convert(string $body): string
     {
-        return $this->converter->convertToHtml($body);
+        if ($this->legacySupport) {
+            return $this->converter->convertToHtml($body);
+        }
+
+        return $this->converter->convert($body);
     }
 }


### PR DESCRIPTION
note: We can not rely on the new interface `ConverterInterface` because this interface already existed in [version 1.0](https://github.com/thephpleague/commonmark/blob/1.0/src/ConverterInterface.php) 