### PR TITLE
Allow psr/container 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0|^2.0"
     },
     "autoload": {
         "psr-4" : {


### PR DESCRIPTION
Should allow psr/container 2.0.2 - not only 1.1.2

Changes:
https://github.com/php-fig/container/compare/2.0.2...1.1.2