### PR TITLE
Add `enum_cases` function

### DIFF
--- a/src/Extension/EnumExtension.php
+++ b/src/Extension/EnumExtension.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Twig\Extension;
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Twig\TwigFunction;
+
+class EnumExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('enum_cases', __CLASS__.'::enumCases'),
+        ];
+    }
+
+    /**
+     * @template T of \BackedEnum
+     *
+     * @param class-string<T> $backedEnum
+     *
+     * @return T[]
+     */
+    public static function enumCases(string $backedEnum): array
+    {
+        if (!is_a($backedEnum, \BackedEnum::class, true)) {
+            throw new \InvalidArgumentException(sprintf('The enum must be a "\BackedEnum", "%s" given.', $backedEnum));
+        }
+
+        return $backedEnum::cases();
+    }
+}

--- a/tests/Extension/EnumExtensionTest.php
+++ b/tests/Extension/EnumExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Twig\Tests\Extension;
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Twig\Extension\EnumExtension;
+
+/**
+ * @requires PHP 8.1
+ */
+class EnumExtensionTest extends TestCase
+{
+    public function testEnumCases()
+    {
+        $cases = EnumExtension::enumCases(MyBackedEnum::class);
+
+        $this->assertSame(MyBackedEnum::cases(), $cases);
+    }
+
+    public function testEnumCasesThrowsIfNotBacked()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The enum must be a "\BackedEnum", "Twig\Tests\Extension\MyUnitEnum" given.');
+
+        EnumExtension::enumCases(MyUnitEnum::class);
+    }
+}
+
+if (80100 <= \PHP_VERSION_ID) {
+    enum MyBackedEnum: string
+    {
+        case ONE = 'one';
+        case TWO = 'two';
+    }
+
+    enum MyUnitEnum
+    {
+        case ONE;
+        case TWO;
+    }
+}


### PR DESCRIPTION
May fix #3681.

Allows:
```twig
{% for enum in enum_cases('App\\MyBackedEnum') %}
    {{ enum.value }}
{% endfor %}
```
________
Use case:
We need to display supported locales for a language switcher in the menu.
The block is included in a header template which is included in the base. It is cumbersome to pass `Locale::cases()` in the context from all controllers rendering a template that inherits from the base, or to cascade the variable from template to template.

Simplified implementation:
```php
enum Locale: string
{
    case EN = 'en';
    case FR = 'fr';

    public function flag(): string
    {
        return match ($this) {
            self::EN => '🇬🇧',
            self::FR => '🇫🇷',
        };
    }
}
```
```twig
{% for locale in enum_cases('App\\Locale') %}
    <option value="{{ locale.value }}"{% if locale.value == app.locale %} selected{% endif %}>
        {{ locale.flag }}
    </option>
{% endfor %}
```