### PR TITLE
Suppress tempnam notices

### DIFF
--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -63,7 +63,7 @@ class FilesystemCache implements CacheInterface
 
             if (self::FORCE_BYTECODE_INVALIDATION == ($this->options & self::FORCE_BYTECODE_INVALIDATION)) {
                 // Compile cached file into bytecode cache
-                if (\function_exists('opcache_invalidate') && filter_var(ini_get('opcache.enable'), \FILTER_VALIDATE_BOOLEAN)) {
+                if (\function_exists('opcache_invalidate') && filter_var(\ini_get('opcache.enable'), \FILTER_VALIDATE_BOOLEAN)) {
                     @opcache_invalidate($key, true);
                 } elseif (\function_exists('apc_compile_file')) {
                     apc_compile_file($key);

--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -57,7 +57,7 @@ class FilesystemCache implements CacheInterface
             throw new \RuntimeException(sprintf('Unable to write in the cache directory (%s).', $dir));
         }
 
-        $tmpFile = tempnam($dir, basename($key));
+        $tmpFile = @tempnam($dir, basename($key));
         if (false !== @file_put_contents($tmpFile, $content) && @rename($tmpFile, $key)) {
             @chmod($key, 0666 & ~umask());
 


### PR DESCRIPTION
```
tempnam(): file created in the system's temporary directory at /var/www/html/support/vendor/twig/twig/src/Cache/FilesystemCache.php:60)
[stacktrace]
#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 /var/www/html/support/vendor/twig/twig/src/Cache/FilesystemCache.php(60): tempnam()
#2 /var/www/html/support/vendor/twig/twig/src/Environment.php(349): Twig\\Cache\\FilesystemCache->write()
#3 /var/www/html/support/vendor/twig/twig/src/Environment.php(399): Twig\\Environment->loadTemplate()
```

Notice introduced in PHP 7.1.0-rc.1 by https://bugs.php.net/bug.php?id=69489