### PR TITLE
fix: add missing initializer for sourceOffset

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -24,7 +24,7 @@ class Compiler
     private $indentation;
     private $env;
     private $debugInfo = [];
-    private $sourceOffset;
+    private $sourceOffset = 0;
     private $sourceLine;
     private $varNameSalt = 0;
 


### PR DESCRIPTION
When I create the compiler by own (test case) and call as first `addDebugInfo` it throws a php deprecation

```php
$compiler = new Compiler(new Environment(new ArrayLoader()));

$compiler
            ->addDebugInfo($myNode);
```

PHP Deprecated:  substr_count(): Passing null to parameter #3 ($offset) of type int is deprecated in /Users/shyim/Code/sw6/vendor/twig/twig/src/Compiler.php on line 166


That variable is only set by `compile`, but already used by `addDebugInfo` 🤔 