### PR TITLE
Update signature to acknowledge a TemplateWrapper

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1303,12 +1303,12 @@ function twig_test_iterable($value)
 /**
  * Renders a template.
  *
- * @param array        $context
- * @param string|array $template      The template to render or an array of templates to try consecutively
- * @param array        $variables     The variables to pass to the template
- * @param bool         $withContext
- * @param bool         $ignoreMissing Whether to ignore missing templates or not
- * @param bool         $sandboxed     Whether to sandbox the template or not
+ * @param array                        $context
+ * @param string|array|TemplateWrapper $template      The template to render or an array of templates to try consecutively
+ * @param array                        $variables     The variables to pass to the template
+ * @param bool                         $withContext
+ * @param bool                         $ignoreMissing Whether to ignore missing templates or not
+ * @param bool                         $sandboxed     Whether to sandbox the template or not
  *
  * @return string The rendered template
  */


### PR DESCRIPTION
`$name` legitimately can be of type `Twig\TemplateWrapper`. This is already considered in line 1331. This PR updates the method signature in the PHPDoc.

This PR is necessary because other developers may rely on the signature, see contao/contao#6169.