### PR TITLE
Added token type and value to error message

### DIFF
--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -488,7 +488,7 @@ class ExpressionParser
                     }
                 }
             } else {
-                throw new SyntaxError('Expected name or number.', $lineno, $stream->getSourceContext());
+                throw new SyntaxError(sprintf('Expected name or number, got value "%s" of type %s.', $token->getValue(), Token::typeToEnglish($token->getType())), $lineno, $stream->getSourceContext());
             }
 
             if ($node instanceof NameExpression && null !== $this->parser->getImportedSymbol('template', $node->getAttribute('name'))) {


### PR DESCRIPTION
Added the given token type and value to the error message in case that the token after '.' is neither a name  nor a number.

I think it helps a lot to have more expressive verbose error messages (specially in this case with the dot `.` operator, since it's the concatenation operator in PHP and developers may mistakenly use it instead of tilde `~` operator which is the concatenation operator in Twig.

I also think that it's better to extract the error message generating script out of `TokenStream::expect` (the code I included at the end of this message) and make it a new method with more general flexibility to be able to use the same method with all these scenarios but I'm not sure if this level of abstraction meets the Twig source policy so I didn't try to do that.

```
sprintf('%sUnexpected token "%s"%s ("%s" expected%s).',
                $message ? $message.'. ' : '',
                Token::typeToEnglish($token->getType()),
                $token->getValue() ? sprintf(' of value "%s"', $token->getValue()) : '',
                Token::typeToEnglish($type), $value ? sprintf(' with value "%s"', $value) : '')
```