### PR TITLE
Rename variable in SecurityPolicyInterface.php

### DIFF
--- a/src/Extension/SandboxExtension.php
+++ b/src/Extension/SandboxExtension.php
@@ -91,11 +91,11 @@ final class SandboxExtension extends AbstractExtension
         }
     }
 
-    public function checkPropertyAllowed($obj, $method, int $lineno = -1, Source $source = null)
+    public function checkPropertyAllowed($obj, $property, int $lineno = -1, Source $source = null)
     {
         if ($this->isSandboxed()) {
             try {
-                $this->policy->checkPropertyAllowed($obj, $method);
+                $this->policy->checkPropertyAllowed($obj, $property);
             } catch (SecurityNotAllowedPropertyError $e) {
                 $e->setSourceContext($source);
                 $e->setTemplateLine($lineno);

--- a/src/Sandbox/SecurityPolicyInterface.php
+++ b/src/Sandbox/SecurityPolicyInterface.php
@@ -31,7 +31,7 @@ interface SecurityPolicyInterface
     /**
      * @throws SecurityNotAllowedPropertyError
      */
-    public function checkPropertyAllowed($obj, $method);
+    public function checkPropertyAllowed($obj, $property);
 }
 
 class_alias('Twig\Sandbox\SecurityPolicyInterface', 'Twig_Sandbox_SecurityPolicyInterface');


### PR DESCRIPTION
Hi @fabpot

When using psalm, an error is reported when the name of the variable is not the same than the one in the interface.
This also could give issues with named params.

The securityPolicy implementation is using `property` as the name of the variable, which make a lot more sens https://github.com/twigphp/Twig/blob/3.x/src/Sandbox/SecurityPolicy.php#L110.

So I updated the interface. But I wasn't sure on which branch (1.x, 2.x, 3.x) I should have opened the PR.

I also wondering if you want me to rename $obj to $object maybe ?