### PR TITLE
throwing syntax error when the matches regexp is not valid

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -310,7 +310,6 @@ namespace {
     use Twig\Environment;
     use Twig\Error\LoaderError;
     use Twig\Error\RuntimeError;
-    use Twig\Error\SyntaxError;
     use Twig\Extension\CoreExtension;
     use Twig\Extension\SandboxExtension;
     use Twig\Markup;
@@ -1020,18 +1019,18 @@ function twig_compare($a, $b)
     return $a <=> $b;
 }
 
-    /**
-     * @param string $pattern
-     * @param string $subject
-     *
-     * @return int
-     *
-     * @throws SyntaxError When an invalid pattern is used
-     */
+/**
+ * @param string $pattern
+ * @param string $subject
+ *
+ * @return int
+ *
+ * @throws RuntimeError When an invalid pattern is used
+ */
 function twig_matches(string $regexp, string $str)
 {
     set_error_handler(function ($t, $m) use ($regexp) {
-        throw new SyntaxError(sprintf('Regexp "%s" passed to "matches" is not valid', $regexp).substr($m, 12));
+        throw new RuntimeError(sprintf('Regexp "%s" passed to "matches" is not valid', $regexp).substr($m, 12));
     });
     try {
         return preg_match($regexp, $str);

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -310,6 +310,7 @@ namespace {
     use Twig\Environment;
     use Twig\Error\LoaderError;
     use Twig\Error\RuntimeError;
+    use Twig\Error\SyntaxError;
     use Twig\Extension\CoreExtension;
     use Twig\Extension\SandboxExtension;
     use Twig\Markup;
@@ -1017,6 +1018,26 @@ function twig_compare($a, $b)
 
     // fallback to <=>
     return $a <=> $b;
+}
+
+    /**
+     * @param string $pattern
+     * @param string $subject
+     *
+     * @return int
+     *
+     * @throws SyntaxError When an invalid pattern is used
+     */
+function twig_matches(string $regexp, string $str)
+{
+    set_error_handler(function ($t, $m) use ($regexp) {
+        throw new SyntaxError(sprintf('Regexp "%s" passed to "matches" is not valid', $regexp).substr($m, 12));
+    });
+    try {
+        return preg_match($regexp, $str);
+    } finally {
+        restore_error_handler();
+    }
 }
 
 /**

--- a/src/Node/Expression/Binary/MatchesBinary.php
+++ b/src/Node/Expression/Binary/MatchesBinary.php
@@ -18,7 +18,7 @@ class MatchesBinary extends AbstractBinary
     public function compile(Compiler $compiler): void
     {
         $compiler
-            ->raw('preg_match(')
+            ->raw('twig_matches(')
             ->subcompile($this->getNode('right'))
             ->raw(', ')
             ->subcompile($this->getNode('left'))

--- a/tests/Fixtures/expressions/matches_error.test
+++ b/tests/Fixtures/expressions/matches_error.test
@@ -1,0 +1,8 @@
+--TEST--
+Twig supports the "matches" operator with a great error message
+--TEMPLATE--
+{{ 'foo' matches '/o' }}
+--DATA--
+return []
+--EXCEPTION--
+Twig\Error\RuntimeError: Regexp "/o" passed to "matches" is not valid: No ending delimiter '/' found in "index.twig" at line 2


### PR DESCRIPTION
During the symfony live, Fabien talk about a PR he did on the Expression Language component (https://github.com/symfony/symfony/pull/45875/files). The goal was to throw a more readable error when using the matchs operator. This think need to be fix in twig to. So as promises, here is my PR ! 
This is my first contrib to symfony so any advice is welcome ! 😁 