### PR TITLE
prevent direct invocation of compiled files under docroot

### DIFF
--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -33,7 +33,7 @@ class FilesystemCache implements CacheInterface
     {
         $hash = hash(\PHP_VERSION_ID < 80100 ? 'sha256' : 'xxh128', $className);
 
-        return $this->directory.$hash[0].$hash[1].'/'.$hash.'.php';
+        return $this->directory.$hash[0].$hash[1].'/'.$hash.'.compiled';
     }
 
     public function load(string $key): void

--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -22,18 +22,20 @@ class FilesystemCache implements CacheInterface
 
     private $directory;
     private $options;
+    private $extension;
 
-    public function __construct(string $directory, int $options = 0)
+    public function __construct(string $directory, int $options = 0, $extension = 'php')
     {
         $this->directory = rtrim($directory, '\/').'/';
         $this->options = $options;
+        $this->extension = $extension;
     }
 
     public function generateKey(string $name, string $className): string
     {
         $hash = hash(\PHP_VERSION_ID < 80100 ? 'sha256' : 'xxh128', $className);
 
-        return $this->directory.$hash[0].$hash[1].'/'.$hash.'.compiled';
+        return $this->directory.$hash[0].$hash[1].'/'.$hash.'.'.$this->extension;
     }
 
     public function load(string $key): void

--- a/tests/Cache/FilesystemTest.php
+++ b/tests/Cache/FilesystemTest.php
@@ -167,13 +167,13 @@ class FilesystemTest extends TestCase
      */
     public function testGenerateKey($expected, $input)
     {
-        $cache = new FilesystemCache($input);
+        $cache = new FilesystemCache($input, 0, 'customextension');
         $this->assertMatchesRegularExpression($expected, $cache->generateKey('_test_', static::class));
     }
 
     public function provideDirectories()
     {
-        $pattern = '#a/b/[a-zA-Z0-9]+/[a-zA-Z0-9]+.compiled$#';
+        $pattern = '#a/b/[a-zA-Z0-9]+/[a-zA-Z0-9]+.customextension$#';
 
         return [
             [$pattern, 'a/b'],

--- a/tests/Cache/FilesystemTest.php
+++ b/tests/Cache/FilesystemTest.php
@@ -173,7 +173,7 @@ class FilesystemTest extends TestCase
 
     public function provideDirectories()
     {
-        $pattern = '#a/b/[a-zA-Z0-9]+/[a-zA-Z0-9]+.php$#';
+        $pattern = '#a/b/[a-zA-Z0-9]+/[a-zA-Z0-9]+.compiled$#';
 
         return [
             [$pattern, 'a/b'],


### PR DESCRIPTION
When the template compiler stores .php files, many setups allow those .php files to be invoked by external traffic. This may be provably non-problematic here beyond errors in logs, but at least [one managed host](https://wpengine.com/support/wp-engines-security-environment/#Disk_Write_Protection) prevents writes to .php files at runtime because of the large number of vulnerabilities in the category. 