### PR TITLE
Adding support for the ...spread operator on arrays and hashes

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -779,6 +779,14 @@ The following operators don't fit into any of the other categories:
       {# returns the value of foo if it is defined and not null, 'no' otherwise #}
       {{ foo ?? 'no' }}
 
+* ``...``: The spread operator can be used to expand arrays or hashes (it cannot
+  be used to expand the arguments of a function call):
+
+  .. code-block:: twig
+
+      {% set numbers = [1, 2, ...moreNumbers] %}
+      {% set ratings = { 'foo': 10, 'bar': 5, ...moreRatings } %}
+
 .. _templates-string-interpolation:
 
 String Interpolation

--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -334,7 +334,14 @@ class ExpressionParser
             }
             $first = false;
 
-            $node->addElement($this->parseExpression());
+            if ($stream->test(/* Token::SPREAD_TYPE */ 13)) {
+                $stream->next();
+                $expr = $this->parseExpression();
+                $expr->setAttribute('spread', true);
+                $node->addElement($expr);
+            } else {
+                $node->addElement($this->parseExpression());
+            }
         }
         $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ']', 'An opened array is not properly closed');
 
@@ -358,6 +365,14 @@ class ExpressionParser
                 }
             }
             $first = false;
+
+            if ($stream->test(/* Token::SPREAD_TYPE */ 13)) {
+                $stream->next();
+                $value = $this->parseExpression();
+                $value->setAttribute('spread', true);
+                $node->addElement($value);
+                continue;
+            }
 
             // a hash key can be:
             //

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -609,31 +609,33 @@ function twig_urlencode_filter($url)
 }
 
 /**
- * Merges an array with another one.
+ * Merges any number of arrays or Traversable objects.
  *
  *  {% set items = { 'apple': 'fruit', 'orange': 'fruit' } %}
  *
- *  {% set items = items|merge({ 'peugeot': 'car' }) %}
+ *  {% set items = items|merge({ 'peugeot': 'car' }, { 'banana': 'fruit' }) %}
  *
- *  {# items now contains { 'apple': 'fruit', 'orange': 'fruit', 'peugeot': 'car' } #}
+ *  {# items now contains { 'apple': 'fruit', 'orange': 'fruit', 'peugeot': 'car', 'banana': 'fruit' } #}
  *
- * @param array|\Traversable $arr1 An array
- * @param array|\Traversable $arr2 An array
+ * @param array|\Traversable ...$arrays Any number of arrays or Traversable objects to merge
  *
  * @return array The merged array
  */
