### PR TITLE
Add phpdoc to SecurityPolicyInterface

### DIFF
--- a/src/Sandbox/SecurityPolicyInterface.php
+++ b/src/Sandbox/SecurityPolicyInterface.php
@@ -19,16 +19,26 @@ namespace Twig\Sandbox;
 interface SecurityPolicyInterface
 {
     /**
+     * @param string[] $tags
+     * @param string[] $filters
+     * @param string[] $functions
+     *
      * @throws SecurityError
      */
     public function checkSecurity($tags, $filters, $functions);
 
     /**
+     * @param object $obj
+     * @param string $method
+     *
      * @throws SecurityNotAllowedMethodError
      */
     public function checkMethodAllowed($obj, $method);
 
     /**
+     * @param object $obj
+     * @param string $property
+     *
      * @throws SecurityNotAllowedPropertyError
      */
     public function checkPropertyAllowed($obj, $property);


### PR DESCRIPTION
Hi @fabpot, this is a follow up of https://github.com/twigphp/Twig/pull/3664

I think adding phpdoc to this interface wouldn't hurt.
I took a look at https://github.com/twigphp/Twig/blob/2.x/src/Sandbox/SecurityPolicy.php to know the type of the parameters.