### PR TITLE
Mention where named arguments are supported

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -205,6 +205,8 @@ built-in functions.
 Named Arguments
 ---------------
 
+Named arguments are supported in functions, filters and tests.
+
 .. code-block:: twig
 
     {% for i in range(low=1, high=10, step=2) %}


### PR DESCRIPTION
This follows up on #929. I tend to forget this detail, so it confuses me over and over again.