### PR TITLE
Fix php 8.0 compatilibity

### DIFF
--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -63,7 +63,7 @@ class FilesystemCache implements CacheInterface
 
             if (self::FORCE_BYTECODE_INVALIDATION == ($this->options & self::FORCE_BYTECODE_INVALIDATION)) {
                 // Compile cached file into bytecode cache
-                if (\function_exists('opcache_invalidate') && filter_var(ini_get('opcache.enable'), \FILTER_VALIDATE_BOOLEAN)) {
+                if (\function_exists('opcache_invalidate') && \filter_var(ini_get('opcache.enable'), \FILTER_VALIDATE_BOOLEAN)) {
                     @opcache_invalidate($key, true);
                 } elseif (\function_exists('apc_compile_file')) {
                     apc_compile_file($key);

--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -63,7 +63,7 @@ class FilesystemCache implements CacheInterface
 
             if (self::FORCE_BYTECODE_INVALIDATION == ($this->options & self::FORCE_BYTECODE_INVALIDATION)) {
                 // Compile cached file into bytecode cache
-                if (\function_exists('opcache_invalidate') && \filter_var(ini_get('opcache.enable'), \FILTER_VALIDATE_BOOLEAN)) {
+                if (\function_exists('opcache_invalidate') && \filter_var(\ini_get('opcache.enable'), \FILTER_VALIDATE_BOOLEAN)) {
                     @opcache_invalidate($key, true);
                 } elseif (\function_exists('apc_compile_file')) {
                     apc_compile_file($key);


### PR DESCRIPTION
At least with php80 I get something like `Call to undefined function filter_var()` at line 66 of FilesystemCache.php

With the patch applied, it works again.