### PR TITLE
Optional defaults for SecurityPolicy

### DIFF
--- a/src/Sandbox/SecurityPolicy.php
+++ b/src/Sandbox/SecurityPolicy.php
@@ -29,25 +29,26 @@ final class SecurityPolicy implements SecurityPolicyInterface
 
     public function __construct(array $allowedTags = [], array $allowedFilters = [], array $allowedMethods = [], array $allowedProperties = [], array $allowedFunctions = [])
     {
-        $this->allowedTags = $allowedTags;
-        $this->allowedFilters = $allowedFilters;
+        $this->setAllowedTags($allowedTags);
+        $this->setAllowedFilters($allowedFilters);
         $this->setAllowedMethods($allowedMethods);
-        $this->allowedProperties = $allowedProperties;
-        $this->allowedFunctions = $allowedFunctions;
+        $this->setAllowedProperties($allowedProperties);
+        $this->setAllowedFunctions($allowedFunctions);
     }
 
     public function setAllowedTags(array $tags)
     {
-        $this->allowedTags = $tags;
+        $this->allowedTags = SecurityPolicyDefaults::processDefaultsTokenForTags($tags);
     }
 
     public function setAllowedFilters(array $filters)
     {
-        $this->allowedFilters = $filters;
+        $this->allowedFilters = SecurityPolicyDefaults::processDefaultsTokenForFilters($filters);
     }
 
     public function setAllowedMethods(array $methods)
     {
+        $methods = SecurityPolicyDefaults::processDefaultsTokenForMethods($methods);
         $this->allowedMethods = [];
         foreach ($methods as $class => $m) {
             $this->allowedMethods[$class] = array_map(function ($value) { return strtr($value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'); }, \is_array($m) ? $m : [$m]);
@@ -56,12 +57,12 @@ final class SecurityPolicy implements SecurityPolicyInterface
 
     public function setAllowedProperties(array $properties)
     {
-        $this->allowedProperties = $properties;
+        $this->allowedProperties = SecurityPolicyDefaults::processDefaultsTokenForProperties($properties);
     }
 
     public function setAllowedFunctions(array $functions)
     {
-        $this->allowedFunctions = $functions;
+        $this->allowedFunctions = SecurityPolicyDefaults::processDefaultsTokenForFunctions($functions);
     }
 
     public function checkSecurity($tags, $filters, $functions)

--- a/src/Sandbox/SecurityPolicyDefaults.php
+++ b/src/Sandbox/SecurityPolicyDefaults.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Sandbox;
+
+/**
+ * A set of defaults for the security policy. These can be automatically added to the policy by including the special value SecurityPolicyDefaults::INCLUDE_DEFAULTS in the array of allowed tags, filters, functions, methods, or properties.
+ * The static functions in this class simply check if that special value is present, and if so, replace it with the actual defaults. 
+ * 
+ * @author Yaakov Saxon <ysaxon@gmail.com>
+ */
+
+ class SecurityPolicyDefaults {
+    public const INCLUDE_DEFAULTS = '(include_defaults)';
+
+    // TODO: Note that below defaults have not been exhaustively analyzed for correctness or completeness but rather represent an example of what defaults could look like for the initial code review of this pull request.
+    const TAGS = [
+        'autoescape',
+        'filter',
+        'do',
+        'flush',
+        'for',
+        'set',
+        'verbatium',
+        'if',
+        'spaceless',
+        'sandbox'
+    ];
+
+    const FILTERS =  [
+        'abs',
+        'batch',
+        'capitalize',
+        'convert_encoding',
+        'date',
+        'date_modify',
+        'default',
+        'escape',
+        'first',
+        'format',
+        'join',
+        'json_encode',
+        'keys',
+        'last',
+        'length',
+        'lower',
+        'merge',
+        'nl2br',
+        'number_format',
+        'raw',
+        'replace',
+        'reverse',
+        'slice',
+        'sort',
+        'split',
+        'striptags',
+        'title',
+        'trim',
+        'upper',
+        'url_encode',
+    ];
+    
+    const FUNCTIONS = [
+        'attribute',
+        'block',
+        'constant',
+        'cycle',
+        'date',
+        'html_classes',
+        'max',
+        'min',
+        'parent',
+        'random',
+        'range',
+        'source',
+    ];
+
+    const METHODS = [
+        // ...
+    ];
+    
+    const PROPERTIES = [
+        // ...
+    ];
+
+    private static function processDefaultsTokenForMethods(array $input){
+        return self::processDefaultsTokenForAssociativeArray($input, self::METHODS);
+    }
+
+    private static function processDefaultsTokenForProperties(array $input){
+        return self::processDefaultsTokenForAssociativeArray($input, self::PROPERTIES);
+    }
+
+    private static function processDefaultsTokenForTags(array $input){
+        return self::processDefaultsTokenForIndexedArray($input, self::TAGS);
+    }
+
+    private static function processDefaultsTokenForFilters(array $input){
+        return self::processDefaultsTokenForIndexedArray($input, self::FILTERS);
+    }
+
+    private static function processDefaultsTokenForFunctions(array $input){
+        return self::processDefaultsTokenForIndexedArray($input, self::FUNCTIONS);
+    }
+
+
+    private static function processDefaultsTokenForIndexedArray(array $array, array $defaults)
+    {
+        if (in_array(self::INCLUDE_DEFAULTS, $array)) {
+            //remove DEFAULTS marker
+            $array = array_diff($array, [self::INCLUDE_DEFAULTS]);
+            //add defaults
+            $array = array_merge($array, $defaults);
+            //uniquify
+            $array = array_unique($array);
+        }
+        return $array;
+    }
+
+    private static function processDefaultsTokenForAssociativeArray(array $array, array $defaults)
+    {
+        $key = array_search(SecurityPolicyDefaults::INCLUDE_DEFAULTS, $array);
+        if ($key !== false) {
+            //remove DEFAULTS marker
+            unset($array[$key]);
+            //add defaults
+            $array = self::AssociativeArrayMerge($array, $defaults);
+        }
+        return $array;
+    }
+
+    private static function AssociativeArrayMerge($array1, $array2)
+    {
+        $new_array = [];
+        // Merge keys from both arrays
+        $all_keys = array_merge(array_keys($array1), array_keys($array2));
+        $all_keys = array_unique($all_keys);
+
+        // Iterate through all unique keys
+        foreach ($all_keys as $key) {
+            $val1 = isset($array1[$key]) ? $array1[$key] : [];
+            $val2 = isset($array2[$key]) ? $array2[$key] : [];
+
+            // Convert to array if not already an array
+            if (!is_array($val1)) {
+                $val1 = [$val1];
+            }
+            if (!is_array($val2)) {
+                $val2 = [$val2];
+            }
+
+            // Merge the values and eliminate duplicates
+            $combined_vals = array_unique(array_merge($val1, $val2));
+            $new_array[$key] = $combined_vals;
+        }
+        return $new_array;
+    }
+
+ }

--- a/src/Sandbox/SecurityPolicyDefaults.php
+++ b/src/Sandbox/SecurityPolicyDefaults.php
@@ -13,16 +13,16 @@ namespace Twig\Sandbox;
 
 /**
  * A set of defaults for the security policy. These can be automatically added to the policy by including the special value SecurityPolicyDefaults::INCLUDE_DEFAULTS in the array of allowed tags, filters, functions, methods, or properties.
- * The static functions in this class simply check if that special value is present, and if so, replace it with the actual defaults. 
- * 
+ * The static functions in this class simply check if that special value is present, and if so, replace it with the actual defaults.
+ *
  * @author Yaakov Saxon <ysaxon@gmail.com>
  */
-
- class SecurityPolicyDefaults {
+class SecurityPolicyDefaults
+{
     public const INCLUDE_DEFAULTS = '(include_defaults)';
 
     // TODO: Note that below defaults have not been exhaustively analyzed for correctness or completeness but rather represent an example of what defaults could look like for the initial code review of this pull request.
-    const TAGS = [
+    public const TAGS = [
         'autoescape',
         'filter',
         'do',
@@ -32,10 +32,10 @@ namespace Twig\Sandbox;
         'verbatium',
         'if',
         'spaceless',
-        'sandbox'
+        'sandbox',
     ];
 
-    const FILTERS =  [
+    public const FILTERS = [
         'abs',
         'batch',
         'capitalize',
@@ -66,9 +66,27 @@ namespace Twig\Sandbox;
         'trim',
         'upper',
         'url_encode',
+        'country_name',
+        'currency_name',
+        'currency_symbol',
+        'language_name',
+        'locale_name',
+        'timezone_name',
+        'format_currency',
+        'format_number',
+        'format_decimal_number',
+        'format_currency_number',
+        'format_percent_number',
+        'format_scientific_number',
+        'format_spellout_number',
+        'format_ordinal_number',
+        'format_duration_number',
+        'format_date',
+        'format_datetime',
+        'format_time',
     ];
-    
-    const FUNCTIONS = [
+
+    public const FUNCTIONS = [
         'attribute',
         'block',
         'constant',
@@ -83,57 +101,63 @@ namespace Twig\Sandbox;
         'source',
     ];
 
-    const METHODS = [
-        // ...
-    ];
-    
-    const PROPERTIES = [
+    public const METHODS = [
         // ...
     ];
 
-    private static function processDefaultsTokenForMethods(array $input){
+    public const PROPERTIES = [
+        // ...
+    ];
+
+    private static function processDefaultsTokenForMethods(array $input)
+    {
         return self::processDefaultsTokenForAssociativeArray($input, self::METHODS);
     }
 
-    private static function processDefaultsTokenForProperties(array $input){
+    private static function processDefaultsTokenForProperties(array $input)
+    {
         return self::processDefaultsTokenForAssociativeArray($input, self::PROPERTIES);
     }
 
-    private static function processDefaultsTokenForTags(array $input){
+    private static function processDefaultsTokenForTags(array $input)
+    {
         return self::processDefaultsTokenForIndexedArray($input, self::TAGS);
     }
 
-    private static function processDefaultsTokenForFilters(array $input){
+    private static function processDefaultsTokenForFilters(array $input)
+    {
         return self::processDefaultsTokenForIndexedArray($input, self::FILTERS);
     }
 
-    private static function processDefaultsTokenForFunctions(array $input){
+    private static function processDefaultsTokenForFunctions(array $input)
+    {
         return self::processDefaultsTokenForIndexedArray($input, self::FUNCTIONS);
     }
 
-
     private static function processDefaultsTokenForIndexedArray(array $array, array $defaults)
     {
-        if (in_array(self::INCLUDE_DEFAULTS, $array)) {
-            //remove DEFAULTS marker
+        if (\in_array(self::INCLUDE_DEFAULTS, $array)) {
+            // remove DEFAULTS marker
             $array = array_diff($array, [self::INCLUDE_DEFAULTS]);
-            //add defaults
+            // add defaults
             $array = array_merge($array, $defaults);
-            //uniquify
+            // uniquify
             $array = array_unique($array);
         }
+
         return $array;
     }
 
     private static function processDefaultsTokenForAssociativeArray(array $array, array $defaults)
     {
-        $key = array_search(SecurityPolicyDefaults::INCLUDE_DEFAULTS, $array);
-        if ($key !== false) {
-            //remove DEFAULTS marker
+        $key = array_search(self::INCLUDE_DEFAULTS, $array);
+        if (false !== $key) {
+            // remove DEFAULTS marker
             unset($array[$key]);
-            //add defaults
+            // add defaults
             $array = self::AssociativeArrayMerge($array, $defaults);
         }
+
         return $array;
     }
 
@@ -150,10 +174,10 @@ namespace Twig\Sandbox;
             $val2 = isset($array2[$key]) ? $array2[$key] : [];
 
             // Convert to array if not already an array
-            if (!is_array($val1)) {
+            if (!\is_array($val1)) {
                 $val1 = [$val1];
             }
-            if (!is_array($val2)) {
+            if (!\is_array($val2)) {
                 $val2 = [$val2];
             }
 
@@ -161,7 +185,7 @@ namespace Twig\Sandbox;
             $combined_vals = array_unique(array_merge($val1, $val2));
             $new_array[$key] = $combined_vals;
         }
+
         return $new_array;
     }
-
- }
+}


### PR DESCRIPTION
This is an implementation of Defaults for the Twig Security Policy.

The idea is that there should be a set of known safe values that a user can whitelist. The goals for the pull request were:
* It should be easy to use the defaults
* It should be easy to NOT use the defaults
* It should be easy to include all the values in the defaults plus some of your own. I've seen implementations of defaults where you need to take it or leave it; if you like the defaults but want to add some extra values in your project, you have no choice but to reject the defaults and just copy them into your own policy.

I've implemented this via a special value or "token", meant to be referred to as SecurityPolicyDefaults::INCLUDE_DEFAULTS, which, if included as a value in any of the whitelist config arguments, will be replaced and merged with the actual hardcoded default values.

So for instance if you want to trust all of the default filters, plus your own custom filters `format_number` and `format_currency` and 'format_currency', you can initialize your SecurityPolicy with `$allowedFilters = ['format_number', 'format_currency', SecurityPolicyDefaults::INCLUDE_DEFAULTS]`, and the actual allowedFilters will end up as `['format_number', 'format_currency','abs','batch','capitalize', 'date', 'date_modify', ...]`.


Note that I haven't done extensive research for the present list of defaults. They are intended as a proof-of-concept sample for the purpose of the pull request, and should definitely be reviewed thoroughly before actually accepting and merging.