### PR TITLE
Fix optimizing closures callbacks

### DIFF
--- a/src/Node/Expression/CallExpression.php
+++ b/src/Node/Expression/CallExpression.php
@@ -304,7 +304,9 @@ abstract class CallExpression extends AbstractExpression
         if ($object = $r->getClosureThis()) {
             $callable = [$object, $r->name];
             $callableName = (\function_exists('get_debug_type') ? get_debug_type($object) : \get_class($object)).'::'.$r->name;
-        } elseif ($class = $r->getClosureScopeClass()) {
+        } elseif (\PHP_VERSION_ID >= 80111 && $class = $r->getClosureCalledClass()) {
+            $callableName = $class->name.'::'.$r->name;
+        } elseif (\PHP_VERSION_ID < 80111 && $class = $r->getClosureScopeClass()) {
             $callableName = (\is_array($callable) ? $callable[0] : $class->name).'::'.$r->name;
         } else {
             $callable = $callableName = $r->name;


### PR DESCRIPTION
Follows https://github.com/twigphp/Twig/pull/3722 and https://github.com/php/php-src/issues/8932

Uses a dedicated method added to PHP 8.1.11 (and 8.0.24, but I feel like there is no need to make the check too complex for an outdated version. We just need a marker to make the code simpler when we'll bump to PHP >= 8.1.11.)