### PR TITLE
Allow inherited magic method to still run with calling class

### DIFF
--- a/src/Node/Expression/CallExpression.php
+++ b/src/Node/Expression/CallExpression.php
@@ -283,8 +283,15 @@ abstract class CallExpression extends AbstractExpression
             $callable = [substr($callable, 0, $pos), substr($callable, 2 + $pos)];
         }
 
-        if (\is_array($callable) && method_exists($callable[0], $callable[1])) {
-            $r = new \ReflectionMethod($callable[0], $callable[1]);
+        if (\is_array($callable) && \is_callable($callable[0], $callable[1])) {
+            if (!method_exists($callable[0], $callable[1]) && method_exists($callable[0], '__callStatic')) {
+                $r = new \ReflectionMethod($callable[0], '__callStatic');
+                $callable = function (...$args) use ($callable) {
+                    return $callable[0]::__callStatic($callable[1], $args);
+                };
+            } else {
+                $r = new \ReflectionMethod($callable[0], $callable[1]);
+            }
 
             return $this->reflector = [$r, $callable, $r->class.'::'.$r->name];
         }

--- a/tests/Fixtures/functions/inherited_magic_static_call.test
+++ b/tests/Fixtures/functions/inherited_magic_static_call.test
@@ -1,0 +1,10 @@
+--TEST--
+inherited __staticCall calls
+--TEMPLATE--
+{{ 'foo'|inherited_magic_call_string }}
+{{ 'foo'|inherited_magic_call_array }}
+--DATA--
+return []
+--EXPECT--
+inherited_static_magic_child_foo
+inherited_static_magic_child_foo

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -172,6 +172,8 @@ class TwigTestExtension extends AbstractExtension
             new TwigFilter('magic_call_closure', \Closure::fromCallable([$this, 'magicCall'])),
             new TwigFilter('magic_call_string', 'Twig\Tests\TwigTestExtension::magicStaticCall'),
             new TwigFilter('magic_call_array', ['Twig\Tests\TwigTestExtension', 'magicStaticCall']),
+            new TwigFilter('inherited_magic_call_string', 'Twig\Tests\ChildMagicCallStub::magicStaticCall'),
+            new TwigFilter('inherited_magic_call_array', ['Twig\Tests\ChildMagicCallStub', 'magicStaticCall']),
             new TwigFilter('*_path', [$this, 'dynamic_path']),
             new TwigFilter('*_foo_*_bar', [$this, 'dynamic_foo']),
             new TwigFilter('not', [$this, 'notFilter']),
@@ -408,5 +410,34 @@ class SimpleIteratorForTesting implements \Iterator
     {
         // for testing, make sure string length returned is not the same as the `iterator_count`
         return str_repeat('X', iterator_count($this) + 10);
+    }
+}
+
+/**
+ * These classes are used for demonstrating a static call on a class that inherits its magic from a 
+ * parent class, but still needs to run in the context of itself.
+ */
+class ChildMagicCallStub extends ParentMagicCallStub
+{
+    public static function identifier()
+    {
+        return 'child';
+    }
+}
+
+class ParentMagicCallStub
+{
+    public static function identifier()
+    {
+        throw new \Exception('Identifier has not been defined');
+    }
+
+    public static function __callStatic($method, $arguments)
+    {
+        if ('magicStaticCall' !== $method) {
+            throw new \BadMethodCallException('Unexpected call to __callStatic');
+        }
+
+        return 'inherited_static_magic_' . static::identifier() . '_' . $arguments[0];
     }
 }


### PR DESCRIPTION
If a static method cannot be resolved to the calling class, but the calling class has, or inherits, a `__callStatic` handler, this allows the `__callStatic` handler to be used with the calling class, and not the inherited class as would occur with reflection. This allows systems such as Laravel facades to still work.

Fixes https://github.com/twigphp/Twig/issues/3716