### PR TITLE
Fix callable phpdoc for twig elements

### DIFF
--- a/src/TwigFilter.php
+++ b/src/TwigFilter.php
@@ -29,7 +29,7 @@ final class TwigFilter
     private $arguments = [];
 
     /**
-     * @param callable|array<class-string, string>|null $callable A callable implementing the filter. If null, you need to overwrite the "node_class" option to customize compilation.
+     * @param callable|array{class-string, string}|null $callable A callable implementing the filter. If null, you need to overwrite the "node_class" option to customize compilation.
      */
     public function __construct(string $name, $callable = null, array $options = [])
     {
@@ -57,7 +57,7 @@ final class TwigFilter
     /**
      * Returns the callable to execute for this filter.
      *
-     * @return callable|array<class-string, string>|null
+     * @return callable|array{class-string, string}|null
      */
     public function getCallable()
     {

--- a/src/TwigFunction.php
+++ b/src/TwigFunction.php
@@ -29,7 +29,7 @@ final class TwigFunction
     private $arguments = [];
 
     /**
-     * @param callable|array<class-string, string>|null $callable A callable implementing the function. If null, you need to overwrite the "node_class" option to customize compilation.
+     * @param callable|array{class-string, string}|null $callable A callable implementing the function. If null, you need to overwrite the "node_class" option to customize compilation.
      */
     public function __construct(string $name, $callable = null, array $options = [])
     {
@@ -55,7 +55,7 @@ final class TwigFunction
     /**
      * Returns the callable to execute for this function.
      *
-     * @return callable|array<class-string, string>|null
+     * @return callable|array{class-string, string}|null
      */
     public function getCallable()
     {

--- a/src/TwigTest.php
+++ b/src/TwigTest.php
@@ -28,7 +28,7 @@ final class TwigTest
     private $arguments = [];
 
     /**
-     * @param callable|array<class-string, string>|null $callable A callable implementing the test. If null, you need to overwrite the "node_class" option to customize compilation.
+     * @param callable|array{class-string, string}|null $callable A callable implementing the test. If null, you need to overwrite the "node_class" option to customize compilation.
      */
     public function __construct(string $name, $callable = null, array $options = [])
     {
@@ -51,7 +51,7 @@ final class TwigTest
     /**
      * Returns the callable to execute for this test.
      *
-     * @return callable|array<class-string, string>|null
+     * @return callable|array{class-string, string}|null
      */
     public function getCallable()
     {


### PR DESCRIPTION
Hi @fabpot 
I made a stupid mistake in https://github.com/twigphp/Twig/pull/3856

The correct phpdoc is `array{class-string, string}` and not `array<class-string, string>`.

Code is used this way
```
$compiler->raw(sprintf('$this->env->getRuntime(\'%s\')->%s', $callable[0], $callable[1]));
```
which means the key 0 is a class string, and the key 1 is a string.

`array{class-string, string}` is same as `array{0: class-string, 1: string}`
`array<class-string, string>` is saying all the keys are class-string, and values are string.