### PR TITLE
[Documentation] Add note about simple string matching

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -664,6 +664,8 @@ string:
         {% if phone matches '/^[\\d\\.]+$/' %}
         {% endif %}
 
+    For simple string comparisons, the containment operator can be used.
+
 Containment Operator
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
During the Symfony Live we mentionned the need to update the documentation around string matching to mention that an approach was possible with the ``ìn`` operator was simpler.

As the documentation part about ``in`` was just below, I wasn't sure that an anchor link was relevant, nor a code example.

Happy to make this first tiny contribution, and available if there are more stuff to do for this PR :).