### PR TITLE
Use twig_ord instead of mb_ord (1.x)

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1237,7 +1237,7 @@ function _twig_escape_js_callback($matches)
         return $shortMap[$char];
     }
 
-    $codepoint = mb_ord($char, 'UTF-8');
+    $codepoint = twig_ord($char, 'UTF-8');
     if (0x10000 > $codepoint) {
         return sprintf('\u%04X', $codepoint);
     }


### PR DESCRIPTION
.. so that twig still works users without mbstring extension.


Twig provides its own wrapper function for `mb_ord` called `twig_ord`, but does not use it. This breaks installations without mbstring.