### PR TITLE
[Extra][Markdown] Allow more variant of MD converter

### DIFF
--- a/extra/markdown-extra/LeagueMarkdown.php
+++ b/extra/markdown-extra/LeagueMarkdown.php
@@ -12,13 +12,14 @@
 namespace Twig\Extra\Markdown;
 
 use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\MarkdownConverter;
 
 class LeagueMarkdown implements MarkdownInterface
 {
     private $converter;
     private $legacySupport;
 
-    public function __construct(CommonMarkConverter $converter = null)
+    public function __construct(MarkdownConverter $converter = null)
     {
         $this->converter = $converter ?: new CommonMarkConverter();
         $this->legacySupport = !method_exists($this->converter, 'convert');


### PR DESCRIPTION
I want to inject `GithubFlavoredMarkdownConverter` but ATM, it's not possible

ref: https://github.com/thephpleague/commonmark#-installation--basic-usage
