### PR TITLE
Making the Lexer initialize itself lazily, to avoid loading the extension set early

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -21,6 +21,8 @@ use Twig\Error\SyntaxError;
  */
 class Lexer
 {
+    private $isInitialized = false;
+
     private $tokens;
     private $code;
     private $cursor;
@@ -63,6 +65,15 @@ class Lexer
             'whitespace_line_chars' => ' \t\0\x0B',
             'interpolation' => ['#{', '}'],
         ], $options);
+    }
+
+    private function initialize()
+    {
+        if ($this->isInitialized) {
+            return;
+        }
+
+        $this->isInitialized = true;
 
         // when PHP 7.3 is the min version, we will be able to remove the '#' part in preg_quote as it's part of the default
         $this->regexes = [
@@ -155,6 +166,8 @@ class Lexer
 
     public function tokenize(Source $source)
     {
+        $this->initialize();
+
         $this->source = $source;
         $this->code = str_replace(["\r\n", "\r"], "\n", $source->getCode());
         $this->cursor = 0;


### PR DESCRIPTION
Hi!

Over on Symfony UX, we are pushing Twig in some crazy, "unconventional" ways by overriding the lexer to add a new HTML-like syntax - e.g. `<twig:Alert type="success">` - https://github.com/symfony/ux/blob/2.x/src/TwigComponent/src/Twig/ComponentLexer.php

Normally, the internal `Lexer` is not instantiated until it's needed - i.e. when a template is rendered. However, when overriding the lexer, our `ComponentLexer` needs to be instantiated early and set onto the `Environment`. And since it needs to extend `Lexer`, `Lexer::__construct()` is called much earlier than normal. One line in the constructor - https://github.com/twigphp/Twig/blob/f5ee1b6815a28fbab6e6fbb8c48b7964f0d93dd4/src/Lexer.php#L108 - causes the "extension set" to be loaded inside `Environment`. Some applications rely on being able to set extra Twig extensions after `Environment` is created, but before a template is rendered and our custom lexer currently breaks that.

So, the suggestion is to make the work inside `__construct()` done later. Everything is private, so I believe this is safe.

Cheers!