### PR TITLE
Fix deprecation warnings on Node::getIterator

### DIFF
--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -154,6 +154,7 @@ class Node implements \Countable, \IteratorAggregate
         return \count($this->nodes);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->nodes);


### PR DESCRIPTION
Fixes a deprecation warning on php version 8.1