### PR TITLE
Fix premature loop exit in Security Policy lookup of allowed methods/properties

### DIFF
--- a/src/Sandbox/SecurityPolicy.php
+++ b/src/Sandbox/SecurityPolicy.php
@@ -94,9 +94,8 @@ final class SecurityPolicy implements SecurityPolicyInterface
         $allowed = false;
         $method = strtr($method, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
         foreach ($this->allowedMethods as $class => $methods) {
-            if ($obj instanceof $class) {
-                $allowed = \in_array($method, $methods);
-
+            if ($obj instanceof $class && \in_array($method, $methods)) {
+                $allowed = true;
                 break;
             }
         }
@@ -111,9 +110,8 @@ final class SecurityPolicy implements SecurityPolicyInterface
     {
         $allowed = false;
         foreach ($this->allowedProperties as $class => $properties) {
-            if ($obj instanceof $class) {
-                $allowed = \in_array($property, \is_array($properties) ? $properties : [$properties]);
-
+            if ($obj instanceof $class && \in_array($property, \is_array($properties) ? $properties : [$properties])) {
+                $allowed = true;
                 break;
             }
         }


### PR DESCRIPTION
The current security policy logic exits too soon when checking permissions for allowed classes and their methods/properties, causing false negatives in situations involving classes related by inheritance.

Consider the following configuration:

```
'methods' => [
  'App\BasicCollection' => ['sortAlphabetically'],
  'App\AdvancedCollection'=> ['sortByTimestamp'],
],
```
where `AdvancedCollection` is a subclass of `BasicCollection`, and `mylist` is an instance of `AdvancedCollection`

If you try to call `{{ mylist.sortByTimestamp() }}`, the current code will first match `mylist` against `App\BasicCollection`. Since `sortByTimestamp` is not an allowed method for `App\BasicCollection`, the code will exit the loop and incorrectly deny access. It will never get to checking `App\AdvancedCollection`.

Note that reordering classes in the config can't solve this issue. If you flipped the order, then it would fail for `{{ mylist.sortAlphabetically() }}` instead.

This pull request fixes the issue by only exiting the loop early when both the class and method/property match.