### PR TITLE
POC - Opt - Add leading slash before function invocation to speed up resolving

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -175,65 +175,65 @@ final class CoreExtension extends AbstractExtension
     {
         return [
             // formatting filters
-            new TwigFilter('date', 'twig_date_format_filter', ['needs_environment' => true]),
-            new TwigFilter('date_modify', 'twig_date_modify_filter', ['needs_environment' => true]),
-            new TwigFilter('format', 'twig_sprintf'),
-            new TwigFilter('replace', 'twig_replace_filter'),
-            new TwigFilter('number_format', 'twig_number_format_filter', ['needs_environment' => true]),
-            new TwigFilter('abs', 'abs'),
-            new TwigFilter('round', 'twig_round'),
+            new TwigFilter('date', '\twig_date_format_filter', ['needs_environment' => true]),
+            new TwigFilter('date_modify', '\twig_date_modify_filter', ['needs_environment' => true]),
+            new TwigFilter('format', '\twig_sprintf'),
+            new TwigFilter('replace', '\twig_replace_filter'),
+            new TwigFilter('number_format', '\twig_number_format_filter', ['needs_environment' => true]),
+            new TwigFilter('abs', '\abs'),
+            new TwigFilter('round', '\twig_round'),
 
             // encoding
-            new TwigFilter('url_encode', 'twig_urlencode_filter'),
-            new TwigFilter('json_encode', 'json_encode'),
-            new TwigFilter('convert_encoding', 'twig_convert_encoding'),
+            new TwigFilter('url_encode', '\twig_urlencode_filter'),
+            new TwigFilter('json_encode', '\json_encode'),
+            new TwigFilter('convert_encoding', '\twig_convert_encoding'),
 
             // string filters
-            new TwigFilter('title', 'twig_title_string_filter', ['needs_environment' => true]),
-            new TwigFilter('capitalize', 'twig_capitalize_string_filter', ['needs_environment' => true]),
-            new TwigFilter('upper', 'twig_upper_filter', ['needs_environment' => true]),
-            new TwigFilter('lower', 'twig_lower_filter', ['needs_environment' => true]),
-            new TwigFilter('striptags', 'twig_striptags'),
-            new TwigFilter('trim', 'twig_trim_filter'),
-            new TwigFilter('nl2br', 'twig_nl2br', ['pre_escape' => 'html', 'is_safe' => ['html']]),
-            new TwigFilter('spaceless', 'twig_spaceless', ['is_safe' => ['html']]),
+            new TwigFilter('title', '\twig_title_string_filter', ['needs_environment' => true]),
+            new TwigFilter('capitalize', '\twig_capitalize_string_filter', ['needs_environment' => true]),
+            new TwigFilter('upper', '\twig_upper_filter', ['needs_environment' => true]),
+            new TwigFilter('lower', '\twig_lower_filter', ['needs_environment' => true]),
+            new TwigFilter('striptags', '\twig_striptags'),
+            new TwigFilter('trim', '\twig_trim_filter'),
+            new TwigFilter('nl2br', '\twig_nl2br', ['pre_escape' => 'html', 'is_safe' => ['html']]),
+            new TwigFilter('spaceless', '\twig_spaceless', ['is_safe' => ['html']]),
 
             // array helpers
-            new TwigFilter('join', 'twig_join_filter'),
-            new TwigFilter('split', 'twig_split_filter', ['needs_environment' => true]),
-            new TwigFilter('sort', 'twig_sort_filter', ['needs_environment' => true]),
-            new TwigFilter('merge', 'twig_array_merge'),
-            new TwigFilter('batch', 'twig_array_batch'),
-            new TwigFilter('column', 'twig_array_column'),
-            new TwigFilter('filter', 'twig_array_filter', ['needs_environment' => true]),
-            new TwigFilter('map', 'twig_array_map', ['needs_environment' => true]),
-            new TwigFilter('reduce', 'twig_array_reduce', ['needs_environment' => true]),
+            new TwigFilter('join', '\twig_join_filter'),
+            new TwigFilter('split', '\twig_split_filter', ['needs_environment' => true]),
+            new TwigFilter('sort', '\twig_sort_filter', ['needs_environment' => true]),
+            new TwigFilter('merge', '\twig_array_merge'),
+            new TwigFilter('batch', '\twig_array_batch'),
+            new TwigFilter('column', '\twig_array_column'),
+            new TwigFilter('filter', '\twig_array_filter', ['needs_environment' => true]),
+            new TwigFilter('map', '\twig_array_map', ['needs_environment' => true]),
+            new TwigFilter('reduce', '\twig_array_reduce', ['needs_environment' => true]),
 
             // string/array filters
-            new TwigFilter('reverse', 'twig_reverse_filter', ['needs_environment' => true]),
-            new TwigFilter('length', 'twig_length_filter', ['needs_environment' => true]),
-            new TwigFilter('slice', 'twig_slice', ['needs_environment' => true]),
-            new TwigFilter('first', 'twig_first', ['needs_environment' => true]),
-            new TwigFilter('last', 'twig_last', ['needs_environment' => true]),
+            new TwigFilter('reverse', '\twig_reverse_filter', ['needs_environment' => true]),
+            new TwigFilter('length', '\twig_length_filter', ['needs_environment' => true]),
+            new TwigFilter('slice', '\twig_slice', ['needs_environment' => true]),
+            new TwigFilter('first', '\twig_first', ['needs_environment' => true]),
+            new TwigFilter('last', '\twig_last', ['needs_environment' => true]),
 
             // iteration and runtime
-            new TwigFilter('default', '_twig_default_filter', ['node_class' => DefaultFilter::class]),
-            new TwigFilter('keys', 'twig_get_array_keys_filter'),
+            new TwigFilter('default', '\_twig_default_filter', ['node_class' => DefaultFilter::class]),
+            new TwigFilter('keys', '\twig_get_array_keys_filter'),
         ];
     }
 
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('max', 'max'),
-            new TwigFunction('min', 'min'),
-            new TwigFunction('range', 'range'),
-            new TwigFunction('constant', 'twig_constant'),
-            new TwigFunction('cycle', 'twig_cycle'),
-            new TwigFunction('random', 'twig_random', ['needs_environment' => true]),
-            new TwigFunction('date', 'twig_date_converter', ['needs_environment' => true]),
-            new TwigFunction('include', 'twig_include', ['needs_environment' => true, 'needs_context' => true, 'is_safe' => ['all']]),
-            new TwigFunction('source', 'twig_source', ['needs_environment' => true, 'is_safe' => ['all']]),
+            new TwigFunction('max', '\max'),
+            new TwigFunction('min', '\min'),
+            new TwigFunction('range', '\range'),
+            new TwigFunction('constant', '\twig_constant'),
+            new TwigFunction('cycle', '\twig_cycle'),
+            new TwigFunction('random', '\twig_random', ['needs_environment' => true]),
+            new TwigFunction('date', '\twig_date_converter', ['needs_environment' => true]),
+            new TwigFunction('include', '\twig_include', ['needs_environment' => true, 'needs_context' => true, 'is_safe' => ['all']]),
+            new TwigFunction('source', '\twig_source', ['needs_environment' => true, 'is_safe' => ['all']]),
         ];
     }
 
