### PR TITLE
Update michelf/php-markdown require-dev to allow v2

### DIFF
--- a/extra/markdown-extra/composer.json
+++ b/extra/markdown-extra/composer.json
@@ -23,7 +23,7 @@
         "erusev/parsedown": "^1.7",
         "league/commonmark": "^1.0",
         "league/html-to-markdown": "^4.8|^5.0",
-        "michelf/php-markdown": "^1.8"
+        "michelf/php-markdown": "^1.8|^2.0"
     },
     "autoload": {
         "psr-4" : { "Twig\\Extra\\Markdown\\" : "" },


### PR DESCRIPTION
This new release should work fine: https://github.com/michelf/php-markdown#version-history