### PR TITLE
Add `level` argument to `parent()` function

### DIFF
--- a/doc/functions/parent.rst
+++ b/doc/functions/parent.rst
@@ -17,6 +17,16 @@ parent block when overriding a block by using the ``parent`` function:
 The ``parent()`` call will return the content of the ``sidebar`` block as
 defined in the ``base.html`` template.
 
+In addition, the ``parent`` function takes one optional argument that specifies the inheritance level
+in case there are multiple levels of inheritance:
+
+.. code-block:: twig
+
+    {{ parent(level=2) }}
+
+This allows you to render the contents of a template that's further up the inheritance tree,
+without rendering the contents of the intermediate templates.
+
 .. seealso::
 
     :doc:`extends<../tags/extends>`, :doc:`block<../functions/block>`, :doc:`block<../tags/block>`

--- a/src/Node/Expression/ParentExpression.php
+++ b/src/Node/Expression/ParentExpression.php
@@ -13,6 +13,7 @@
 namespace Twig\Node\Expression;
 
 use Twig\Compiler;
+use Twig\Node\Node;
 
 /**
  * Represents a parent node.
@@ -21,9 +22,25 @@ use Twig\Compiler;
  */
 class ParentExpression extends AbstractExpression
 {
-    public function __construct(string $name, int $lineno, string $tag = null)
+    public function __construct(string $name, int $lineno, /* Node */ $level = null, string $tag = null)
     {
-        parent::__construct([], ['output' => false, 'name' => $name], $lineno, $tag);
+        if (\is_string($level)) {
+            $tag = $level;
+            $level = null;
+
+            @trigger_error(sprintf('Passing $tag as the 3rd argument instead of 4th to the %s constructor is deprecated since Twig 3.5.', __CLASS__), \E_USER_DEPRECATED);
+        }
+
+        if (null !== $level && !$level instanceof Node) {
+            throw new \TypeError(sprintf('Argument 3 passed to "%s()" must be an instance of "%s" or null, "%s" given.', __METHOD__, Node::class, \is_object($level) ? \get_class($level) : \gettype($level)));
+        }
+
+        $nodes = [];
+        if (null !== $level) {
+            $nodes['level'] = $level;
+        }
+
+        parent::__construct($nodes, ['output' => false, 'name' => $name], $lineno, $tag);
     }
 
     public function compile(Compiler $compiler): void
@@ -33,14 +50,30 @@ class ParentExpression extends AbstractExpression
                 ->addDebugInfo($this)
                 ->write('$this->displayParentBlock(')
                 ->string($this->getAttribute('name'))
-                ->raw(", \$context, \$blocks);\n")
+                ->raw(', $context, $blocks')
             ;
+            $this->compileLevel($compiler);
+            $compiler->raw(");\n");
         } else {
             $compiler
                 ->raw('$this->renderParentBlock(')
                 ->string($this->getAttribute('name'))
-                ->raw(', $context, $blocks)')
+                ->raw(', $context, $blocks')
             ;
+            $this->compileLevel($compiler);
+            $compiler->raw(')');
         }
+    }
+
+    private function compileLevel(Compiler $compiler): void
+    {
+        if (!$this->hasNode('level')) {
+            return;
+        }
+
+        $compiler
+            ->raw(', ')
+            ->subcompile($this->getNode('level'))
+        ;
     }
 }

--- a/tests/Fixtures/functions/block_without_parent_with_level.test
+++ b/tests/Fixtures/functions/block_without_parent_with_level.test
@@ -1,0 +1,16 @@
+--TEST--
+"block" calling parent() with a level with no definition in parent template
+--TEMPLATE--
+{% extends "parent.twig" %}
+
+{% block label %}{{ parent(level=2) }}{% endblock %}
+--TEMPLATE(parent.twig)--
+{% extends "grandparent.twig" %}
+
+{% block label %}{{ parent() }}{% endblock %}
+--TEMPLATE(grandparent.twig)--
+{{ block('label') }}
+--DATA--
+return []
+--EXCEPTION--
+Twig\Error\RuntimeError: Block "label" should not call parent() in "index.twig" as the block does not exist in the parent template "grandparent.twig" in "index.twig" at line 4.

--- a/tests/Fixtures/functions/parent_with_invalid_num_args.test
+++ b/tests/Fixtures/functions/parent_with_invalid_num_args.test
@@ -1,0 +1,12 @@
+--TEST--
+"parent" function with invalid number of arguments
+--TEMPLATE--
+{% extends "parent.twig" %}
+
+{% block content %}{{ parent(2, 3) }}{% endblock %}
+--TEMPLATE(parent.twig)--
+{% block content %}{% endblock %}
+--DATA--
+return []
+--EXCEPTION--
+Twig\Error\SyntaxError: The "parent" function takes one optional argument (the level) in "index.twig" at line 4.

