### PR TITLE
Fix timezone fallback to CoreExtension in IntlExtension

### DIFF
--- a/extra/intl-extra/IntlExtension.php
+++ b/extra/intl-extra/IntlExtension.php
@@ -371,7 +371,7 @@ final class IntlExtension extends AbstractExtension
         $date = twig_date_converter($env, $date, $timezone);
 
         $formatterTimezone = $timezone;
-        if (false === $formatterTimezone) {
+        if (null === $formatterTimezone) {
             $formatterTimezone = $date->getTimezone();
         } elseif (\is_string($formatterTimezone)) {
             $formatterTimezone = new \DateTimeZone($timezone);

--- a/extra/intl-extra/Tests/IntlExtensionTest.php
+++ b/extra/intl-extra/Tests/IntlExtensionTest.php
@@ -13,6 +13,7 @@ namespace Twig\Extra\Intl\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
+use Twig\Extension\CoreExtension;
 use Twig\Extra\Intl\IntlExtension;
 use Twig\Loader\ArrayLoader;
 
@@ -27,6 +28,20 @@ class IntlExtensionTest extends TestCase
         $this->assertSame(
             'Feb 20, 2020, 1:37:00 PM',
             $ext->formatDateTime($env, new \DateTime('2020-02-20T13:37:00+00:00'))
+        );
+    }
+
+    public function testFormatterWithoutProtoFallsBackToCoreExtensionTimezone()
+    {
+        $ext = new IntlExtension();
+        $env = new Environment(new ArrayLoader());
+        // EET is always +2 without changes for daylight saving time
+        // so it has a fixed difference to UTC
+        $env->getExtension(CoreExtension::class)->setTimezone('EET');
+
+        $this->assertSame(
+            'Feb 20, 2020, 3:37:00 PM',
+            $ext->formatDateTime($env, new \DateTime('2020-02-20T13:37:00+00:00', new \DateTimeZone('UTC')))
         );
     }
 


### PR DESCRIPTION
This is probably a regression from #3844

Refer to my comment on the original MR: https://github.com/twigphp/Twig/pull/3844#issuecomment-1792464040