### PR TITLE
Updates CoreExtension::twig_constant to check for definition first to avoid hard crash

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1329,6 +1329,10 @@ function twig_constant($constant, $object = null)
         $constant = \get_class($object).'::'.$constant;
     }
 
+    if (!\defined($constant)) {
+        throw new RuntimeError(sprintf('Constant "%s" is undefined.', $constant));
+    }
+
     return \constant($constant);
 }
 


### PR DESCRIPTION
The behaviour of PHP's constant() method has been updated after https://github.com/php/php-src/issues/9905 was accepted and fixed in PHP 8.1 (and previously changed post PHP 8.0) . This PR prevents a fatal error in the case a constant is supplied that doesn't actually exist.