### PR TITLE
Added a loop that uses keys and values

### DIFF
--- a/doc/filters/keys.rst
+++ b/doc/filters/keys.rst
@@ -9,3 +9,11 @@ iterate over the keys of an array:
     {% for key in array|keys %}
         ...
     {% endfor %}
+    
+Or, if you need both the keys and the values:
+
+.. code-block:: twig
+
+    {% for key, value in array %}
+        {{ key }} : {{ value }}
+    {% endfor %}


### PR DESCRIPTION
If we might need both the keys and the values in a Twig loop. It would be useful.
Solves [this Stackoverflow question](https://stackoverflow.com/questions/58319883/not-able-to-print-the-key-and-values-in-twig-files).