### PR TITLE
Add @codeCoverageIgnore to untestable compiled methods

### DIFF
--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -355,6 +355,9 @@ final class ModuleNode extends Node
     protected function compileGetTemplateName(Compiler $compiler)
     {
         $compiler
+            ->write("/**")
+            ->write(" * @codeCoverageIgnore")
+            ->write(" */")
             ->write("public function getTemplateName()\n", "{\n")
             ->indent()
             ->write('return ')
@@ -409,6 +412,9 @@ final class ModuleNode extends Node
         }
 
         $compiler
+            ->write("/**")
+            ->write(" * @codeCoverageIgnore")
+            ->write(" */")
             ->write("public function isTraitable()\n", "{\n")
             ->indent()
             ->write(sprintf("return %s;\n", $traitable ? 'true' : 'false'))
@@ -420,6 +426,9 @@ final class ModuleNode extends Node
     protected function compileDebugInfo(Compiler $compiler)
     {
         $compiler
+            ->write("/**")
+            ->write(" * @codeCoverageIgnore")
+            ->write(" */")
             ->write("public function getDebugInfo()\n", "{\n")
             ->indent()
             ->write(sprintf("return %s;\n", str_replace("\n", '', var_export(array_reverse($compiler->getDebugInfo(), true), true))))


### PR DESCRIPTION
I've been experimenting with adding my compiled templates to my code coverage reports and it works largely as expected. Templates that get executed return percentages accurate to the number of lines the tests actually cover. The only exception are the "meta" methods on the compiled template that aren't necessarily called by the tests.

This PR adds `@codeCoverageIgnore` comments to the compiled template for all non-display methods so the coverage report only lists lines from `doDisplay`.

I'm assuming that I will need to update some of the Twig tests to account for these new comments, but am curious if you'd be open to this change.

An example screenshot below. The last line shows line 46 out of the compiled template is never executed. The compiled template's `getDebugInfo` even correctly informs me that line 46 maps to line 4 in my `.twig` so I'll work on updating the line numbering next.

![image](https://user-images.githubusercontent.com/48975/166098890-fbaf99ad-9aa4-4430-9f82-050f482a6777.png)
