### PR TITLE
fix `NumberFormatter::TYPE_CURRENCY` being deprecated in PHP 8.3

### DIFF
--- a/extra/intl-extra/IntlExtension.php
+++ b/extra/intl-extra/IntlExtension.php
@@ -67,7 +67,6 @@ final class IntlExtension extends AbstractExtension
         'int32' => \NumberFormatter::TYPE_INT32,
         'int64' => \NumberFormatter::TYPE_INT64,
         'double' => \NumberFormatter::TYPE_DOUBLE,
-        'currency' => \NumberFormatter::TYPE_CURRENCY,
     ];
     private const NUMBER_STYLES = [
         'decimal' => \NumberFormatter::DECIMAL,


### PR DESCRIPTION
It was never used anyway (by Twig and by PHP), so removing it should not have any side-effects.