@@ -248,8 +248,8 @@ final class CoreExtension extends AbstractExtension
             new TwigTest('null', null, ['node_class' => NullTest::class]),
             new TwigTest('divisible by', null, ['node_class' => DivisiblebyTest::class, 'one_mandatory_argument' => true]),
             new TwigTest('constant', null, ['node_class' => ConstantTest::class]),
-            new TwigTest('empty', 'twig_test_empty'),
-            new TwigTest('iterable', 'twig_test_iterable'),
+            new TwigTest('empty', '\twig_test_empty'),
+            new TwigTest('iterable', '\twig_test_iterable'),
         ];
     }
 

--- a/src/Extension/DebugExtension.php
+++ b/src/Extension/DebugExtension.php
@@ -27,7 +27,7 @@ final class DebugExtension extends AbstractExtension
         ;
 
         return [
-            new TwigFunction('dump', 'twig_var_dump', ['is_safe' => $isDumpOutputHtmlSafe ? ['html'] : [], 'needs_context' => true, 'needs_environment' => true, 'is_variadic' => true]),
+            new TwigFunction('dump', '\twig_var_dump', ['is_safe' => $isDumpOutputHtmlSafe ? ['html'] : [], 'needs_context' => true, 'needs_environment' => true, 'is_variadic' => true]),
         ];
     }
 }

--- a/src/Node/Expression/Binary/EndsWithBinary.php
+++ b/src/Node/Expression/Binary/EndsWithBinary.php
@@ -20,11 +20,11 @@ class EndsWithBinary extends AbstractBinary
         $left = $compiler->getVarName();
         $right = $compiler->getVarName();
         $compiler
-            ->raw(sprintf('(is_string($%s = ', $left))
+            ->raw(sprintf('(\is_string($%s = ', $left))
             ->subcompile($this->getNode('left'))
-            ->raw(sprintf(') && is_string($%s = ', $right))
+            ->raw(sprintf(') && \is_string($%s = ', $right))
             ->subcompile($this->getNode('right'))
