### PR TITLE
Improve error message for `constant(FQCN::class)`

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1456,6 +1456,10 @@ final class CoreExtension extends AbstractExtension
         }
 
         if (!\defined($constant)) {
+            if ('::class' === strtolower(substr($constant, -7))) {
+                throw new RuntimeError(sprintf('You cannot use the Twig function "constant()" to access "%s". You could provide an object and call constant("class", $object) or use the class name directly as a string.', $constant));
+            }
+
             throw new RuntimeError(sprintf('Constant "%s" is undefined.', $constant));
         }
 


### PR DESCRIPTION
It is not obvious that you cannot use the Twig function `constant` to get the special `::class` constants of classes like so: `{{ constant('Twig\\Extension\\CoreExtension::class') }}`, due to the underlying PHP function `\constant()`.

The previous error message
> Constant "Twig\Extension\CoreExtension::class" is undefined.

was generally helpful, but in this special case it was a bit misleading.

An alternative might be to determine and return the FCQN (e.g. via `substr($constant, 0, -7)`), but I'm not sure if this would be too much of a guess.