### PR TITLE
Fix PHP 8.1 deprecation warnings on branch 1.x

### DIFF
--- a/src/Markup.php
+++ b/src/Markup.php
@@ -32,10 +32,7 @@ class Markup implements \Countable
         return $this->content;
     }
 
-    /**
-     * @return int
-     */
-    public function count()
+    public function count(): int
     {
         return \function_exists('mb_get_info') ? mb_strlen($this->content, $this->charset) : \strlen($this->content);
     }

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -78,7 +78,7 @@ class Node implements \Twig_NodeInterface
     }
 
     /**
-     * @deprecated since 1.16.1 (to be removed in 2.0)
+     * @deprecated since Symfony 1.16.1 (to be removed in 2.0)
      */
     public function toXml($asDom = false)
     {
@@ -125,7 +125,7 @@ class Node implements \Twig_NodeInterface
     }
 
     /**
-     * @deprecated since 1.27 (to be removed in 2.0)
+     * @deprecated since Symfony 1.27 (to be removed in 2.0)
      */
     public function getLine()
     {
@@ -248,7 +248,7 @@ class Node implements \Twig_NodeInterface
     }
 
     /**
-     * @deprecated since 1.27 (to be removed in 2.0)
+     * @deprecated since Symfony 1.27 (to be removed in 2.0)
      */
     public function setFilename($name)
     {
@@ -258,7 +258,7 @@ class Node implements \Twig_NodeInterface
     }
 
     /**
-     * @deprecated since 1.27 (to be removed in 2.0)
+     * @deprecated since Symfony 1.27 (to be removed in 2.0)
      */
     public function getFilename()
     {
@@ -271,4 +271,4 @@ class Node implements \Twig_NodeInterface
 class_alias('Twig\Node\Node', 'Twig_Node');
 
 // Ensure that the aliased name is loaded to keep BC for classes implementing the typehint with the old aliased name.
-class_exists('Twig\Compiler');
+class_exists(Compiler::class);

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -207,18 +207,12 @@ class Node implements \Twig_NodeInterface
         unset($this->nodes[$name]);
     }
 
-    /**
-     * @return int
-     */
-    public function count()
+    public function count(): int
     {
         return \count($this->nodes);
     }
 
-    /**
-     * @return \Traversable
-     */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->nodes);
     }

--- a/src/Util/TemplateDirIterator.php
+++ b/src/Util/TemplateDirIterator.php
@@ -16,12 +16,12 @@ namespace Twig\Util;
  */
 class TemplateDirIterator extends \IteratorIterator
 {
-    public function current()
+    public function current(): mixed
     {
         return file_get_contents(parent::current());
     }
 
-    public function key()
+    public function key(): string
     {
         return (string) parent::key();
     }


### PR DESCRIPTION
## What
Fix PHP 8.1 deprecation warnings, e.g.:

```
Deprecated: Return type of Twig\Node\Node::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in twig/twig/src/Node/Node.php on line 213
Deprecated: Return type of Twig\Node\Node::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in twig/twig/src/Node/Node.php on line 221
```

## Why
To fix deprecation warnings on PHP 8.1

I realise 1.x is quite old but it still has some usage