### PR TITLE
Added configuration for commonmark use in twig-extra-bundle.

### DIFF
--- a/extra/twig-extra-bundle/DependencyInjection/Configuration.php
+++ b/extra/twig-extra-bundle/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Twig\Extra\TwigExtraBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Twig\Extra\TwigExtraBundle\Extensions;
@@ -35,6 +36,63 @@ class Configuration implements ConfigurationInterface
             ;
         }
 
+        $this->addCommonMarkConfiguration($rootNode);
+
         return $treeBuilder;
+    }
+
+    /**
+     * Full configuration from {@link https://commonmark.thephpleague.com/2.3/configuration}.
+     */
+    private function addCommonMarkConfiguration(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('commonmark')
+                    ->ignoreExtraKeys()
+                    ->children()
+                        ->arrayNode('renderer')
+                            ->info('Array of options for rendering HTML.')
+                            ->children()
+                                ->scalarNode('block_separator')->end()
+                                ->scalarNode('inner_separator')->end()
+                                ->scalarNode('soft_break')->end()
+                            ->end()
+                        ->end()
+                        ->enumNode('html_input')
+                            ->info('How to handle HTML input.')
+                            ->values(['strip','allow','escape'])
+                            ->end()
+                        ->booleanNode('allow_unsafe_links')
+                            ->info('Remove risky link and image URLs by setting this to false.')
+                            ->defaultTrue()
+                            ->end()
+                        ->integerNode('max_nesting_level')
+                            ->info('The maximum nesting level for blocks.')
+                            ->defaultValue(PHP_INT_MAX)
+                            ->end()
+                        ->arrayNode('slug_normalizer')
+                            ->info('Array of options for configuring how URL-safe slugs are created.')
+                            ->children()
+                                ->variableNode('instance')->end()
+                                ->integerNode('max_length')->defaultValue(255)->end()
+                                ->variableNode('unique')->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('commonmark')
+                            ->info('Array of options for configuring the CommonMark core extension.')
+                            ->children()
+                                ->booleanNode('enable_em')->defaultTrue()->end()
+                                ->booleanNode('enable_strong')->defaultTrue()->end()
+                                ->booleanNode('use_asterisk')->defaultTrue()->end()
+                                ->booleanNode('use_underscore')->defaultTrue()->end()
+                                ->arrayNode('unordered_list_markers')
+                                    ->scalarPrototype()->end()
+                                    ->defaultValue([['-', '*', '+']])->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
     }
 }

--- a/extra/twig-extra-bundle/DependencyInjection/TwigExtraExtension.php
+++ b/extra/twig-extra-bundle/DependencyInjection/TwigExtraExtension.php
@@ -39,6 +39,12 @@ class TwigExtraExtension extends Extension
 
                 if ('markdown' === $extension && \class_exists(CommonMarkConverter::class)) {
                     $loader->load('markdown_league.php');
+
+                    if ($container->hasDefinition('twig.markdown.league_common_mark_converter_factory')) {
+                        $container
+                            ->getDefinition('twig.markdown.league_common_mark_converter_factory')
+                            ->setArgument('$config', $config['commonmark'] ?? []);
+                    }
                 }
             }
         }

--- a/extra/twig-extra-bundle/LeagueCommonMarkConverterFactory.php
+++ b/extra/twig-extra-bundle/LeagueCommonMarkConverterFactory.php
@@ -21,17 +21,20 @@ final class LeagueCommonMarkConverterFactory
 {
     private $extensions;
 
+    private $config;
+
     /**
      * @param ExtensionInterface[] $extensions
      */
-    public function __construct(iterable $extensions)
+    public function __construct(iterable $extensions, array $config = [])
     {
         $this->extensions = $extensions;
+        $this->config = $config;
     }
 
     public function __invoke(): CommonMarkConverter
     {
-        $converter = new CommonMarkConverter();
+        $converter = new CommonMarkConverter($this->config);
 
         foreach ($this->extensions as $extension) {
             $converter->getEnvironment()->addExtension($extension);

--- a/extra/twig-extra-bundle/Tests/DependencyInjection/TwigExtraExtensionTest.php
+++ b/extra/twig-extra-bundle/Tests/DependencyInjection/TwigExtraExtensionTest.php
@@ -26,7 +26,29 @@ class TwigExtraExtensionTest extends TestCase
             'kernel.debug' => false,
         ]));
         $container->registerExtension(new TwigExtraExtension());
-        $container->loadFromExtension('twig_extra');
+        $container->loadFromExtension('twig_extra', [
+            'commonmark' =>  [
+                'extra_key' => true,
+                'renderer' => [
+                    'block_separator' => "\n",
+                    'inner_separator' => "\n",
+                    'soft_break'      => "\n",
+                ],
+                'commonmark' => [
+                    'enable_em' => true,
+                    'enable_strong' => true,
+                    'use_asterisk' => true,
+                    'use_underscore' => true,
+                    'unordered_list_markers' => ['-', '*', '+'],
+                ],
+                'html_input' => 'escape',
+                'allow_unsafe_links' => false,
+                'max_nesting_level' => PHP_INT_MAX,
+                'slug_normalizer' => [
+                    'max_length' => 255,
+                ],
+            ],
+        ]);
         $container->getCompilerPassConfig()->setOptimizationPasses([]);
         $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->getCompilerPassConfig()->setAfterRemovingPasses([]);


### PR DESCRIPTION
Following this tweet: https://twitter.com/ramsey/status/1561894460560138241, this PR adds the configuration options for `commonmark` to the `twig-extra-bundle`.

The configuration is added to the `LeagueCommonMarkConverterFactory` and in turn injected in the `CommonMarkConverter`. This way a user can provide the configuration for usage inside twig.

I'm not sure if adding the configuration inside the extension is the way to go.

Hope this helps out at least @ramsey :-)

Added `ignoreExtraKeys` to be somewhat future proof in case extra configuration is added later on, and also to be able to provide de configuration for extensions.