### PR TITLE
range example leads to Array to string conversion exception

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -752,11 +752,11 @@ The following operators don't fit into any of the other categories:
   (this is syntactic sugar for the :doc:`range<functions/range>` function):
 
   .. code-block:: twig
-
-      {{ 1..5 }}
+      {# join filter is applied to avoid Array to string conversion exception #} 
+      {{ (1..5)|join(', ') }}
 
       {# equivalent to #}
-      {{ range(1, 5) }}
+      {{ range(1, 5)|join(', ') }}
 
   Note that you must use parentheses when combining it with the filter operator
   due to the :ref:`operator precedence rules <twig-expressions>`:


### PR DESCRIPTION
In templates documentation, a range example is displayed and leads to an Array to string conversion exception without a join filter.
