### PR TITLE
Add the new PHP 8.0 IntlDateFormatter::RELATIVE_* constants for date formatting.

### DIFF
--- a/doc/filters/format_datetime.rst
+++ b/doc/filters/format_datetime.rst
@@ -26,6 +26,12 @@ You can tweak the output for the date part and the time part:
 
 Supported values are: ``none``, ``short``, ``medium``, ``long``, and ``full``.
 
+.. versionadded:: 3.6
+
+    ``relative_short``, ``relative_medium``, ``relative_long``, and ``relative_full`` are also supported when running on
+    PHP 8.0 and superior or when using a polyfill that define the ``IntlDateFormatter::RELATIVE_*`` constants and
+    associated behavior.
+
 For greater flexibility, you can even define your own pattern
 (see the `ICU user guide`_ for supported patterns).
 

--- a/extra/intl-extra/Tests/Fixtures/format_date_php8.test
+++ b/extra/intl-extra/Tests/Fixtures/format_date_php8.test
@@ -1,0 +1,12 @@
+--TEST--
+"format_date" filter
+--CONDITION--
+PHP_VERSION_ID >= 80000
+--TEMPLATE--
+{{ 'today 23:39:12'|format_datetime('relative_short', 'none', locale='fr') }}
+{{ 'today 23:39:12'|format_datetime('relative_full', 'full', locale='fr') }}
+--DATA--
+return [];
+--EXPECT--
+aujourd’hui
+aujourd’hui à 23:39:12 temps universel coordonné


### PR DESCRIPTION
Since PHP 8.0, IntlDateFormatter get new constants to format relative dates. This PR add those constants.