### PR TITLE
Changing `nl2br` from `<br />` to `<br>`

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1020,7 +1020,7 @@ function twig_trim_filter($string, $characterMask = null, $side = 'both')
  */
 function twig_nl2br($string)
 {
-    return nl2br($string ?? '');
+    return nl2br($string ?? '', false);
 }
 
 /**


### PR DESCRIPTION
https://validator.w3.org/nu/ says:

> Warning: Self-closing tag syntax in text/html documents is [widely discouraged](https://google.github.io/styleguide/htmlcssguide.html#Document_Type); it’s unnecessary and [interacts badly with other HTML features](https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=10809) (e.g., unquoted attribute values). If you’re using a tool that injects self-closing tag syntax into all void elements, [without any option to prevent it from doing so](https://github.com/prettier/prettier/issues/5246), then consider switching to a different tool.

See also https://github.com/symfony/symfony-docs/pull/17308