### PR TITLE
Add strict_properties, array_methods options

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -113,6 +113,10 @@ The following options are available:
   with the same name (or `get{name}` methods) if the property
   does not exist (defaults to ``false``).
 
+  Note that many Symfony libraries rely on the default, 
+  non-strict behavior, so only set this value to ``true``
+  if using Twig without using Symfony.
+
 
 * ``array_methods`` *boolean*
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -106,6 +106,19 @@ The following options are available:
   replace them with a ``null`` value. When set to ``true``, Twig throws an
   exception instead (default to ``false``).
 
+* ``strict_properties`` *boolean*
+
+  If set to ``true``, treats property accesses in templates only as
+  property accesses, without ever trying to invoke methods
+  with the same name (or `get{name}` methods) if the property
+  does not exist (defaults to ``false``).
+
+
+* ``array_methods`` *boolean*
+
+    If ``true``, treats method calls on callable array elements
+    as if they were object method calls (defaults to ``false``).
+
 * ``autoescape`` *string*
 
   Sets the default auto-escaping strategy (``name``, ``html``, ``js``, ``css``,

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -60,6 +60,8 @@ class Environment
     private $resolvedGlobals;
     private $loadedTemplates;
     private $strictVariables;
+    private $arrayMethods;
+    private $strictProperties;
     private $templateClassPrefix = '__TwigTemplate_';
     private $originalCache;
     private $extensionSet;
@@ -88,6 +90,13 @@ class Environment
      *  * strict_variables: Whether to ignore invalid variables in templates
      *                      (default to false).
      *
+     *  * strict_properties: Whether to treat property accesses in templates only as property accesses,
+     *                       without ever invoking methods with the same name if the property does not exist
+     *                       (default to false).
+     *
+     *  * array_methods: Whether to treat method calls on callable array elements as if they were object method calls
+     *                   (defaults to false).
+     *
      *  * autoescape: Whether to enable auto-escaping (default to html):
      *                  * false: disable auto-escaping
      *                  * html, js: set the autoescaping to one of the supported strategies
@@ -106,6 +115,8 @@ class Environment
             'debug' => false,
             'charset' => 'UTF-8',
             'strict_variables' => false,
+            'array_methods' => false,
+            'strict_properties' => false,
             'autoescape' => 'html',
             'cache' => false,
             'auto_reload' => null,
@@ -116,6 +127,8 @@ class Environment
         $this->setCharset($options['charset'] ?? 'UTF-8');
         $this->autoReload = null === $options['auto_reload'] ? $this->debug : (bool) $options['auto_reload'];
         $this->strictVariables = (bool) $options['strict_variables'];
+        $this->arrayMethods = (bool) $options['array_methods'];
+        $this->strictProperties = (bool) $options['strict_properties'];
         $this->setCache($options['cache']);
         $this->extensionSet = new ExtensionSet();
 
@@ -204,6 +217,63 @@ class Environment
     public function isStrictVariables()
     {
         return $this->strictVariables;
+    }
+
+
+    /**
+     * Enables the strict_properties option.
+     */
+    public function enableStrictProperties()
+    {
+        $this->strictProperties = true;
+        $this->updateOptionsHash();
+    }
+
+    /**
+     * Disables the strict_properties option.
+     */
+    public function disableStrictProperties()
+    {
+        $this->strictProperties = false;
+        $this->updateOptionsHash();
+    }
+
+    /**
+     * Checks if the strict_properties option is enabled.
+     *
+     * @return bool true if strict_properties is enabled, false otherwise
+     */
+    public function isStrictProperties()
+    {
+        return $this->strictProperties;
+    }
+
+    /**
+     * Enables the array_methods option.
+     */
+    public function enableArrayMethods()
+    {
+        $this->arrayMethods = true;
+        $this->updateOptionsHash();
+    }
+
+    /**
+     * Disables the array_methods option.
+     */
+    public function disableArrayMethods()
+    {
+        $this->arrayMethods = false;
+        $this->updateOptionsHash();
+    }
+
+    /**
+     * Checks if the array_methods option is enabled.
+     *
+     * @return bool true if array_methods is enabled, false otherwise
+     */
+    public function isArrayMethods()
+    {
+        return $this->arrayMethods;
     }
 
     /**

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -93,6 +93,10 @@ class Environment
      *  * strict_properties: Whether to treat property accesses in templates only as property accesses,
      *                       without ever invoking methods with the same name if the property does not exist
      *                       (default to false).
+     * 
+     *                       Note that many Symfony libraries rely on the default, 
+     *                       non-strict behavior, so only set this value to true
+     *                       if using Twig without using Symfony.
      *
      *  * array_methods: Whether to treat method calls on callable array elements as if they were object method calls
      *                   (defaults to false).

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1481,6 +1481,31 @@ function twig_get_attribute(Environment $env, Source $source, $object, $item, ar
 
             if ($type === 'method') {
                 if (is_callable($object[$arrayItem])) {
+                    if ($sandboxed) {
+                        if (is_array($object[$arrayItem])) {
+                            $env->getExtension(SandboxExtension::class)->checkMethodAllowed(
+                                $object[$arrayItem][0],
+                                $object[$arrayItem][0],
+                                $lineno,
+                                $source
+                            );
+                        } elseif (is_string($object[$arrayItem])) {
+                            $env->getExtension(SandboxExtension::class)->checkSecurity(
+                                [],
+                                [],
+                                [$object[$arrayItem]],
+                            );
+                        } elseif ($object[$arrayItem] instanceof Closure) {
+                            $env->getExtension(SandboxExtension::class)->checkMethodAllowed(
+                                $object[$arrayItem],
+                                'call',
+                                $lineno,
+                                $source
+                            );
+                        } else {
+                            throw new AssertionError("Unreachable");
+                        }
+                    }
                     return $object[$arrayItem](...$arguments);
                 }
             } else {


### PR DESCRIPTION
* `strict_properties`: if true, treats property accesses in templates only as property accesses, without ever trying to invoke methods with the same name if the property does not exist (defaults to false).
* `array_methods`: if true, treats method calls on callable array elements as if they were object method calls.

Both rules came in extremely handy @ nicelocal, as the first one increases strictness, also avoiding issues in our automated migration from smarty to twig, while the second one allows the usage of some specific abstractions.