### PR TITLE
Enable cache invalidation when auto_reload=true

### DIFF
--- a/doc/recipes.rst
+++ b/doc/recipes.rst
@@ -329,11 +329,11 @@ If you iterate over a set of files, you can pass the filename to the
     is enforced during template rendering (as Twig needs the context for some
     checks like allowed methods on objects).
 
-Refreshing modified Templates when OPcache or APC is enabled
-------------------------------------------------------------
+Refreshing modified Templates when OPcache is enabled
+-----------------------------------------------------
 
-When using OPcache with ``opcache.validate_timestamps`` set to ``0`` or APC
-with ``apc.stat`` set to ``0`` and Twig cache enabled, clearing the template
+When using OPcache with ``opcache.validate_timestamps`` set to ``0``,
+Twig cache enabled and auto reload disabled, clearing the template
 cache won't update the cache.
 
 To get around this, force Twig to invalidate the bytecode cache::

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -264,7 +264,7 @@ class Environment
     {
         if (\is_string($cache)) {
             $this->originalCache = $cache;
-            $this->cache = new FilesystemCache($cache);
+            $this->cache = new FilesystemCache($cache, $this->autoReload ? FilesystemCache::FORCE_BYTECODE_INVALIDATION : 0);
         } elseif (false === $cache) {
             $this->originalCache = $cache;
             $this->cache = new NullCache();


### PR DESCRIPTION
Related to https://github.com/symfony/symfony-docs/pull/16671

Enabling `auto_reload` is not effective when `opcache.validate_timestamps=0`.