### PR TITLE
chore: add ci tests for php 8.2, bump github actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,12 @@ jobs:
                     - '7.4'
                     - '8.0'
                     - '8.1'
+                    - '8.2'
                 experimental: [false]
 
         steps:
             - name: "Checkout code"
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: "Install PHP with extensions"
               uses: shivammathur/setup-php@v2
@@ -73,6 +74,7 @@ jobs:
                     - '7.4'
                     - '8.0'
                     - '8.1'
+                    - '8.2'
                 extension:
                     - 'extra/cache-extra'
                     - 'extra/cssinliner-extra'
@@ -86,7 +88,7 @@ jobs:
 
         steps:
             - name: "Checkout code"
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: "Install PHP with extensions"
               uses: shivammathur/setup-php@v2
@@ -134,7 +136,7 @@ jobs:
 #
 #        steps:
 #            - name: "Checkout code"
-#              uses: actions/checkout@v2
+#              uses: actions/checkout@v3
 #
 #            - name: "Install PHP with extensions"
 #              uses: shivammathur/setup-php@2

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,22 +18,22 @@ jobs:
 
         steps:
             -   name: "Checkout code"
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: "Set-up PHP"
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none
                     tools: "composer:v2"
 
             -   name: Get composer cache directory
                 id: composercache
                 working-directory: doc/_build
-                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             -   name: Cache dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ${{ steps.composercache.outputs.dir }}
                     key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -54,7 +54,7 @@ jobs:
 
         steps:
             - name: "Checkout code"
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: "Run DOCtor-RST"
               uses: docker://oskarstark/doctor-rst


### PR DESCRIPTION
Bump github action version to fix deprecations.
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
