### PR TITLE
Add ReturnTypeWillChange to mute deprecation warnings

### DIFF
--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -207,7 +207,8 @@ class Node implements \Twig_NodeInterface
         unset($this->nodes[$name]);
     }
 
-    public function count(): int
+    #[\ReturnTypeWillChange]
+    public function count()
     {
         return \count($this->nodes);
     }

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -276,4 +276,4 @@ class Node implements \Twig_NodeInterface
 class_alias('Twig\Node\Node', 'Twig_Node');
 
 // Ensure that the aliased name is loaded to keep BC for classes implementing the typehint with the old aliased name.
-class_exists('Compiler::class');
+class_exists(Compiler::class);

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -207,6 +207,9 @@ class Node implements \Twig_NodeInterface
         unset($this->nodes[$name]);
     }
 
+    /**
+     * @return int
+     */
     #[\ReturnTypeWillChange]
     public function count()
     {

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -78,7 +78,7 @@ class Node implements \Twig_NodeInterface
     }
 
     /**
-     * @deprecated since 1.16.1 (to be removed in 2.0)
+     * @deprecated since Symfony 1.16.1 (to be removed in 2.0)
      */
     public function toXml($asDom = false)
     {
@@ -125,7 +125,7 @@ class Node implements \Twig_NodeInterface
     }
 
     /**
-     * @deprecated since 1.27 (to be removed in 2.0)
+     * @deprecated since Symfony 1.27 (to be removed in 2.0)
      */
     public function getLine()
     {
@@ -248,7 +248,7 @@ class Node implements \Twig_NodeInterface
     }
 
     /**
-     * @deprecated since 1.27 (to be removed in 2.0)
+     * @deprecated since Symfony 1.27 (to be removed in 2.0)
      */
     public function setFilename($name)
     {
@@ -258,7 +258,7 @@ class Node implements \Twig_NodeInterface
     }
 
     /**
-     * @deprecated since 1.27 (to be removed in 2.0)
+     * @deprecated since Symfony 1.27 (to be removed in 2.0)
      */
     public function getFilename()
     {
@@ -271,4 +271,4 @@ class Node implements \Twig_NodeInterface
 class_alias('Twig\Node\Node', 'Twig_Node');
 
 // Ensure that the aliased name is loaded to keep BC for classes implementing the typehint with the old aliased name.
-class_exists('Twig\Compiler');
+class_exists('Compiler::class');

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -207,18 +207,12 @@ class Node implements \Twig_NodeInterface
         unset($this->nodes[$name]);
     }
 
-    /**
-     * @return int
-     */
-    public function count()
+    public function count(): int
     {
         return \count($this->nodes);
     }
 
-    /**
-     * @return \Traversable
-     */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->nodes);
     }

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -213,6 +213,9 @@ class Node implements \Twig_NodeInterface
         return \count($this->nodes);
     }
 
+    /**
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -213,7 +213,8 @@ class Node implements \Twig_NodeInterface
         return \count($this->nodes);
     }
 
-    public function getIterator(): \Traversable
+    #[\ReturnTypeWillChange]
+    public function getIterator()
     {
         return new \ArrayIterator($this->nodes);
     }


### PR DESCRIPTION
Without this change, version 1.44.7 will show this warning:

![warning](https://user-images.githubusercontent.com/5783787/235679186-004d9385-3e7a-4974-8dd3-e20ff8fcc08d.png)

An alternative fix to this would be something like this:

```
    /**
     * @return int
     */
    #[\ReturnTypeWillChange]
    public function count()
    {
        return \count($this->nodes);
    }

    /**
     * @return \Traversable
     */

    #[\ReturnTypeWillChange]
    public function getIterator()
    {
        return new \ArrayIterator($this->nodes);
    }
```

But I considered this cleaner. 