### PR TITLE
Adds dump_json function and documentation

### DIFF
--- a/doc/functions/dump_json.rst
+++ b/doc/functions/dump_json.rst
@@ -48,7 +48,7 @@ dumped:
 
 .. note::
 
-    Internally, Twig uses the PHP `json_encode` function.
+    Internally, Twig uses the PHP `json_encode` function, which only encodes the public properties of an object.
 
 Arguments
 ---------

--- a/doc/functions/dump_json.rst
+++ b/doc/functions/dump_json.rst
@@ -30,7 +30,7 @@ In an HTML context, wrap the output with a ``<script>`` tag to display it in the
 .. code-block:: html+twig
 
     <script>
-        console.log({{ dump(user) }})
+        console.log({{ dump_json(user) }})
     </script>
 
 You can debug several variables by passing them as additional arguments:

--- a/doc/functions/dump_json.rst
+++ b/doc/functions/dump_json.rst
@@ -1,0 +1,56 @@
+``dump_json``
+========
+
+The ``dump_json`` function dumps information about a template variable. This is
+mostly useful to debug a template that does not behave as expected by
+introspecting its variables:
+
+.. code-block:: twig
+
+    {{ dump_json(user) }}
+
+.. note::
+
+    The ``dump_json`` function is not available by default. You must add the
+    ``\Twig\Extension\DebugExtension`` extension explicitly when creating your Twig
+    environment::
+
+        $twig = new \Twig\Environment($loader, [
+            'debug' => true,
+            // ...
+        ]);
+        $twig->addExtension(new \Twig\Extension\DebugExtension());
+
+    Even when enabled, the ``dump_json`` function won't display anything if the
+    ``debug`` option on the environment is not enabled (to avoid leaking debug
+    information on a production server).
+
+In an HTML context, wrap the output with a ``<script>`` tag to display it in the browser console:
+
+.. code-block:: html+twig
+
+    <script>
+        console.log({{ dump(user) }})
+    </script>
+
+You can debug several variables by passing them as additional arguments:
+
+.. code-block:: twig
+
+    {{ dump_json(user, categories) }}
+
+If you don't pass any value, all variables from the current context are
+dumped:
+
+.. code-block:: twig
+
+    {{ dump_json() }}
+
+.. note::
+
+    Internally, Twig uses the PHP `json_encode` function.
+
+Arguments
+---------
+
+* ``context``: The context to dump

--- a/src/Extension/DebugExtension.php
+++ b/src/Extension/DebugExtension.php
@@ -19,10 +19,10 @@ final class DebugExtension extends AbstractExtension
         // dump is safe if var_dump is overridden by xdebug
         $isDumpOutputHtmlSafe = \extension_loaded('xdebug')
             // false means that it was not set (and the default is on) or it explicitly enabled
-            && (false === ini_get('xdebug.overload_var_dump') || ini_get('xdebug.overload_var_dump'))
+            && (false === \ini_get('xdebug.overload_var_dump') || \ini_get('xdebug.overload_var_dump'))
             // false means that it was not set (and the default is on) or it explicitly enabled
             // xdebug.overload_var_dump produces HTML only when html_errors is also enabled
-            && (false === ini_get('html_errors') || ini_get('html_errors'))
+            && (false === \ini_get('html_errors') || \ini_get('html_errors'))
             || 'cli' === \PHP_SAPI
         ;
 

--- a/src/Extension/DebugExtension.php
+++ b/src/Extension/DebugExtension.php
@@ -27,7 +27,9 @@ final class DebugExtension extends AbstractExtension
         ;
 
         return [
-            new TwigFunction('dump', 'twig_var_dump', ['is_safe' => $isDumpOutputHtmlSafe ? ['html'] : [], 'needs_context' => true, 'needs_environment' => true, 'is_variadic' => true]),
+            new TwigFunction('dump', 'twig_var_dump_to_html', ['is_safe' => $isDumpOutputHtmlSafe ? ['html'] : [], 'needs_context' => true, 'needs_environment' => true, 'is_variadic' => true]),
+
+            new TwigFunction('dump_json', 'twig_var_dump_to_json', ['is_safe' => $isDumpOutputHtmlSafe ? ['html'] : [], 'needs_context' => true, 'needs_environment' => true, 'is_variadic' => true]),
         ];
     }
 }
@@ -38,7 +40,7 @@ use Twig\Environment;
 use Twig\Template;
 use Twig\TemplateWrapper;
 
-function twig_var_dump(Environment $env, $context, ...$vars)
+function twig_var_dump_to_html(Environment $env, $context, ...$vars)
 {
     if (!$env->isDebug()) {
         return;
@@ -57,6 +59,29 @@ function twig_var_dump(Environment $env, $context, ...$vars)
         var_dump($vars);
     } else {
         var_dump(...$vars);
+    }
+
+    return ob_get_clean();
+}
+
+function twig_var_dump_to_json(Environment $env, $context, ...$vars)
+{
+    if (!$env->isDebug()) {
+        return;
+    }
+
+    ob_start();
+
+    if (!$vars) {
+        $vars = [];
+        foreach ($context as $key => $value) {
+            if (!$value instanceof Template && !$value instanceof TemplateWrapper) {
+                $vars[$key] = $value;
+            }
+        }
+        echo json_encode($vars);
+    } else {
+        echo json_encode(...$vars);
     }
 
     return ob_get_clean();


### PR DESCRIPTION
Good morning! 

I built this extension locally last night for a project I'm working on and it occurred to me that someone else might find it useful. 

This PR adds a new debug function, `dump_json` which internally uses PHP's native `json_encode` function and `echo`s the resulting string. Also includes a documentation page.