### PR TITLE
Shorten and improve sentence structure

### DIFF
--- a/doc/tags/extends.rst
+++ b/doc/tags/extends.rst
@@ -242,8 +242,8 @@ Let's take another example: a block included within an ``if`` statement:
     {% endif %}
 
 Contrary to what you might think, this template does not define a block
-conditionally; it just makes overridable by a child template the output of
-what will be rendered when the condition is ``true``.
+conditionally; when the condition is ``true``, the rendered output of the 
+block may be overridden by a child template.
 
 If you want the output to be displayed conditionally, use the following
 instead:


### PR DESCRIPTION
This is more succinct and easier to read.

When I initially read it it took me a bit of time to comprehend due to the sentence structure. I feel this reads better, and says what it means in less words.