-            ->raw(sprintf(') && (\'\' === $%2$s || $%2$s === substr($%1$s, -strlen($%2$s))))', $left, $right))
+            ->raw(sprintf(') && (\'\' === $%2$s || $%2$s === \substr($%1$s, -\strlen($%2$s))))', $left, $right))
         ;
     }
 

--- a/src/Node/Expression/Binary/EqualBinary.php
+++ b/src/Node/Expression/Binary/EqualBinary.php
@@ -24,7 +24,7 @@ class EqualBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('(0 === twig_compare(')
+            ->raw('(0 === \twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))

--- a/src/Node/Expression/Binary/FloorDivBinary.php
+++ b/src/Node/Expression/Binary/FloorDivBinary.php
@@ -17,7 +17,7 @@ class FloorDivBinary extends AbstractBinary
 {
     public function compile(Compiler $compiler): void
     {
-        $compiler->raw('(int) floor(');
+        $compiler->raw('(int) \floor(');
         parent::compile($compiler);
         $compiler->raw(')');
     }

--- a/src/Node/Expression/Binary/GreaterBinary.php
+++ b/src/Node/Expression/Binary/GreaterBinary.php
@@ -24,7 +24,7 @@ class GreaterBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('(1 === twig_compare(')
+            ->raw('(1 === \twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))

--- a/src/Node/Expression/Binary/GreaterEqualBinary.php
+++ b/src/Node/Expression/Binary/GreaterEqualBinary.php
@@ -24,7 +24,7 @@ class GreaterEqualBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('(0 <= twig_compare(')
+            ->raw('(0 <= \twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))

--- a/src/Node/Expression/Binary/InBinary.php
+++ b/src/Node/Expression/Binary/InBinary.php
@@ -18,7 +18,7 @@ class InBinary extends AbstractBinary
     public function compile(Compiler $compiler): void
     {
         $compiler
-            ->raw('twig_in_filter(')
+            ->raw('\twig_in_filter(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))

--- a/src/Node/Expression/Binary/LessBinary.php
+++ b/src/Node/Expression/Binary/LessBinary.php
@@ -24,7 +24,7 @@ class LessBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('(-1 === twig_compare(')
+            ->raw('(-1 === \twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))

--- a/src/Node/Expression/Binary/LessEqualBinary.php
+++ b/src/Node/Expression/Binary/LessEqualBinary.php
@@ -24,7 +24,7 @@ class LessEqualBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('(0 >= twig_compare(')
+            ->raw('(0 >= \twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))

--- a/src/Node/Expression/Binary/MatchesBinary.php
+++ b/src/Node/Expression/Binary/MatchesBinary.php
@@ -18,7 +18,7 @@ class MatchesBinary extends AbstractBinary
     public function compile(Compiler $compiler): void
     {
         $compiler
-            ->raw('preg_match(')
+            ->raw('\preg_match(')
             ->subcompile($this->getNode('right'))
             ->raw(', ')
             ->subcompile($this->getNode('left'))

--- a/src/Node/Expression/Binary/NotEqualBinary.php
+++ b/src/Node/Expression/Binary/NotEqualBinary.php
@@ -24,7 +24,7 @@ class NotEqualBinary extends AbstractBinary
         }
 
         $compiler
-            ->raw('(0 !== twig_compare(')
+            ->raw('(0 !== \twig_compare(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))

--- a/src/Node/Expression/Binary/NotInBinary.php
+++ b/src/Node/Expression/Binary/NotInBinary.php
@@ -18,7 +18,7 @@ class NotInBinary extends AbstractBinary
     public function compile(Compiler $compiler): void
     {
         $compiler
-            ->raw('!twig_in_filter(')
+            ->raw('!\twig_in_filter(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))

--- a/src/Node/Expression/Binary/RangeBinary.php
+++ b/src/Node/Expression/Binary/RangeBinary.php
@@ -18,7 +18,7 @@ class RangeBinary extends AbstractBinary
     public function compile(Compiler $compiler): void
     {
         $compiler
-            ->raw('range(')
+            ->raw('\range(')
             ->subcompile($this->getNode('left'))
             ->raw(', ')
             ->subcompile($this->getNode('right'))

--- a/src/Node/Expression/Binary/StartsWithBinary.php
+++ b/src/Node/Expression/Binary/StartsWithBinary.php
@@ -20,11 +20,11 @@ class StartsWithBinary extends AbstractBinary
         $left = $compiler->getVarName();
         $right = $compiler->getVarName();
         $compiler
-            ->raw(sprintf('(is_string($%s = ', $left))
+            ->raw(sprintf('(\is_string($%s = ', $left))
             ->subcompile($this->getNode('left'))
-            ->raw(sprintf(') && is_string($%s = ', $right))
+            ->raw(sprintf(') && \is_string($%s = ', $right))
             ->subcompile($this->getNode('right'))
-            ->raw(sprintf(') && (\'\' === $%2$s || 0 === strpos($%1$s, $%2$s)))', $left, $right))
+            ->raw(sprintf(') && (\'\' === $%2$s || 0 === \strpos($%1$s, $%2$s)))', $left, $right))
         ;
     }
 

--- a/src/Node/Expression/CallExpression.php
+++ b/src/Node/Expression/CallExpression.php
@@ -153,7 +153,7 @@ abstract class CallExpression extends AbstractExpression
         $pos = 0;
         foreach ($callableParameters as $callableParameter) {
             $name = $this->normalizeName($callableParameter->name);
-            if (\PHP_VERSION_ID >= 80000 && 'range' === $callable) {
+            if (\PHP_VERSION_ID >= 80000 && '\range' === $callable) {
                 if ('start' === $name) {
                     $name = 'low';
                 } elseif ('end' === $name) {

--- a/src/Node/Expression/GetAttrExpression.php
+++ b/src/Node/Expression/GetAttrExpression.php
@@ -43,11 +43,11 @@ class GetAttrExpression extends AbstractExpression
             $compiler
                 ->raw('(('.$var.' = ')
                 ->subcompile($this->getNode('node'))
-                ->raw(') && is_array(')
+                ->raw(') && \is_array(')
                 ->raw($var)
                 ->raw(') || ')
                 ->raw($var)
-                ->raw(' instanceof ArrayAccess ? (')
+                ->raw(' instanceof \ArrayAccess ? (')
                 ->raw($var)
                 ->raw('[')
                 ->subcompile($this->getNode('attribute'))
@@ -57,7 +57,7 @@ class GetAttrExpression extends AbstractExpression
             return;
         }
 
-        $compiler->raw('twig_get_attribute($this->env, $this->source, ');
+        $compiler->raw('\twig_get_attribute($this->env, $this->source, ');
 
         if ($this->getAttribute('ignore_strict_check')) {
             $this->getNode('node')->setAttribute('ignore_strict_check', true);

--- a/src/Node/Expression/MethodCallExpression.php
+++ b/src/Node/Expression/MethodCallExpression.php
@@ -28,7 +28,7 @@ class MethodCallExpression extends AbstractExpression
     {
         if ($this->getAttribute('is_defined_test')) {
             $compiler
-                ->raw('method_exists($macros[')
+                ->raw('\method_exists($macros[')
                 ->repr($this->getNode('node')->getAttribute('name'))
                 ->raw('], ')
                 ->repr($this->getAttribute('method'))
@@ -39,7 +39,7 @@ class MethodCallExpression extends AbstractExpression
         }
 
         $compiler
-            ->raw('twig_call_macro($macros[')
+            ->raw('\twig_call_macro($macros[')
             ->repr($this->getNode('node')->getAttribute('name'))
             ->raw('], ')
             ->repr($this->getAttribute('method'))

--- a/src/Node/Expression/NameExpression.php
+++ b/src/Node/Expression/NameExpression.php
@@ -38,7 +38,7 @@ class NameExpression extends AbstractExpression
                 $compiler->repr(true);
             } elseif (\PHP_VERSION_ID >= 70400) {
                 $compiler
-                    ->raw('array_key_exists(')
+                    ->raw('\array_key_exists(')
                     ->string($name)
                     ->raw(', $context)')
                 ;
@@ -46,7 +46,7 @@ class NameExpression extends AbstractExpression
                 $compiler
                     ->raw('(isset($context[')
                     ->string($name)
-                    ->raw(']) || array_key_exists(')
+                    ->raw(']) || \array_key_exists(')
                     ->string($name)
                     ->raw(', $context))')
                 ;
@@ -70,7 +70,7 @@ class NameExpression extends AbstractExpression
                 $compiler
                     ->raw('(isset($context[')
                     ->string($name)
-                    ->raw(']) || array_key_exists(')
+                    ->raw(']) || \array_key_exists(')
                     ->string($name)
                     ->raw(', $context) ? $context[')
                     ->string($name)

--- a/src/Node/Expression/Test/ConstantTest.php
+++ b/src/Node/Expression/Test/ConstantTest.php
@@ -30,12 +30,12 @@ class ConstantTest extends TestExpression
         $compiler
             ->raw('(')
             ->subcompile($this->getNode('node'))
-            ->raw(' === constant(')
+            ->raw(' === \constant(')
         ;
 
         if ($this->getNode('arguments')->hasNode(1)) {
             $compiler
-                ->raw('get_class(')
+                ->raw('\get_class(')
                 ->subcompile($this->getNode('arguments')->getNode(1))
                 ->raw(')."::".')
             ;

--- a/src/Node/FlushNode.php
+++ b/src/Node/FlushNode.php
@@ -29,7 +29,7 @@ class FlushNode extends Node
     {
         $compiler
             ->addDebugInfo($this)
-            ->write("flush();\n")
+            ->write("\\flush();\n")
         ;
     }
 }

--- a/src/Node/ForNode.php
+++ b/src/Node/ForNode.php
@@ -42,7 +42,7 @@ class ForNode extends Node
         $compiler
             ->addDebugInfo($this)
             ->write("\$context['_parent'] = \$context;\n")
-            ->write("\$context['_seq'] = twig_ensure_traversable(")
+            ->write("\$context['_seq'] = \\twig_ensure_traversable(")
             ->subcompile($this->getNode('seq'))
             ->raw(");\n")
         ;
@@ -59,9 +59,9 @@ class ForNode extends Node
                 ->write("  'index'  => 1,\n")
                 ->write("  'first'  => true,\n")
                 ->write("];\n")
-                ->write("if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof \Countable)) {\n")
+                ->write("if (\\is_array(\$context['_seq']) || (\\is_object(\$context['_seq']) && \$context['_seq'] instanceof \Countable)) {\n")
                 ->indent()
-                ->write("\$length = count(\$context['_seq']);\n")
+                ->write("\$length = \\count(\$context['_seq']);\n")
                 ->write("\$context['loop']['revindex0'] = \$length - 1;\n")
                 ->write("\$context['loop']['revindex'] = \$length;\n")
                 ->write("\$context['loop']['length'] = \$length;\n")

--- a/src/Node/IncludeNode.php
+++ b/src/Node/IncludeNode.php
@@ -93,12 +93,12 @@ class IncludeNode extends Node implements NodeOutputInterface
             $compiler->raw(false === $this->getAttribute('only') ? '$context' : '[]');
         } elseif (false === $this->getAttribute('only')) {
             $compiler
-                ->raw('twig_array_merge($context, ')
+                ->raw('\twig_array_merge($context, ')
                 ->subcompile($this->getNode('variables'))
                 ->raw(')')
             ;
         } else {
-            $compiler->raw('twig_to_array(');
+            $compiler->raw('\twig_to_array(');
             $compiler->subcompile($this->getNode('variables'));
             $compiler->raw(')');
         }

--- a/src/Node/MacroNode.php
+++ b/src/Node/MacroNode.php
@@ -90,20 +90,20 @@ class MacroNode extends Node
             ->write("\$blocks = [];\n\n")
         ;
         if ($compiler->getEnvironment()->isDebug()) {
-            $compiler->write("ob_start();\n");
+            $compiler->write("\\ob_start();\n");
         } else {
-            $compiler->write("ob_start(function () { return ''; });\n");
+            $compiler->write("\\ob_start(static function () { return ''; });\n");
         }
         $compiler
             ->write("try {\n")
             ->indent()
             ->subcompile($this->getNode('body'))
             ->raw("\n")
-            ->write("return ('' === \$tmp = ob_get_contents()) ? '' : new Markup(\$tmp, \$this->env->getCharset());\n")
+            ->write("return ('' === \$tmp = \\ob_get_contents()) ? '' : new Markup(\$tmp, \$this->env->getCharset());\n")
             ->outdent()
             ->write("} finally {\n")
             ->indent()
-            ->write("ob_end_clean();\n")
+            ->write("\\ob_end_clean();\n")
             ->outdent()
             ->write("}\n")
             ->outdent()

--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -236,7 +236,7 @@ final class ModuleNode extends Node
 
             if ($countTraits > 1) {
                 $compiler
-                    ->write("\$this->traits = array_merge(\n")
+                    ->write("\$this->traits = \\array_merge(\n")
                     ->indent()
                 ;
 
@@ -257,7 +257,7 @@ final class ModuleNode extends Node
             }
 
             $compiler
-                ->write("\$this->blocks = array_merge(\n")
+                ->write("\$this->blocks = \\array_merge(\n")
                 ->indent()
                 ->write("\$this->traits,\n")
                 ->write("[\n")

--- a/src/Node/SetNode.php
+++ b/src/Node/SetNode.php
@@ -58,9 +58,9 @@ class SetNode extends Node implements NodeCaptureInterface
         } else {
             if ($this->getAttribute('capture')) {
                 if ($compiler->getEnvironment()->isDebug()) {
-                    $compiler->write("ob_start();\n");
+                    $compiler->write("\\ob_start();\n");
                 } else {
-                    $compiler->write("ob_start(function () { return ''; });\n");
+                    $compiler->write("\\ob_start(static function () { return ''; });\n");
                 }
                 $compiler
                     ->subcompile($this->getNode('values'))
@@ -70,7 +70,7 @@ class SetNode extends Node implements NodeCaptureInterface
             $compiler->subcompile($this->getNode('names'), false);
 
             if ($this->getAttribute('capture')) {
-                $compiler->raw(" = ('' === \$tmp = ob_get_clean()) ? '' : new Markup(\$tmp, \$this->env->getCharset())");
+                $compiler->raw(" = ('' === \$tmp = \\ob_get_clean()) ? '' : new Markup(\$tmp, \$this->env->getCharset())");
             }
         }
 

--- a/src/Node/WithNode.php
+++ b/src/Node/WithNode.php
@@ -45,14 +45,14 @@ class WithNode extends Node
                 ->write(sprintf('$%s = ', $varsName))
                 ->subcompile($node)
                 ->raw(";\n")
-                ->write(sprintf("if (!twig_test_iterable(\$%s)) {\n", $varsName))
+                ->write(sprintf("if (!\\twig_test_iterable(\$%s)) {\n", $varsName))
                 ->indent()
                 ->write("throw new RuntimeError('Variables passed to the \"with\" tag must be a hash.', ")
                 ->repr($node->getTemplateLine())
                 ->raw(", \$this->getSourceContext());\n")
                 ->outdent()
                 ->write("}\n")
-                ->write(sprintf("\$%s = twig_to_array(\$%s);\n", $varsName, $varsName))
+                ->write(sprintf("\$%s = \\twig_to_array(\$%s);\n", $varsName, $varsName))
             ;
 
             if ($this->getAttribute('only')) {

--- a/src/Test/NodeTestCase.php
+++ b/src/Test/NodeTestCase.php
@@ -60,6 +60,6 @@ abstract class NodeTestCase extends TestCase
 
     protected function getAttributeGetter()
     {
-        return 'twig_get_attribute($this->env, $this->source, ';
+        return '\twig_get_attribute($this->env, $this->source, ';
     }
 }

--- a/tests/Node/Expression/Binary/FloorDivTest.php
+++ b/tests/Node/Expression/Binary/FloorDivTest.php
@@ -34,7 +34,7 @@ class FloorDivTest extends NodeTestCase
         $node = new FloorDivBinary($left, $right, 1);
 
         return [
-            [$node, '(int) floor((1 / 2))'],
+            [$node, '(int) \floor((1 / 2))'],
         ];
     }
 }

--- a/tests/Node/Expression/FilterTest.php
+++ b/tests/Node/Expression/FilterTest.php
@@ -47,7 +47,7 @@ class FilterTest extends NodeTestCase
         $node = $this->createFilter($expr, 'upper');
         $node = $this->createFilter($node, 'number_format', [new ConstantExpression(2, 1), new ConstantExpression('.', 1), new ConstantExpression(',', 1)]);
 
-        $tests[] = [$node, 'twig_number_format_filter($this->env, twig_upper_filter($this->env, "foo"), 2, ".", ",")'];
+        $tests[] = [$node, '\twig_number_format_filter($this->env, \twig_upper_filter($this->env, "foo"), 2, ".", ",")'];
 
         // named arguments
         $date = new ConstantExpression(0, 1);
@@ -55,25 +55,25 @@ class FilterTest extends NodeTestCase
             'timezone' => new ConstantExpression('America/Chicago', 1),
             'format' => new ConstantExpression('d/m/Y H:i:s P', 1),
         ]);
-        $tests[] = [$node, 'twig_date_format_filter($this->env, 0, "d/m/Y H:i:s P", "America/Chicago")'];
+        $tests[] = [$node, '\twig_date_format_filter($this->env, 0, "d/m/Y H:i:s P", "America/Chicago")'];
 
         // skip an optional argument
         $date = new ConstantExpression(0, 1);
         $node = $this->createFilter($date, 'date', [
             'timezone' => new ConstantExpression('America/Chicago', 1),
         ]);
-        $tests[] = [$node, 'twig_date_format_filter($this->env, 0, null, "America/Chicago")'];
+        $tests[] = [$node, '\twig_date_format_filter($this->env, 0, null, "America/Chicago")'];
 
         // underscores vs camelCase for named arguments
         $string = new ConstantExpression('abc', 1);
         $node = $this->createFilter($string, 'reverse', [
             'preserve_keys' => new ConstantExpression(true, 1),
         ]);
-        $tests[] = [$node, 'twig_reverse_filter($this->env, "abc", true)'];
+        $tests[] = [$node, '\twig_reverse_filter($this->env, "abc", true)'];
         $node = $this->createFilter($string, 'reverse', [
             'preserveKeys' => new ConstantExpression(true, 1),
         ]);
-        $tests[] = [$node, 'twig_reverse_filter($this->env, "abc", true)'];
+        $tests[] = [$node, '\twig_reverse_filter($this->env, "abc", true)'];
 
         // filter as an anonymous function
         $node = $this->createFilter(new ConstantExpression('foo', 1), 'anonymous');

--- a/tests/Node/Expression/FunctionTest.php
+++ b/tests/Node/Expression/FunctionTest.php
@@ -72,7 +72,7 @@ class FunctionTest extends NodeTestCase
             'timezone' => new ConstantExpression('America/Chicago', 1),
             'date' => new ConstantExpression(0, 1),
         ]);
-        $tests[] = [$node, 'twig_date_converter($this->env, 0, "America/Chicago")'];
+        $tests[] = [$node, '\twig_date_converter($this->env, 0, "America/Chicago")'];
 
         // arbitrary named arguments
         $node = $this->createFunction('barbar');

--- a/tests/Node/Expression/GetAttrTest.php
+++ b/tests/Node/Expression/GetAttrTest.php
@@ -47,7 +47,7 @@ class GetAttrTest extends NodeTestCase
 
         $node = new GetAttrExpression($expr, $attr, $args, Template::ARRAY_CALL, 1);
         $tests[] = [$node, '(($__internal_%s = // line 1'."\n".
-            '($context["foo"] ?? null)) && is_array($__internal_%s) || $__internal_%s instanceof ArrayAccess ? ($__internal_%s["bar"] ?? null) : null)', null, true, ];
+            '($context["foo"] ?? null)) && \is_array($__internal_%s) || $__internal_%s instanceof \ArrayAccess ? ($__internal_%s["bar"] ?? null) : null)', null, true, ];
 
         $args = new ArrayExpression([], 1);
         $args->addElement(new NameExpression('foo', 1));

--- a/tests/Node/Expression/NameTest.php
+++ b/tests/Node/Expression/NameTest.php
@@ -34,7 +34,7 @@ class NameTest extends NodeTestCase
         $env = new Environment($this->createMock(LoaderInterface::class), ['strict_variables' => true]);
         $env1 = new Environment($this->createMock(LoaderInterface::class), ['strict_variables' => false]);
 
-        $output = '(isset($context["foo"]) || array_key_exists("foo", $context) ? $context["foo"] : (function () { throw new RuntimeError(\'Variable "foo" does not exist.\', 1, $this->source); })())';
+        $output = '(isset($context["foo"]) || \array_key_exists("foo", $context) ? $context["foo"] : (function () { throw new RuntimeError(\'Variable "foo" does not exist.\', 1, $this->source); })())';
 
         return [
             [$node, "// line 1\n".$output, $env],

--- a/tests/Node/ForTest.php
+++ b/tests/Node/ForTest.php
@@ -57,7 +57,7 @@ class ForTest extends NodeTestCase
         $tests[] = [$node, <<<EOF
 // line 1
 \$context['_parent'] = \$context;
-\$context['_seq'] = twig_ensure_traversable({$this->getVariableGetter('items')});
+\$context['_seq'] = \\twig_ensure_traversable({$this->getVariableGetter('items')});
 foreach (\$context['_seq'] as \$context["key"] => \$context["item"]) {
     echo {$this->getVariableGetter('foo')};
 }
@@ -78,15 +78,15 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$context['_parent'] = \$context;
-\$context['_seq'] = twig_ensure_traversable({$this->getVariableGetter('values')});
+\$context['_seq'] = \\twig_ensure_traversable({$this->getVariableGetter('values')});
 \$context['loop'] = [
   'parent' => \$context['_parent'],
   'index0' => 0,
   'index'  => 1,
   'first'  => true,
 ];
-if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof \Countable)) {
-    \$length = count(\$context['_seq']);
+if (\is_array(\$context['_seq']) || (\is_object(\$context['_seq']) && \$context['_seq'] instanceof \Countable)) {
+    \$length = \count(\$context['_seq']);
     \$context['loop']['revindex0'] = \$length - 1;
     \$context['loop']['revindex'] = \$length;
     \$context['loop']['length'] = \$length;
@@ -120,15 +120,15 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$context['_parent'] = \$context;
-\$context['_seq'] = twig_ensure_traversable({$this->getVariableGetter('values')});
+\$context['_seq'] = \\twig_ensure_traversable({$this->getVariableGetter('values')});
 \$context['loop'] = [
   'parent' => \$context['_parent'],
   'index0' => 0,
   'index'  => 1,
   'first'  => true,
 ];
-if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof \Countable)) {
-    \$length = count(\$context['_seq']);
+if (\is_array(\$context['_seq']) || (\is_object(\$context['_seq']) && \$context['_seq'] instanceof \Countable)) {
+    \$length = \count(\$context['_seq']);
     \$context['loop']['revindex0'] = \$length - 1;
     \$context['loop']['revindex'] = \$length;
     \$context['loop']['length'] = \$length;
@@ -162,7 +162,7 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$context['_parent'] = \$context;
-\$context['_seq'] = twig_ensure_traversable({$this->getVariableGetter('values')});
+\$context['_seq'] = \\twig_ensure_traversable({$this->getVariableGetter('values')});
 \$context['_iterated'] = false;
 \$context['loop'] = [
   'parent' => \$context['_parent'],
@@ -170,8 +170,8 @@ EOF
   'index'  => 1,
   'first'  => true,
 ];
-if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof \Countable)) {
-    \$length = count(\$context['_seq']);
+if (\is_array(\$context['_seq']) || (\is_object(\$context['_seq']) && \$context['_seq'] instanceof \Countable)) {
+    \$length = \count(\$context['_seq']);
     \$context['loop']['revindex0'] = \$length - 1;
     \$context['loop']['revindex'] = \$length;
     \$context['loop']['length'] = \$length;

--- a/tests/Node/IncludeTest.php
+++ b/tests/Node/IncludeTest.php
@@ -64,14 +64,14 @@ EOF
         $node = new IncludeNode($expr, $vars, false, false, 1);
         $tests[] = [$node, <<<EOF
 // line 1
-\$this->loadTemplate("foo.twig", null, 1)->display(twig_array_merge(\$context, ["foo" => true]));
+\$this->loadTemplate("foo.twig", null, 1)->display(\\twig_array_merge(\$context, ["foo" => true]));
 EOF
         ];
 
         $node = new IncludeNode($expr, $vars, true, false, 1);
         $tests[] = [$node, <<<EOF
 // line 1
-\$this->loadTemplate("foo.twig", null, 1)->display(twig_to_array(["foo" => true]));
+\$this->loadTemplate("foo.twig", null, 1)->display(\\twig_to_array(["foo" => true]));
 EOF
         ];
 
@@ -85,7 +85,7 @@ try {
     // ignore missing template
 }
 if (\$__internal_%s) {
-    \$__internal_%s->display(twig_to_array(["foo" => true]));
+    \$__internal_%s->display(\\twig_to_array(["foo" => true]));
 }
 EOF
         , null, true];

--- a/tests/Node/MacroTest.php
+++ b/tests/Node/MacroTest.php
@@ -54,13 +54,13 @@ public function macro_foo(\$__foo__ = null, \$__bar__ = "Foo", ...\$__varargs__)
 
     \$blocks = [];
 
-    ob_start(function () { return ''; });
+    \ob_start(static function () { return ''; });
     try {
         echo "foo";
 
-        return ('' === \$tmp = ob_get_contents()) ? '' : new Markup(\$tmp, \$this->env->getCharset());
+        return ('' === \$tmp = \ob_get_contents()) ? '' : new Markup(\$tmp, \$this->env->getCharset());
     } finally {
-        ob_end_clean();
+        \ob_end_clean();
     }
 }
 EOF

--- a/tests/Node/SetTest.php
+++ b/tests/Node/SetTest.php
@@ -51,9 +51,9 @@ EOF
         $node = new SetNode(true, $names, $values, 1);
         $tests[] = [$node, <<<EOF
 // line 1
-ob_start(function () { return ''; });
+\ob_start(static function () { return ''; });
 echo "foo";
-\$context["foo"] = ('' === \$tmp = ob_get_clean()) ? '' : new Markup(\$tmp, \$this->env->getCharset());
+\$context["foo"] = ('' === \$tmp = \ob_get_clean()) ? '' : new Markup(\$tmp, \$this->env->getCharset());
 EOF
         ];
 


### PR DESCRIPTION
POC/proposal

Calling functions with their namespace prefix is faster than without. This especially true for compiler optimized function, but all calls have benefit from this.

In some cases people like to either import the function or do not prefix function declared in the global namespace with `\`.
The main reason is readability, however compiled templates are typically not read.

The diff looks way big because of the utests. Wasn't sure about the branch, but maybe first talk concept and than I'm happy to adjust or close if there is no interest.