--- a/tests/Fixtures/functions/parent_with_nonexisting_level.test
+++ b/tests/Fixtures/functions/parent_with_nonexisting_level.test
@@ -1,0 +1,12 @@
+--TEST--
+"parent" function with non-existing level
+--TEMPLATE--
+{% extends "parent.twig" %}
+
+{% block content %}{{ parent(level=2) }}{% endblock %}
+--TEMPLATE(parent.twig)--
+{% block content %}{% endblock %}
+--DATA--
+return []
+--EXCEPTION--
+Twig\Error\RuntimeError: The template has no parent and no traits defining the "content" block 2 levels up in "index.twig" at line 4.

--- a/tests/Fixtures/functions/parent_with_nonpositive_level.test
+++ b/tests/Fixtures/functions/parent_with_nonpositive_level.test
@@ -1,0 +1,12 @@
+--TEST--
+"parent" function with non-positive level
+--TEMPLATE--
+{% extends "parent.twig" %}
+
+{% block content %}{{ parent(level=-1) }}{% endblock %}
+--TEMPLATE(parent.twig)--
+{% block content %}{% endblock %}
+--DATA--
+return []
+--EXCEPTION--
+Twig\Error\RuntimeError: Level must be an integer greater than zero, -1 provided in "index.twig" at line 4.

--- a/tests/Fixtures/functions/parent_with_unknown_arg.test
+++ b/tests/Fixtures/functions/parent_with_unknown_arg.test
@@ -1,0 +1,12 @@
+--TEST--
+"parent" function with an unknown argument
+--TEMPLATE--
+{% extends "parent.twig" %}
+
+{% block content %}{{ parent(foobar=2) }}{% endblock %}
+--TEMPLATE(parent.twig)--
+{% block content %}{% endblock %}
+--DATA--
+return []
+--EXCEPTION--
+Twig\Error\SyntaxError: Unknown argument "foobar" for function "parent(level=1) in "index.twig" at line 4.

--- a/tests/Fixtures/tags/inheritance/parent_with_level.test
+++ b/tests/Fixtures/tags/inheritance/parent_with_level.test
@@ -1,0 +1,20 @@
+--TEST--
+"parent" function with level
+--TEMPLATE--
+{% extends "parent.twig" %}
+
+{% block title %}{{ parent(2) }} title{% endblock %}
+{% block content %}{{ parent(level=2) }} content{% endblock %}
+--TEMPLATE(parent.twig)--
+{% extends "grandparent.twig" %}
+
+{% block title %}{{ parent() }} title_parent{% endblock %}
+{% block content %}{{ parent() }} content_parent{% endblock %}
+--TEMPLATE(grandparent.twig)--
+{% block title %}title_grandparent{% endblock %}<br>
+{% block content %}content_grandparent{% endblock %}
+--DATA--
+return []
+--EXPECT--
+title_grandparent title<br>
+content_grandparent content

--- a/tests/Fixtures/tags/inheritance/parent_with_level_and_use1.test
+++ b/tests/Fixtures/tags/inheritance/parent_with_level_and_use1.test
@@ -1,0 +1,29 @@
+--TEST--
+"parent" function with level and use in parent template
+--TEMPLATE--
+{% extends "parent.twig" %}
+
+{% block content_use %}
+    {{ parent(level=2) }}
+    content{% endblock %}
+--TEMPLATE(parent.twig)--
+{% use "use.twig" %}
+
+{% block content_use %}
+    {{ parent() }}
+    content_parent{% endblock %}
+--TEMPLATE(use.twig)--
+{% use "parent_use.twig" %}
+
+{% block content_use %}
+    {{ parent() }}
+    content_use{% endblock %}
+--TEMPLATE(parent_use.twig)--
+{% block content_use %}
+    content_parent_use{% endblock %}
+--DATA--
+return []
+--EXPECT--
+    content_parent_use
+    content_use
+    content

--- a/tests/Fixtures/tags/inheritance/parent_with_level_and_use2.test
+++ b/tests/Fixtures/tags/inheritance/parent_with_level_and_use2.test
@@ -1,0 +1,26 @@
+--TEST--
+"parent" function with level and use in child template
+--TEMPLATE--
+{% extends "parent.twig" %}
+{% use "use.twig" %}
+
+{% block content_use %}
+    {{ parent(level=2) }}
+    content{% endblock %}
+--TEMPLATE(parent.twig)--
+{% block content_use %}
+    content_parent{% endblock %}
+--TEMPLATE(use.twig)--
+{% use "parent_use.twig" %}
+
+{% block content_use %}
+    {{ parent() }}
+    content_use{% endblock %}
+--TEMPLATE(parent_use.twig)--
+{% block content_use %}
+    content_parent_use{% endblock %}
+--DATA--
+return []
+--EXPECT--
+    content_parent_use
+    content


### PR DESCRIPTION
Resolves #3232

This PR adds an optional `level` argument to the `parent()` function to allow "skipping" certain parents in case there are multiple levels of inheritance.