### PR TITLE
do not reuse internally generated variable names during parsing

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -62,7 +62,7 @@ class Parser
     public function parse(TokenStream $stream, $test = null, $dropNeedle = false)
     {
         $vars = get_object_vars($this);
-        unset($vars['stack'], $vars['env'], $vars['handlers'], $vars['visitors'], $vars['expressionParser'], $vars['reservedMacroNames']);
+        unset($vars['stack'], $vars['env'], $vars['handlers'], $vars['visitors'], $vars['expressionParser'], $vars['reservedMacroNames'], $vars['varNameSalt']);
         $this->stack[] = $vars;
 
         // tag handlers
@@ -92,7 +92,6 @@ class Parser
         $this->blockStack = [];
         $this->importedSymbols = [[]];
         $this->embeddedTemplates = [];
-        $this->varNameSalt = 0;
 
         try {
             $body = $this->subparse($test, $dropNeedle);

--- a/tests/Fixtures/tags/filter/spaceless_parent.legacy.test
+++ b/tests/Fixtures/tags/filter/spaceless_parent.legacy.test
@@ -1,0 +1,33 @@
+--TEST--
+blocks and autoescape
+--DEPRECATION--
+The "filter" tag in "index.twig" at line 8 is deprecated since Twig 2.9, use the "apply" tag instead.
+--TEMPLATE--
+{% extends 'parent.twig' %}
+
+{% block foo %}
+  {{ parent() }}
+
+  Foo child:
+  {% filter spaceless %}
+    something B
+  {% endfilter %}
+
+{% endblock %}
+--TEMPLATE(parent.twig)--
+{% block foo %}
+  Foo Parent:
+  {% filter spaceless %}
+    something A
+  {% endfilter %}
+
+{% endblock %}
+--DATA--
+return []
+--EXPECT--
+    Foo Parent:
+  something A
+
+
+  Foo child:
+  something B


### PR DESCRIPTION
fixes #3647 