### PR TITLE
Update Template.php

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -301,6 +301,9 @@ abstract class Template
      */
     protected function loadTemplate($template, $templateName = null, $line = null, $index = null)
     {
+        if($tempelate == null){
+            throw new RuntimeError("Unknown tempelate", $line, $this->getSourceContext());
+        }
         try {
             if (\is_array($template)) {
                 return $this->env->resolveTemplate($template);


### PR DESCRIPTION
When use {%include somting%} it will be conveted to  $this->loadTemplate(($context["somting"] ?? null), "<>", 1)

When context["somting"] is not exists it will be null. and a errror happens at $tempelate cant be null.  This will fix it. I dont know if it a propper way