### PR TITLE
Update docs for filters that use the `calendar` option

### DIFF
--- a/doc/filters/format_date.rst
+++ b/doc/filters/format_date.rst
@@ -33,4 +33,4 @@ Arguments
 * ``dateFormat``: The date format
 * ``pattern``: A date time pattern
 * ``timezone``: The date timezone
-* ``calendar``: The calendar (Gregorian by default)
+* ``calendar``: The calendar ("gregorian" by default)

--- a/doc/filters/format_datetime.rst
+++ b/doc/filters/format_datetime.rst
@@ -97,6 +97,6 @@ Arguments
 * ``timeFormat``: The time format
 * ``pattern``: A date time pattern
 * ``timezone``: The date timezone name
-* ``calendar``: The calendar (Gregorian by default)
+* ``calendar``: The calendar ("gregorian" by default)
 
 .. _ICU user guide: https://unicode-org.github.io/icu/userguide/format_parse/datetime/#datetime-format-syntax

--- a/doc/filters/format_time.rst
+++ b/doc/filters/format_time.rst
@@ -33,4 +33,4 @@ Arguments
 * ``timeFormat``: The time format
 * ``pattern``: A date time pattern
 * ``timezone``: The date timezone
-* ``calendar``: The calendar (Gregorian by default)
+* ``calendar``: The calendar ("gregorian" by default)


### PR DESCRIPTION
`IntlExtension` does not accept "Gregorian", just "gregorian" ([ref](https://github.com/twigphp/intl-extra/blob/f5aa1e3fe3286d476ceca5feafd4390564f7cc29/IntlExtension.php#L324)).