### PR TITLE
Add file and line to error message

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -405,7 +405,8 @@ abstract class Template
 
             throw $e;
         } catch (\Exception $e) {
-            $e = new RuntimeError(sprintf('An exception has been thrown during the rendering of a template ("%s").', $e->getMessage()), -1, $this->getSourceContext(), $e);
+            $errorText = 'An exception has been thrown during the rendering of a template ("%s"). File: %s Line: %s ';
+            $e = new RuntimeError(sprintf($errorText, $e->getMessage(), $e->getFile(),$e->getLine()), -1, $this->getSourceContext(), $e);
             $e->guess();
 
             throw $e;

--- a/src/Template.php
+++ b/src/Template.php
@@ -182,7 +182,8 @@ abstract class Template
 
                 throw $e;
             } catch (\Exception $e) {
-                $e = new RuntimeError(sprintf('An exception has been thrown during the rendering of a template ("%s").', $e->getMessage()), -1, $template->getSourceContext(), $e);
+                $errorText = 'An exception has been thrown during the rendering of a template ("%s"). File: %s Line: %s ';
+                $e = new RuntimeError(sprintf($errorText, $e->getMessage(), $e->getFile(), $e->getLine()), -1, $template->getSourceContext(), $e);
                 $e->guess();
 
                 throw $e;


### PR DESCRIPTION
When an error occures we currently get the message e.g. 
"An exception has been thrown during the rendering of a template ("Warning: Undefined array key "select"")."

The problem is, that we don't know in which file and where the error occured so it is very hard to find the "cause" of the problem. 
If we add the File and Line it is quite easy to find the problem:

![image](https://user-images.githubusercontent.com/8791970/210109678-865e2d2d-d546-4946-9adc-bc7623c6ffb2.png)
