### PR TITLE
Improve phpdoc of ExtensionInterface/Environment/Expressionparser arrays

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -25,6 +25,8 @@ use Twig\Extension\OptimizerExtension;
 use Twig\Loader\ArrayLoader;
 use Twig\Loader\ChainLoader;
 use Twig\Loader\LoaderInterface;
+use Twig\Node\Expression\Binary\AbstractBinary;
+use Twig\Node\Expression\Unary\AbstractUnary;
 use Twig\Node\ModuleNode;
 use Twig\Node\Node;
 use Twig\NodeVisitor\NodeVisitorInterface;
@@ -53,6 +55,7 @@ class Environment
     private $lexer;
     private $parser;
     private $compiler;
+    /** @var array<string, mixed> */
     private $globals = [];
     private $resolvedGlobals;
     private $loadedTemplates;
@@ -775,6 +778,8 @@ class Environment
 
     /**
      * @internal
+     *
+     * @return array<string, mixed>
      */
     public function getGlobals(): array
     {
@@ -804,6 +809,8 @@ class Environment
 
     /**
      * @internal
+     *
+     * @return array<string, array{precedence: int, class: class-string<AbstractUnary>}>
      */
     public function getUnaryOperators(): array
     {
@@ -812,6 +819,8 @@ class Environment
 
     /**
      * @internal
+     *
+     * @return array<string, array{precedence: int, class: class-string<AbstractBinary>, associativity: ExpressionParser::OPERATOR_*}>
      */
     public function getBinaryOperators(): array
     {

--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -17,6 +17,7 @@ use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\ArrowFunctionExpression;
 use Twig\Node\Expression\AssignNameExpression;
+use Twig\Node\Expression\Binary\AbstractBinary;
 use Twig\Node\Expression\Binary\ConcatBinary;
 use Twig\Node\Expression\BlockReferenceExpression;
 use Twig\Node\Expression\ConditionalExpression;
@@ -26,6 +27,7 @@ use Twig\Node\Expression\MethodCallExpression;
 use Twig\Node\Expression\NameExpression;
 use Twig\Node\Expression\ParentExpression;
 use Twig\Node\Expression\TestExpression;
+use Twig\Node\Expression\Unary\AbstractUnary;
 use Twig\Node\Expression\Unary\NegUnary;
 use Twig\Node\Expression\Unary\NotUnary;
 use Twig\Node\Expression\Unary\PosUnary;
@@ -48,7 +50,9 @@ class ExpressionParser
 
     private $parser;
     private $env;
+    /** @var array<string, array{precedence: int, class: class-string<AbstractUnary>}> */
     private $unaryOperators;
+    /** @var array<string, array{precedence: int, class: class-string<AbstractBinary>, associativity: self::OPERATOR_*}> */
     private $binaryOperators;
 
     public function __construct(Parser $parser, Environment $env)

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -11,6 +11,9 @@
 
 namespace Twig\Extension;
 
+use Twig\ExpressionParser;
+use Twig\Node\Expression\Binary\AbstractBinary;
+use Twig\Node\Expression\Unary\AbstractUnary;
 use Twig\NodeVisitor\NodeVisitorInterface;
 use Twig\TokenParser\TokenParserInterface;
 use Twig\TwigFilter;
@@ -63,6 +66,11 @@ interface ExtensionInterface
      * Returns a list of operators to add to the existing list.
      *
      * @return array<array> First array of unary operators, second array of binary operators
+     *
+     * @psalm-return array{
+     *     array<string, array{precedence: int, class: class-string<AbstractUnary>}>,
+     *     array<string, array{precedence: int, class: class-string<AbstractBinary>, associativity: ExpressionParser::OPERATOR_*}>
+     * }
      */
     public function getOperators();
 }

--- a/src/Extension/GlobalsInterface.php
+++ b/src/Extension/GlobalsInterface.php
@@ -21,5 +21,8 @@ namespace Twig\Extension;
  */
 interface GlobalsInterface
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function getGlobals(): array;
 }

--- a/src/ExtensionSet.php
+++ b/src/ExtensionSet.php
@@ -15,6 +15,8 @@ use Twig\Error\RuntimeError;
 use Twig\Extension\ExtensionInterface;
 use Twig\Extension\GlobalsInterface;
 use Twig\Extension\StagingExtension;
+use Twig\Node\Expression\Binary\AbstractBinary;
+use Twig\Node\Expression\Unary\AbstractUnary;
 use Twig\NodeVisitor\NodeVisitorInterface;
 use Twig\TokenParser\TokenParserInterface;
 
@@ -31,11 +33,17 @@ final class ExtensionSet
     private $staging;
     private $parsers;
     private $visitors;
+    /** @var array<string, TwigFilter> */
     private $filters;
+    /** @var array<string, TwigTest> */
     private $tests;
+    /** @var array<string, TwigFunction> */
     private $functions;
+    /** @var array<string, array{precedence: int, class: class-string<AbstractUnary>}> */
     private $unaryOperators;
+    /** @var array<string, array{precedence: int, class: class-string<AbstractBinary>, associativity: ExpressionParser::OPERATOR_*}> */
     private $binaryOperators;
+    /** @var array<string, mixed> */
     private $globals;
     private $functionCallbacks = [];
     private $filterCallbacks = [];
@@ -305,6 +313,9 @@ final class ExtensionSet
         $this->parserCallbacks[] = $callable;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getGlobals(): array
     {
         if (null !== $this->globals) {
@@ -379,6 +390,9 @@ final class ExtensionSet
         return null;
     }
 
+    /**
+     * @return array<string, array{precedence: int, class: class-string<AbstractUnary>}>
+     */
     public function getUnaryOperators(): array
     {
         if (!$this->initialized) {
@@ -388,6 +402,9 @@ final class ExtensionSet
         return $this->unaryOperators;
     }
 
+    /**
+     * @return array<string, array{precedence: int, class: class-string<AbstractBinary>, associativity: ExpressionParser::OPERATOR_*}>
+     */
     public function getBinaryOperators(): array
     {
         if (!$this->initialized) {


### PR DESCRIPTION
Binary and Unary operator have a really specific format
```
array<string, array{precedence: int, class: class-string}>,
array<string, array{precedence: int, class: class-string, associativity: int}>
```
so it's worth to mention that in the phpdoc rather than `array<array>`