### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 env:
     SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE: 1
 
+permissions:
+  contents: read
+
 jobs:
     tests:
         name: "PHP ${{ matrix.php-version }}"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,6 +6,9 @@ on:
         branches:
             - '3.x'
 
+permissions:
+  contents: read
+
 jobs:
     build:
         name: "Build"


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
