### PR TITLE
Add "html_attributes" twig filter for easiely write attributes as objects

### DIFF
--- a/extra/html-extra/HtmlExtension.php
+++ b/extra/html-extra/HtmlExtension.php
@@ -111,7 +111,7 @@ final class HtmlExtension extends AbstractExtension
                 continue;
             }
 
-            $htmlAttributes[] = $key . '="' . twig_escape_filter($environment, $value, 'html_attr') . '"';
+            $htmlAttributes[] = $key . '="' . twig_escape_filter($environment, $value) . '"';
         }
 
         return implode(' ', $htmlAttributes);

--- a/extra/html-extra/HtmlExtension.php
+++ b/extra/html-extra/HtmlExtension.php
@@ -89,7 +89,7 @@ final class HtmlExtension extends AbstractExtension
     }
 
     /**
-     * @param array{string, string|bool|null} $attributes
+     * @param array{string, string|bool|int|float|null} $attributes
      */
     public function htmlAttributes(Environment $environment, array $attributes): string
     {
@@ -106,6 +106,7 @@ final class HtmlExtension extends AbstractExtension
                 continue;
             }
 
+            // null represent no value and should not be outputted for a better DX
             if (null === $value) {
                 continue;
             }


### PR DESCRIPTION
Example usage:

```twig
<!-- button.html.twig -->
{# required #}
{%- set text = text -%}

{# optional #}
{%- set id = id|default(null) -%}
{%- set skin = skin|default('primary') -%}
{%- set type = type|default('button') -%}
{%- set disabled = disabled|default(false) -%}
{%- set href = href|default(null) -%}

{% set attributes = {
    'id': id,
    'class': html_classes(
        'c-button',
        {
            'c-button--primary': skin == 'primary',
            'c-button--secondary': skin == 'secondary',
            'c-button--borderless': skin == 'borderless',
        },
    ),
    'href': href,
    'type': not href ? type : null,
    'disabled': disabled,
} %}

{% set tag = href ? 'a' : 'button' %}

<{{ tag }} {{ attributes|html_attributes }}>
    {{- text -}}
</{{ tag }}>
```

## TODO

 - [x] Escape Value
 - [ ] Add Test Case