### PR TITLE
do not dump callables

### DIFF
--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -53,7 +53,9 @@ class Node implements \Countable, \IteratorAggregate
     {
         $attributes = [];
         foreach ($this->attributes as $name => $value) {
-            $attributes[] = sprintf('%s: %s', $name, str_replace("\n", '', var_export($value, true)));
+            if (!is_callable($value)) {
+              $attributes[] = sprintf('%s: %s', $name, str_replace("\n", '', var_export($value, true)));
+            }
         }
 
         $repr = [static::class.'('.implode(', ', $attributes)];


### PR DESCRIPTION
Not all callables can be dumped by `var_export`.

For example https://github.com/symfony/symfony/issues/46209 but there can be any other issues.

It doesn't add much I believe -- the structure is visible without it. I wish there was a better way but apparently there is not. `var_export` simply falls into an infinite loop in some cases. PHP does not want to fix this and recommends print_r/var_dump instead: https://github.com/php/php-src/issues/8456