### PR TITLE
Remove `TemplateWrapper::render()` 2nd parameter not used

### DIFF
--- a/src/TemplateWrapper.php
+++ b/src/TemplateWrapper.php
@@ -35,9 +35,7 @@ final class TemplateWrapper
 
     public function render(array $context = []): string
     {
-        // using func_get_args() allows to not expose the blocks argument
-        // as it should only be used by internal code
-        return $this->template->render($context, \func_get_args()[1] ?? []);
+        return $this->template->render($context);
     }
 
     public function display(array $context = [])


### PR DESCRIPTION
The 2nd virtual parameter of `TemplateWrapper::render()` was added by #2805.
`Template::render()` don't define and don't use this 2nd parameter.

Running the test suite, this method never get more than 1 parameter (I assumed it could be used by the compiled Template via the backtrace, but it isn't).