### PR TITLE
Security policy wildcard support for methods/properties

### DIFF
--- a/src/Sandbox/MemberMatcher.php
+++ b/src/Sandbox/MemberMatcher.php
@@ -16,7 +16,7 @@ namespace Twig\Sandbox;
  * - Class can be specified as wildcard `* => [...]` in order to allow those methods/properties for all classes.
  * - Method/property can be specified as wildcard eg. `\DateTime => '*'` in order to allow all methods/properties for that class.
  * - Method/property can also be specified with a trailing wildcard to allow all methods/properties with a certain prefix, eg. `\DateTime => ['get*', ...]` in order to allow all methods/properties that start with `get`.
- * 
+ *
  * @author Yaakov Saxon <ysaxon@gmail.com>
  */
 final class MemberMatcher
@@ -28,16 +28,16 @@ final class MemberMatcher
     {
         $normalizedMembers = [];
         foreach ($allowedMembers as $class => $members) {
-            if (!is_array($members)) {
+            if (!\is_array($members)) {
                 $normalizedMembers[$class][] = strtolower($members);
-            }
-            else foreach ($members as $index => $member) {
-                $normalizedMembers[$class][$index] = strtolower($member);
+            } else {
+                foreach ($members as $index => $member) {
+                    $normalizedMembers[$class][$index] = strtolower($member);
+                }
             }
         }
         $this->allowedMembers = $normalizedMembers;
     }
-
 
     public function isAllowed($obj, string $member): bool
     {
@@ -51,19 +51,22 @@ final class MemberMatcher
         $member = strtolower($member); // normalize member name
 
         foreach ($this->allowedMembers as $class => $members) {
-            if ($class === '*' || $obj instanceof $class) {
+            if ('*' === $class || $obj instanceof $class) {
                 foreach ($members as $allowedMember) {
-                    if ($allowedMember === '*') {
+                    if ('*' === $allowedMember) {
                         $this->cache[$cacheKey] = true;
+
                         return true;
                     }
                     if ($allowedMember === $member) {
                         $this->cache[$cacheKey] = true;
+
                         return true;
                     }
-                    //if allowedMember ends with a *, check if the member starts with the allowedMember
-                    if (substr($allowedMember, -1) === '*' && substr($member, 0, strlen($allowedMember) - 1) === rtrim($allowedMember, '*')) {
+                    // if allowedMember ends with a *, check if the member starts with the allowedMember
+                    if ('*' === substr($allowedMember, -1) && substr($member, 0, \strlen($allowedMember) - 1) === rtrim($allowedMember, '*')) {
                         $this->cache[$cacheKey] = true;
+
                         return true;
                     }
                 }

--- a/src/Sandbox/MemberMatcher.php
+++ b/src/Sandbox/MemberMatcher.php
@@ -12,8 +12,11 @@
 namespace Twig\Sandbox;
 
 /**
- * Allows for flexible wildcard supported member and property matching in Security Policies.
- *
+ * Allows for flexible wildcard support in allowedMethods and allowedProperties in SecurityPolicy.
+ * - Class can be specified as wildcard `* => [...]` in order to allow those methods/properties for all classes.
+ * - Method/property can be specified as wildcard eg. `\DateTime => '*'` in order to allow all methods/properties for that class.
+ * - Method/property can also be specified with a trailing wildcard to allow all methods/properties with a certain prefix, eg. `\DateTime => ['get*', ...]` in order to allow all methods/properties that start with `get`.
+ * 
  * @author Yaakov Saxon <ysaxon@gmail.com>
  */
 final class MemberMatcher

--- a/src/Sandbox/MemberMatcher.php
+++ b/src/Sandbox/MemberMatcher.php
@@ -23,12 +23,16 @@ final class MemberMatcher
 
     public function __construct(array $allowedMethods)
     {
+        $normalizedMethods = [];
         foreach ($allowedMethods as $class => $methods) {
-            foreach ($methods as $index => $method) {
-                $allowedMethods[$class][$index] = strtolower($method);
+            if (!is_array($methods)) {
+                $normalizedMethods[$class][] = strtolower($methods);
+            }
+            else foreach ($methods as $index => $method) {
+                $normalizedMethods[$class][$index] = strtolower($method);
             }
         }
-        $this->allowedMethods = $allowedMethods;
+        $this->allowedMethods = $normalizedMethods;
     }
 
 

--- a/src/Sandbox/MemberMatcher.php
+++ b/src/Sandbox/MemberMatcher.php
@@ -21,7 +21,7 @@ final class MemberMatcher
     private $allowedMethods;
     private $cache = [];
 
-    public function __construct($allowedMethods)
+    public function __construct(array $allowedMethods)
     {
         foreach ($allowedMethods as $class => $methods) {
             foreach ($methods as $index => $method) {
@@ -32,7 +32,7 @@ final class MemberMatcher
     }
 
 
-    public function isAllowed($obj, $method)
+    public function isAllowed($obj, string $method): bool
     {
         $cacheKey = get_class($obj) . "::" . $method;
 

--- a/src/Sandbox/MemberMatcher.php
+++ b/src/Sandbox/MemberMatcher.php
@@ -12,54 +12,54 @@
 namespace Twig\Sandbox;
 
 /**
- * Allows for flexible wildcard supported method and property matching in Security Policies.
+ * Allows for flexible wildcard supported member and property matching in Security Policies.
  *
  * @author Yaakov Saxon <ysaxon@gmail.com>
  */
 final class MemberMatcher
 {
-    private $allowedMethods;
+    private $allowedMembers;
     private $cache = [];
 
-    public function __construct(array $allowedMethods)
+    public function __construct(array $allowedMembers)
     {
-        $normalizedMethods = [];
-        foreach ($allowedMethods as $class => $methods) {
-            if (!is_array($methods)) {
-                $normalizedMethods[$class][] = strtolower($methods);
+        $normalizedMembers = [];
+        foreach ($allowedMembers as $class => $members) {
+            if (!is_array($members)) {
+                $normalizedMembers[$class][] = strtolower($members);
             }
-            else foreach ($methods as $index => $method) {
-                $normalizedMethods[$class][$index] = strtolower($method);
+            else foreach ($members as $index => $member) {
+                $normalizedMembers[$class][$index] = strtolower($member);
             }
         }
-        $this->allowedMethods = $normalizedMethods;
+        $this->allowedMembers = $normalizedMembers;
     }
 
 
-    public function isAllowed($obj, string $method): bool
+    public function isAllowed($obj, string $member): bool
     {
-        $cacheKey = get_class($obj) . "::" . $method;
+        $cacheKey = get_class($obj) . "::" . $member;
 
         // Check cache first
         if (isset($this->cache[$cacheKey])) {
             return $this->cache[$cacheKey];
         }
 
-        $method = strtolower($method); // normalize method name
+        $member = strtolower($member); // normalize member name
 
-        foreach ($this->allowedMethods as $class => $methods) {
+        foreach ($this->allowedMembers as $class => $members) {
             if ($class === '*' || $obj instanceof $class) {
-                foreach ($methods as $allowedMethod) {
-                    if ($allowedMethod === '*') {
+                foreach ($members as $allowedMember) {
+                    if ($allowedMember === '*') {
                         $this->cache[$cacheKey] = true;
                         return true;
                     }
-                    if ($allowedMethod === $method) {
+                    if ($allowedMember === $member) {
                         $this->cache[$cacheKey] = true;
                         return true;
                     }
-                    //if allowedMethod ends with a *, check if the method starts with the allowedMethod
-                    if (substr($allowedMethod, -1) === '*' && substr($method, 0, strlen($allowedMethod) - 1) === rtrim($allowedMethod, '*')) {
+                    //if allowedMember ends with a *, check if the member starts with the allowedMember
+                    if (substr($allowedMember, -1) === '*' && substr($member, 0, strlen($allowedMember) - 1) === rtrim($allowedMember, '*')) {
                         $this->cache[$cacheKey] = true;
                         return true;
                     }
@@ -67,7 +67,7 @@ final class MemberMatcher
             }
         }
 
-        // If we reach here, the method is not allowed
+        // If we reach here, the member is not allowed
         $this->cache[$cacheKey] = false;
         return false;
     }

--- a/src/Sandbox/MemberMatcher.php
+++ b/src/Sandbox/MemberMatcher.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Sandbox;
+
+/**
+ * Allows for flexible wildcard supported method and property matching in Security Policies.
+ *
+ * @author Yaakov Saxon <ysaxon@gmail.com>
+ */
+final class MemberMatcher
+{
+    private $allowedMethods;
+    private $cache = [];
+
+    public function __construct($allowedMethods)
+    {
+        foreach ($allowedMethods as $class => $methods) {
+            foreach ($methods as $index => $method) {
+                $allowedMethods[$class][$index] = strtolower($method);
+            }
+        }
+        $this->allowedMethods = $allowedMethods;
+    }
+
+
+    public function isAllowed($obj, $method)
+    {
+        $cacheKey = get_class($obj) . "::" . $method;
+
+        // Check cache first
+        if (isset($this->cache[$cacheKey])) {
+            return $this->cache[$cacheKey];
+        }
+
+        $method = strtolower($method); // normalize method name
+
+        foreach ($this->allowedMethods as $class => $methods) {
+            if ($class === '*' || $obj instanceof $class) {
+                foreach ($methods as $allowedMethod) {
+                    if ($allowedMethod === '*') {
+                        $this->cache[$cacheKey] = true;
+                        return true;
+                    }
+                    if ($allowedMethod === $method) {
+                        $this->cache[$cacheKey] = true;
+                        return true;
+                    }
+                    //if allowedMethod ends with a *, check if the method starts with the allowedMethod
+                    if (substr($allowedMethod, -1) === '*' && substr($method, 0, strlen($allowedMethod) - 1) === rtrim($allowedMethod, '*')) {
+                        $this->cache[$cacheKey] = true;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // If we reach here, the method is not allowed
+        $this->cache[$cacheKey] = false;
+        return false;
+    }
+}

--- a/src/Sandbox/MemberMatcher.php
+++ b/src/Sandbox/MemberMatcher.php
@@ -42,7 +42,7 @@ final class MemberMatcher
 
         // Check cache first
         if (isset($this->cache[$cacheKey])) {
-            return $this->cache[$cacheKey];
+            return true;
         }
 
         $member = strtolower($member); // normalize member name
@@ -68,7 +68,6 @@ final class MemberMatcher
         }
 
         // If we reach here, the member is not allowed
-        $this->cache[$cacheKey] = false;
         return false;
     }
 }


### PR DESCRIPTION
 Allows for flexible wildcard support in allowedMethods and allowedProperties in SecurityPolicy.
 - Class can be specified as wildcard, `* => ['foo',...]` in order to allow those methods/properties for all classes.
 - Method/property can be specified as wildcard eg. `\Foo\Bar\Baz => '*'` in order to allow **all** methods/properties for that class.
 - Method/property can also be specified with a trailing wildcard to allow all methods/properties with a certain prefix, eg. `\Foo\Bar\Baz => ['get*', ...]` in order to allow all Baz methods/properties that start with `get`.
 
 
Here are some real examples of security policy items that previously had to be hardcoded that can now be expressed with wildcards:
* Twig's hardcoded [security exceptions for methods in Template and Markup classes](https://github.com/twigphp/Twig/blob/3ae6fb8723776f4fc9d8ab490fcabcd3173da8e3/src/Sandbox/SecurityPolicy.php#L90) can be expressed as 
```
'Twig\Template' => '*',
'Twig\Markup' => '*'
```

* Drupal's [$allowed_classes](https://github.com/drupal/drupal/blob/6efb70cd568335e9b292cde6530cc21c2931c448/core/lib/Drupal/Core/Template/TwigSandboxPolicy.php#L49C7-L49C7) can now be expressed as 
```
Drupal\Core\Template\Attribute => '*'
```

* Drupal's [$allowed_methods](https://github.com/drupal/drupal/blob/6efb70cd568335e9b292cde6530cc21c2931c448/core/lib/Drupal/Core/Template/TwigSandboxPolicy.php#L57) and [$allowed_prefixes](https://github.com/drupal/drupal/blob/6efb70cd568335e9b292cde6530cc21c2931c448/core/lib/Drupal/Core/Template/TwigSandboxPolicy.php#L69) can be expressed together as 
```
'*' => ['get*', 'has*', 'is*', '__toString', 'toString', 'id', 'label', 'bundle']
```