### PR TITLE
Fix callable phpdoc for twig elements

### DIFF
--- a/src/TwigFilter.php
+++ b/src/TwigFilter.php
@@ -29,7 +29,7 @@ final class TwigFilter
     private $arguments = [];
 
     /**
-     * @param callable|null $callable A callable implementing the filter. If null, you need to overwrite the "node_class" option to customize compilation.
+     * @param callable|array<class-string, string>|null $callable A callable implementing the filter. If null, you need to overwrite the "node_class" option to customize compilation.
      */
     public function __construct(string $name, $callable = null, array $options = [])
     {
@@ -57,7 +57,7 @@ final class TwigFilter
     /**
      * Returns the callable to execute for this filter.
      *
-     * @return callable|null
+     * @return callable|array<class-string, string>|null
      */
     public function getCallable()
     {

--- a/src/TwigFunction.php
+++ b/src/TwigFunction.php
@@ -29,7 +29,7 @@ final class TwigFunction
     private $arguments = [];
 
     /**
-     * @param callable|null $callable A callable implementing the function. If null, you need to overwrite the "node_class" option to customize compilation.
+     * @param callable|array<class-string, string>|null $callable A callable implementing the function. If null, you need to overwrite the "node_class" option to customize compilation.
      */
     public function __construct(string $name, $callable = null, array $options = [])
     {
@@ -55,7 +55,7 @@ final class TwigFunction
     /**
      * Returns the callable to execute for this function.
      *
-     * @return callable|null
+     * @return callable|array<class-string, string>|null
      */
     public function getCallable()
     {

--- a/src/TwigTest.php
+++ b/src/TwigTest.php
@@ -28,7 +28,7 @@ final class TwigTest
     private $arguments = [];
 
     /**
-     * @param callable|null $callable A callable implementing the test. If null, you need to overwrite the "node_class" option to customize compilation.
+     * @param callable|array<class-string, string>|null $callable A callable implementing the test. If null, you need to overwrite the "node_class" option to customize compilation.
      */
     public function __construct(string $name, $callable = null, array $options = [])
     {
@@ -51,7 +51,7 @@ final class TwigTest
     /**
      * Returns the callable to execute for this test.
      *
-     * @return callable|null
+     * @return callable|array<class-string, string>|null
      */
     public function getCallable()
     {


### PR DESCRIPTION
Hi @fabpot 
```
[MyRuntime::class, 'myMethod]
```
is not a valid callable in PHP 8 https://3v4l.org/tWqPs

But this syntax is supported because twig has a special behavior
```
$compiler->raw(sprintf('$this->env->getRuntime(\'%s\')->%s', $callable[0], $callable[1]));
```

The PHPDoc should be updated in order to reflect the real behavior and solve static analysis errors.
A phpstan discussion can be found here: https://github.com/phpstan/phpstan/discussions/9567