### PR TITLE
Restores the leniency of the `matches` twig comparison

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1021,19 +1021,19 @@ function twig_compare($a, $b)
 
 /**
  * @param string $pattern
- * @param string $subject
+ * @param string|null $subject
  *
  * @return int
  *
  * @throws RuntimeError When an invalid pattern is used
  */
-function twig_matches(string $regexp, string $str)
+function twig_matches(string $regexp, ?string $str)
 {
     set_error_handler(function ($t, $m) use ($regexp) {
         throw new RuntimeError(sprintf('Regexp "%s" passed to "matches" is not valid', $regexp).substr($m, 12));
     });
     try {
-        return preg_match($regexp, $str);
+        return preg_match($regexp, $str ?? '');
     } finally {
         restore_error_handler();
     }

--- a/tests/Fixtures/expressions/matches.test
+++ b/tests/Fixtures/expressions/matches.test
@@ -4,9 +4,11 @@ Twig supports the "matches" operator
 {{ 'foo' matches '/o/' ? 'OK' : 'KO' }}
 {{ 'foo' matches '/^fo/' ? 'OK' : 'KO' }}
 {{ 'foo' matches '/O/i' ? 'OK' : 'KO' }}
+{{ null matches '/o/' }}
 --DATA--
 return []
 --EXPECT--
 OK
 OK
 OK
+0


### PR DESCRIPTION
Restores the leniency of the `matches` twig comparison, allowing null subject to result in a non-match.

Resolves BC break introduced in PR https://github.com/twigphp/Twig/pull/3687 ref in https://github.com/twigphp/Twig/issues/3801#issuecomment-1413345131

As per pattern in https://github.com/twigphp/Twig/pull/3617