-function twig_array_merge($arr1, $arr2)
+function twig_array_merge(...$arrays)
 {
-    if (!twig_test_iterable($arr1)) {
-        throw new RuntimeError(sprintf('The merge filter only works with arrays or "Traversable", got "%s" as first argument.', \gettype($arr1)));
+    $result = [];
+
+    foreach ($arrays as $argNumber => $array) {
+        if (!twig_test_iterable($array)) {
+            throw new RuntimeError(sprintf('The merge filter only works with arrays or "Traversable", got "%s" for argument %d.', \gettype($array), $argNumber + 1));
+        }
+
+        $result = array_merge($result, twig_to_array($array));
     }
 
-    if (!twig_test_iterable($arr2)) {
-        throw new RuntimeError(sprintf('The merge filter only works with arrays or "Traversable", got "%s" as second argument.', \gettype($arr2)));
-    }
-
-    return array_merge(twig_to_array($arr1), twig_to_array($arr2));
+    return $result;
 }
+
 
 /**
  * Slices a variable.

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -315,8 +315,13 @@ class Lexer
             }
         }
 
+        // spread operator
+        if ('.' === $this->code[$this->cursor] && ($this->cursor + 2 < $this->end) && '.' === $this->code[$this->cursor + 1] && '.' === $this->code[$this->cursor + 2]) {
+            $this->pushToken(Token::SPREAD_TYPE, '...');
+            $this->moveCursor('...');
+        }
         // arrow function
-        if ('=' === $this->code[$this->cursor] && '>' === $this->code[$this->cursor + 1]) {
+        elseif ('=' === $this->code[$this->cursor] && '>' === $this->code[$this->cursor + 1]) {
             $this->pushToken(Token::ARROW_TYPE, '=>');
             $this->moveCursor('=>');
         }

--- a/src/Token.php
+++ b/src/Token.php
@@ -35,6 +35,7 @@ final class Token
     public const INTERPOLATION_START_TYPE = 10;
     public const INTERPOLATION_END_TYPE = 11;
     public const ARROW_TYPE = 12;
+    public const SPREAD_TYPE = 13;
 
     public function __construct(int $type, $value, int $lineno)
     {
@@ -133,6 +134,9 @@ final class Token
             case self::ARROW_TYPE:
                 $name = 'ARROW_TYPE';
                 break;
+            case self::SPREAD_TYPE:
+                $name = 'SPREAD_TYPE';
+                break;
             default:
                 throw new \LogicException(sprintf('Token of type "%s" does not exist.', $type));
         }
@@ -171,6 +175,8 @@ final class Token
                 return 'end of string interpolation';
             case self::ARROW_TYPE:
                 return 'arrow function';
+            case self::SPREAD_TYPE:
+                return 'spread operator';
             default:
                 throw new \LogicException(sprintf('Token of type "%s" does not exist.', $type));
         }

--- a/tests/Fixtures/expressions/spread_array_operator.test
+++ b/tests/Fixtures/expressions/spread_array_operator.test
@@ -1,0 +1,14 @@
+--TEST--
+Twig supports the spread operator on arrays
+--TEMPLATE--
+{{ [1, 2, ...[3, 4]]|join(',') }}
+{{ [1, 2, ...moreNumbers]|join(',') }}
+{{ [1, 2, ...iterableNumbers]|join(',') }}
+{{ [1, 2, ...iterableNumbers, 0, ...moreNumbers]|join(',') }}
+--DATA--
+return ['moreNumbers' => [5, 6, 7, 8], 'iterableNumbers' => new \ArrayObject([6, 7, 8, 9])]
+--EXPECT--
+1,2,3,4
+1,2,5,6,7,8
+1,2,6,7,8,9
+1,2,6,7,8,9,0,5,6,7,8

--- a/tests/Fixtures/expressions/spread_hash_operator.test
+++ b/tests/Fixtures/expressions/spread_hash_operator.test
@@ -1,0 +1,37 @@
+--TEST--
+Twig supports the spread operator on hashes
+--TEMPLATE--
+{% for key, value in { firstName: 'Ryan', lastName: 'Weaver', favoriteFood: 'popcorn', ...{favoriteFood: 'pizza', sport: 'running'} } %}
+    {{ key }}: {{ value }}
+{% endfor %}
+
+{% for key, value in { firstName: 'Ryan', ...morePersonalDetails} %}
+    {{ key }}: {{ value }}
+{% endfor %}
+
+{% for key, value in { firstName: 'Ryan', ...iterablePersonalDetails} %}
+    {{ key }}: {{ value }}
+{% endfor %}
+
+{# multiple spreads #}
+{% for key, value in { firstName: 'Ryan', ...iterablePersonalDetails, lastName: 'Weaver', ...morePersonalDetails} %}
+    {{ key }}: {{ value }}
+{% endfor %}
+--DATA--
+return ['morePersonalDetails' => ['favoriteColor' => 'orange'], 'iterablePersonalDetails' => new \ArrayObject(['favoriteShoes' => 'barefoot'])];
+--EXPECT--
+    firstName: Ryan
+    lastName: Weaver
+    favoriteFood: pizza
+    sport: running
+
+    firstName: Ryan
+    favoriteColor: orange
+
+    firstName: Ryan
+    favoriteShoes: barefoot
+
+    firstName: Ryan
+    favoriteShoes: barefoot
+    lastName: Weaver
+    favoriteColor: orange

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -51,6 +51,16 @@ class LexerTest extends TestCase
         $this->assertEquals(2, $this->countToken($template, Token::PUNCTUATION_TYPE, '}'));
     }
 
+    public function testSpreadOperator()
+    {
+        $template = '{{ { a: "a", ...{ b: "b" } } }}';
+
+        $this->assertEquals(1, $this->countToken($template, Token::SPREAD_TYPE, '...'));
+        // sanity check on lexing after spread
+        $this->assertEquals(2, $this->countToken($template, Token::PUNCTUATION_TYPE, '{'));
+        $this->assertEquals(2, $this->countToken($template, Token::PUNCTUATION_TYPE, '}'));
+    }
+
     protected function countToken($template, $type, $value = null)
     {
         $lexer = new Lexer(new Environment($this->createMock(LoaderInterface::class)));

--- a/tests/Node/Expression/FilterTest.php
+++ b/tests/Node/Expression/FilterTest.php
@@ -127,7 +127,7 @@ class FilterTest extends NodeTestCase
             new ConstantExpression('3', 1),
             'foo' => new ConstantExpression('bar', 1),
         ]);
-        $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_filter_barbar($context, "abc", "1", "2", [0 => "3", "foo" => "bar"])', $environment];
+        $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_filter_barbar($context, "abc", "1", "2", ["3", "foo" => "bar"])', $environment];
 
         // from extension
         $node = $this->createFilter($string, 'foo');

--- a/tests/Node/Expression/FunctionTest.php
+++ b/tests/Node/Expression/FunctionTest.php
@@ -94,7 +94,7 @@ class FunctionTest extends NodeTestCase
             new ConstantExpression('3', 1),
             'foo' => new ConstantExpression('bar', 1),
         ]);
-        $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_barbar("1", "2", [0 => "3", "foo" => "bar"])', $environment];
+        $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_barbar("1", "2", ["3", "foo" => "bar"])', $environment];
 
         // function as an anonymous function
         $node = $this->createFunction('anonymous', [new ConstantExpression('foo', 1)]);

--- a/tests/Node/Expression/GetAttrTest.php
+++ b/tests/Node/Expression/GetAttrTest.php
@@ -53,7 +53,7 @@ class GetAttrTest extends NodeTestCase
         $args->addElement(new NameExpression('foo', 1));
         $args->addElement(new ConstantExpression('bar', 1));
         $node = new GetAttrExpression($expr, $attr, $args, Template::METHOD_CALL, 1);
-        $tests[] = [$node, sprintf('%s%s, "bar", [0 => %s, 1 => "bar"], "method", false, false, false, 1)', $this->getAttributeGetter(), $this->getVariableGetter('foo', 1), $this->getVariableGetter('foo'))];
+        $tests[] = [$node, sprintf('%s%s, "bar", [%s, "bar"], "method", false, false, false, 1)', $this->getAttributeGetter(), $this->getVariableGetter('foo', 1), $this->getVariableGetter('foo'))];
 
         return $tests;
     }

--- a/tests/Node/Expression/TestTest.php
+++ b/tests/Node/Expression/TestTest.php
@@ -67,7 +67,7 @@ class TestTest extends NodeTestCase
             new ConstantExpression('3', 1),
             'foo' => new ConstantExpression('bar', 1),
         ]);
-        $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_test_barbar("abc", "1", "2", [0 => "3", "foo" => "bar"])', $environment];
+        $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_test_barbar("abc", "1", "2", ["3", "foo" => "bar"])', $environment];
 
         return $tests;
     }


### PR DESCRIPTION
Hi!

Long time user, first time contributor of a real future. I hope I didn't miss anything - but this seemed quite straightforward in the end.

Notes:
* In PHP 7.3 or lower, using the spread operator will result in a Twig syntax error.
* In 8.0 or lower, using the spread operator on a hash will result in a Twig syntax error.

fabbot failures are unrelated, so I'm not touching them.

Cheers!