### PR TITLE
Twig\Environment::compileSource fail to catch php-native Error's

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -517,7 +517,7 @@ class Environment
         } catch (Error $e) {
             $e->setSourceContext($source);
             throw $e;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             throw new SyntaxError(sprintf('An exception has been thrown during the compilation of a template ("%s").', $e->getMessage()), -1, $source, $e);
         }
     }


### PR DESCRIPTION
it will catch Exceptions and Twig\Error\Error's (whatever that is, i haven't investigated), but it won't catch [native PHP Error](https://www.php.net/manual/en/class.error.php)'s and derivatives, for example [ArgumentCountError](https://www.php.net/manual/en/class.argumentcounterror.php)

not sure if the code should be rewritten to 
```
        } catch (Error $e) {
            $e->setSourceContext($source);
            throw $e;
        } catch (\Throwable $e) {
            throw new SyntaxError(sprintf('An exception has been thrown during the compilation of a template ("%s").', $e->getMessage()), -1, $source, $e);
        }
```
or
```
        } catch (\Error $e) {
            $e->setSourceContext($source);
            throw $e;
        } catch (\Exception $e) {
            throw new SyntaxError(sprintf('An exception has been thrown during the compilation of a template ("%s").', $e->getMessage()), -1, $source, $e);
        }
```
but probably 1 of those.. and my best guess is the former.