### PR TITLE
Prevent calling twig_get_attribute by generating the guessed PHP code instead

### DIFF
--- a/doc/tags/type.rst
+++ b/doc/tags/type.rst
@@ -1,0 +1,9 @@
+``type``
+==============
+
+Twig can perform more performant access, when type of variables can be predicted.
+To support prediction you can provide type hints, that you already know from PHP:
+
+.. code-block:: twig
+
+    {% type interval \DateInterval %}

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -33,6 +33,8 @@ use Twig\Node\Node;
 use Twig\NodeVisitor\NodeVisitorInterface;
 use Twig\RuntimeLoader\RuntimeLoaderInterface;
 use Twig\TokenParser\TokenParserInterface;
+use Twig\TypeHint\ContextStack;
+use Twig\TypeHint\TypeInterface;
 
 /**
  * Stores the Twig configuration and renders templates.
@@ -69,6 +71,7 @@ class Environment
     private $optionsHash;
     /** @var bool */
     private $useYield;
+    private $typeHintStack;
 
     /**
      * Constructor.
@@ -127,6 +130,7 @@ class Environment
         $this->strictVariables = (bool) $options['strict_variables'];
         $this->setCache($options['cache']);
         $this->extensionSet = new ExtensionSet();
+        $this->typeHintStack = new ContextStack();
 
         $this->addExtension(new CoreExtension());
         $this->addExtension(new EscaperExtension($options['autoescape']));
@@ -843,6 +847,11 @@ class Environment
     public function getBinaryOperators(): array
     {
         return $this->extensionSet->getBinaryOperators();
+    }
+
+    public function getTypeHintStack(): ContextStack
+    {
+        return $this->typeHintStack;
     }
 
     private function updateOptionsHash(): void

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -74,6 +74,7 @@ use Twig\TokenParser\ImportTokenParser;
 use Twig\TokenParser\IncludeTokenParser;
 use Twig\TokenParser\MacroTokenParser;
 use Twig\TokenParser\SetTokenParser;
+use Twig\TokenParser\TypeHintTokenParser;
 use Twig\TokenParser\UseTokenParser;
 use Twig\TokenParser\WithTokenParser;
 use Twig\TwigFilter;
@@ -178,6 +179,7 @@ final class CoreExtension extends AbstractExtension
             new EmbedTokenParser(),
             new WithTokenParser(),
             new DeprecatedTokenParser(),
+            new TypeHintTokenParser(),
         ];
     }
 

--- a/src/Extension/TypeOptimizerExtension.php
+++ b/src/Extension/TypeOptimizerExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Extension;
+
+use Twig\NodeVisitor\TypeEvaluateNodeVisitor;
+
+/**
+ * Extension to improve PHP code compiling by predicting variable types of expressions.
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+final class TypeOptimizerExtension extends AbstractExtension
+{
+    public function getTokenParsers(): array
+    {
+        return [];
+    }
+
+    public function getNodeVisitors(): array
+    {
+        return [new TypeEvaluateNodeVisitor()];
+    }
+}

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -412,7 +412,27 @@ class Lexer
             throw new SyntaxError('Unclosed comment.', $this->lineno, $this->source);
         }
 
-        $this->moveCursor(substr($this->code, $this->cursor, $match[0][1] - $this->cursor).$match[0][0]);
+        $text = substr($this->code, $this->cursor, $match[0][1] - $this->cursor) . $match[0][0];
+
+        if (preg_match('/(.*@var\s+)([a-z][a-z0-9]*)(\s+)(\S+)(.*)$/is', $text, $hintMatch) === 1) {
+            $this->pushToken(Token::BLOCK_START_TYPE);
+            $this->moveCursor($hintMatch[1]);
+
+            $this->pushToken(Token::NAME_TYPE, 'type');
+
+            $this->pushToken(Token::NAME_TYPE, $hintMatch[2]);
+            $this->moveCursor($hintMatch[2]);
+
+            $this->moveCursor($hintMatch[3]);
+
+            $this->pushToken(Token::NAME_TYPE, $hintMatch[4]);
+            $this->moveCursor($hintMatch[4]);
+
+            $this->pushToken(Token::BLOCK_END_TYPE);
+            $this->moveCursor($hintMatch[5]);
+        } else {
+            $this->moveCursor($text);
+        }
     }
 
     private function lexString(): void

--- a/src/Node/Expression/GetAttrExpression.php
+++ b/src/Node/Expression/GetAttrExpression.php
@@ -13,10 +13,13 @@
 namespace Twig\Node\Expression;
 
 use Twig\Compiler;
+use Twig\Environment;
 use Twig\Extension\SandboxExtension;
 use Twig\Template;
 use Twig\TypeHint\ArrayType;
 use Twig\TypeHint\ObjectType;
+use Twig\TypeHint\TypeInterface;
+use Twig\TypeHint\UnionType;
 
 class GetAttrExpression extends AbstractExpression
 {
@@ -41,63 +44,23 @@ class GetAttrExpression extends AbstractExpression
                 $type = $this->getNode('node')->getAttribute('typeHint');
             }
 
-            if ($type instanceof ArrayType) {
-                $compiler
-                    ->raw('((')
-                    ->subcompile($this->getNode('node'))
-                    ->raw(')[')
-                    ->subcompile($this->getNode('attribute'))
-                    ->raw('] ?? null)')
-                ;
+            if ($type instanceof TypeInterface) {
+                $sourceCompiler = $this->createNodeSourceCompiler();
+                $accessCompiler = $this->createAccessCompiler($type, $env);
+
+                if (true || $accessCompiler['condition'] === null) {
+                    $accessCompiler['accessor']($compiler, $sourceCompiler);
+                } else {
+                    $compiler->raw('(');
+                    $accessCompiler['condition']($compiler, $sourceCompiler);
+                    $compiler->raw(' ? ');
+                    $accessCompiler['accessor']($compiler, $sourceCompiler);
+                    $compiler->raw(' : ');
+                    $this->createGuessingAccessCompiler($env->hasExtension(SandboxExtension::class))['accessor']($compiler, $sourceCompiler);
+                    $compiler->raw(')');
+                }
 
                 return;
-            } else if ($type instanceof ObjectType && $this->getNode('attribute') instanceof ConstantExpression) {
-                $attributeName = $this->getNode('attribute')->getAttribute('value');
-
-                if ($type->getPropertyType($attributeName) !== null) {
-                    $compiler
-                        ->raw('((')
-                        ->subcompile($this->getNode('node'))
-                        ->raw(')?->')
-                        ->raw($attributeName)
-                        ->raw(')')
-                    ;
-
-                    return;
-                }
-
-                /** Keep similar to @see \Twig\TypeHint\ObjectType::getAttributeType */
-                $methodNames = [
-                    $attributeName,
-                    'get' . $attributeName,
-                    'is' . $attributeName,
-                    'has' . $attributeName,
-                ];
-
-                foreach ($methodNames as $methodName) {
-                    if ($type->getMethodType($methodName) !== null) {
-                        $compiler
-                            ->raw('((')
-                            ->subcompile($this->getNode('node'))
-                            ->raw(')?->')
-                            ->raw($methodName)
-                            ->raw('(')
-                        ;
-
-                        if ($this->hasNode('arguments') && $this->getNode('arguments') instanceof ArrayExpression && $this->getNode('arguments')->count() > 0) {
-                            for ($argIndex = 0; $argIndex < $this->getNode('arguments')->count(); $argIndex += 2) {
-                                if ($argIndex > 0) {
-                                    $compiler->raw(', ');
-                                }
-
-                                $compiler->subcompile($this->getNode('arguments')->getNode($argIndex + 1));
-                            }
-                        }
-
-                        $compiler->raw('))');
-                        return;
-                    }
-                }
             }
         }
 
@@ -126,31 +89,264 @@ class GetAttrExpression extends AbstractExpression
             return;
         }
 
-        $compiler->raw('CoreExtension::getAttribute($this->env, $this->source, ');
+        $this->createGuessingAccessCompiler($env->hasExtension(SandboxExtension::class))['accessor']($compiler, $this->createNodeSourceCompiler());
+    }
 
-        if ($this->getAttribute('ignore_strict_check')) {
-            $this->getNode('node')->setAttribute('ignore_strict_check', true);
+    /**
+     * @return array{
+     *     condition: \Closure(Compiler, \Closure(Compiler): void): void|null,
+     *     accessor: \Closure(Compiler, \Closure(Compiler): void): void
+     * }
+     */
+    private function createAccessCompiler(TypeInterface $type, Environment $env): array
+    {
+        if ($type instanceof UnionType) {
+            return $this->createUnionAccessCompiler($type, $env);
         }
 
-        $compiler
-            ->subcompile($this->getNode('node'))
-            ->raw(', ')
-            ->subcompile($this->getNode('attribute'))
-        ;
-
-        if ($this->hasNode('arguments')) {
-            $compiler->raw(', ')->subcompile($this->getNode('arguments'));
-        } else {
-            $compiler->raw(', []');
+        if ($type instanceof ArrayType) {
+            return $this->createArrayAccessCompiler();
         }
 
-        $compiler->raw(', ')
-            ->repr($this->getAttribute('type'))
-            ->raw(', ')->repr($this->getAttribute('is_defined_test'))
-            ->raw(', ')->repr($this->getAttribute('ignore_strict_check'))
-            ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
-            ->raw(', ')->repr($this->getNode('node')->getTemplateLine())
-            ->raw(')')
-        ;
+        if ($type instanceof ObjectType && $this->getNode('attribute') instanceof ConstantExpression) {
+            $attributeName = $this->getNode('attribute')->getAttribute('value');
+
+            if ($type->getPropertyType($attributeName) !== null) {
+                return $this->createObjectPropertyAccessCompiler($type, $attributeName);
+            }
+
+            /** Keep similar to @see \Twig\TypeHint\ObjectType::getAttributeType */
+            $methodNames = [
+                $attributeName,
+                'get' . $attributeName,
+                'is' . $attributeName,
+                'has' . $attributeName,
+            ];
+
+            foreach ($methodNames as $methodName) {
+                if ($type->getMethodType($methodName) === null) {
+                    continue;
+                }
+
+                return $this->createObjectMethodAccessCompiler($type, $methodName);
+            }
+        }
+
+        return $this->createGuessingAccessCompiler($env->hasExtension(SandboxExtension::class));
+    }
+
+    /**
+     * @return array{
+     *     condition: null,
+     *     accessor: \Closure(Compiler, \Closure(Compiler): void): void
+     * }
+     */
+    private function createGuessingAccessCompiler(bool $isSandboxed): array
+    {
+        return [
+            'condition' => null,
+            'accessor' => function (Compiler $compiler, \Closure $sourceCompiler) use ($isSandboxed): void {
+                $compiler->raw('CoreExtension::getAttribute($this->env, $this->source, ');
+
+                if ($this->getAttribute('ignore_strict_check')) {
+                    $this->getNode('node')->setAttribute('ignore_strict_check', true);
+                }
+
+                $sourceCompiler($compiler);
+
+                $compiler
+                    ->raw(', ')
+                    ->subcompile($this->getNode('attribute'))
+                ;
+
+                if ($this->hasNode('arguments')) {
+                    $compiler->raw(', ')->subcompile($this->getNode('arguments'));
+                } else {
+                    $compiler->raw(', []');
+                }
+
+                $compiler->raw(', ')
+                    ->repr($this->getAttribute('type'))
+                    ->raw(', ')->repr($this->getAttribute('is_defined_test'))
+                    ->raw(', ')->repr($this->getAttribute('ignore_strict_check'))
+                    ->raw(', ')->repr($isSandboxed)
+                    ->raw(', ')->repr($this->getNode('node')->getTemplateLine())
+                    ->raw(')')
+                ;
+            },
+        ];
+    }
+
+    /**
+     * @return array{
+     *     condition: \Closure(Compiler, \Closure(Compiler): void): void,
+     *     accessor: \Closure(Compiler, \Closure(Compiler): void): void
+     * }
+     */
+    private function createObjectMethodAccessCompiler(ObjectType $type, string $attributeName): array
+    {
+        return [
+            'condition' => function (Compiler $compiler, \Closure $sourceCompiler) use ($type): void {
+                $sourceCompiler($compiler);
+                $compiler->raw(' instanceof \\')->raw($type->getType());
+            },
+            'accessor' => function (Compiler $compiler, \Closure $sourceCompiler) use ($attributeName): void {
+                $compiler->raw('(');
+
+                $sourceCompiler($compiler);
+
+                $compiler->raw('?->')->raw($attributeName)->raw('(');
+
+                if ($this->hasNode('arguments') && $this->getNode('arguments') instanceof ArrayExpression && $this->getNode('arguments')->count() > 0) {
+                    for ($argIndex = 0; $argIndex < $this->getNode('arguments')->count(); $argIndex += 2) {
+                        if ($argIndex > 0) {
+                            $compiler->raw(', ');
+                        }
+
+                        $compiler->subcompile($this->getNode('arguments')->getNode($argIndex + 1));
+                    }
+                }
+
+                $compiler->raw('))');
+            },
+        ];
+    }
+
+    /**
+     * @return array{
+     *     condition: \Closure(Compiler, \Closure(Compiler): void): void,
+     *     accessor: \Closure(Compiler, \Closure(Compiler): void): void
+     * }
+     */
+    private function createObjectPropertyAccessCompiler(ObjectType $type, string $attributeName): array
+    {
+        return [
+            'condition' => function (Compiler $compiler, \Closure $sourceCompiler) use ($type): void {
+                $sourceCompiler($compiler);
+                $compiler->raw(' instanceof \\')->raw($type->getType());
+            },
+            'accessor' => function (Compiler $compiler, \Closure $sourceCompiler) use ($attributeName): void {
+                $sourceCompiler($compiler);
+                $compiler
+                    ->raw('?->')
+                    ->raw($attributeName);
+            },
+        ];
+    }
+
+    /**
+     * @return array{
+     *     condition: null,
+     *     accessor: \Closure(Compiler, \Closure(Compiler): void): void
+     * }
+     */
+    private function createUnionAccessCompiler(UnionType $type, Environment $env): array
+    {
+        $accessors = [];
+
+        foreach ($type->getTypes() as $innerType) {
+            $accessors[] = $this->createAccessCompiler($innerType, $env);
+        }
+
+        return [
+            'condition' => null,
+            'accessor' => function (Compiler $compiler, \Closure $sourceCompiler) use ($accessors) {
+                $compiler->raw('match ([');
+                $compiler->indent();
+                $sourceCompiler($compiler);
+                $compiler->raw(", true][1]) {\n");
+
+                foreach ($accessors as $accessor) {
+                    if ($accessor['condition'] === null) {
+                        $compiler->raw('default');
+                    } else {
+                        $accessor['condition']($compiler, $sourceCompiler);
+                    }
+
+                    $compiler->raw(' => ');
+                    $accessor['accessor']($compiler, $sourceCompiler);
+                    $compiler->raw(";\n");
+                }
+
+                $compiler->outdent();
+                $compiler->raw('}');
+            }
+        ];
+    }
+
+    /**
+     * @return array{
+     *     condition: \Closure(Compiler, \Closure(Compiler): void): void,
+     *     accessor: \Closure(Compiler, \Closure(Compiler): void): void
+     * }
+     */
+    private function createArrayAccessCompiler(): array
+    {
+        return [
+            'condition' => function (Compiler $compiler, \Closure $sourceCompiler): void {
+                $compiler->raw('(\is_array(');
+                $sourceCompiler($compiler);
+                $compiler->raw(') || ');
+                $sourceCompiler($compiler);
+                $compiler->raw(' instanceof \\ArrayAccess)');
+            },
+            'accessor' => function (Compiler $compiler, \Closure $sourceCompiler): void {
+                $compiler->raw('(');
+                $sourceCompiler($compiler);
+                $compiler
+                    ->raw('[')
+                    ->subcompile($this->getNode('attribute'))
+                    ->raw('] ?? null)');
+            },
+        ];
+    }
+
+    /**
+     * @return \Closure(Compiler): void
+     */
+    private function createAutoInlineSourceCompiler(): \Closure
+    {
+        $varName = null;
+        $sourceCompiler = $this->createNodeSourceCompiler();
+
+        return function (Compiler $compiler) use (&$varName, &$sourceCompiler): void {
+            if ($varName === null) {
+                $varName = $compiler->getVarName();
+                $newSourceCompiler = $this->createVarNameSourceCompiler($varName);
+
+                $compiler->raw('(');
+                $newSourceCompiler($compiler);
+                $compiler->raw(' = ');
+                $sourceCompiler($compiler);
+                $compiler->raw(')');
+
+                $sourceCompiler = $newSourceCompiler;
+            } else {
+                $sourceCompiler($compiler);
+            }
+        };
+    }
+
+    /**
+     * @return \Closure(Compiler): void
+     */
+    private function createNodeSourceCompiler(): \Closure
+    {
+        return function (Compiler $compiler): void {
+            $compiler->subcompile($this->getNode('node'));
+        };
+    }
+
+    /**
+     * @return \Closure(Compiler): void
+     */
+    private function createVarNameSourceCompiler(string $varName): \Closure
+    {
+        return function (Compiler $compiler) use ($varName): void {
+            $compiler
+                ->raw('$')
+                ->raw($varName)
+            ;
+        };
     }
 }

--- a/src/Node/TypeHintNode.php
+++ b/src/Node/TypeHintNode.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Node;
+
+use Twig\Compiler;
+
+/**
+ * Represents a type-hint node.
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+class TypeHintNode extends Node
+{
+    public function __construct(string $name, string $type, int $lineno, string $tag = null)
+    {
+        parent::__construct([], ['name' => $name, 'type' => $type], $lineno, $tag);
+    }
+
+    public function compile(Compiler $compiler): void
+    {
+        $compiler->addDebugInfo($this);
+    }
+}

--- a/src/Node/WithNode.php
+++ b/src/Node/WithNode.php
@@ -24,10 +24,13 @@ class WithNode extends Node
 {
     public function __construct(Node $body, ?Node $variables, bool $only, int $lineno, ?string $tag = null)
     {
-        $nodes = ['body' => $body];
+        $nodes = [];
+
         if (null !== $variables) {
             $nodes['variables'] = $variables;
         }
+
+        $nodes['body'] = $body;
 
         parent::__construct($nodes, ['only' => $only], $lineno, $tag);
     }

--- a/src/NodeVisitor/TypeEvaluateNodeVisitor.php
+++ b/src/NodeVisitor/TypeEvaluateNodeVisitor.php
@@ -45,6 +45,7 @@ use Twig\Node\Expression\Binary\StartsWithBinary;
 use Twig\Node\Expression\Binary\SubBinary;
 use Twig\Node\Expression\BlockReferenceExpression;
 use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\GetAttrExpression;
 use Twig\Node\Expression\ParentExpression;
 use Twig\Node\Expression\TestExpression;
 use Twig\Node\Expression\Unary\NegUnary;
@@ -153,6 +154,25 @@ final class TypeEvaluateNodeVisitor implements NodeVisitorInterface
 
         if ($node instanceof ConstantExpression) {
             yield from $this->getPossibleConstantExpressionTypes($node);
+        }
+
+        if ($node instanceof GetAttrExpression) {
+            if ($node->getNode('attribute') instanceof ConstantExpression) {
+                $attributeName = $node->getNode('attribute')->getAttribute('value');
+                $typeHint = null;
+
+                if ($node->getNode('node')->hasAttribute('typeHint')) {
+                    $typeHint = $node->getNode('node')->getAttribute('typeHint');
+                }
+
+                if ($typeHint instanceof TypeInterface) {
+                    $variableType = $typeHint->getAttributeType($attributeName);
+
+                    if ($variableType !== null) {
+                        yield $variableType;
+                    }
+                }
+            }
         }
 
         if ($node instanceof MacroNode) {

--- a/src/NodeVisitor/TypeEvaluateNodeVisitor.php
+++ b/src/NodeVisitor/TypeEvaluateNodeVisitor.php
@@ -1,0 +1,352 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\NodeVisitor;
+
+use Twig\Environment;
+use Twig\Node\AutoEscapeNode;
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Expression\AssignNameExpression;
+use Twig\Node\Expression\Binary\AddBinary;
+use Twig\Node\Expression\Binary\AndBinary;
+use Twig\Node\Expression\Binary\BitwiseAndBinary;
+use Twig\Node\Expression\Binary\BitwiseOrBinary;
+use Twig\Node\Expression\Binary\BitwiseXorBinary;
+use Twig\Node\Expression\Binary\ConcatBinary;
+use Twig\Node\Expression\Binary\DivBinary;
+use Twig\Node\Expression\Binary\EndsWithBinary;
+use Twig\Node\Expression\Binary\EqualBinary;
+use Twig\Node\Expression\Binary\FloorDivBinary;
+use Twig\Node\Expression\Binary\GreaterBinary;
+use Twig\Node\Expression\Binary\GreaterEqualBinary;
+use Twig\Node\Expression\Binary\HasEveryBinary;
+use Twig\Node\Expression\Binary\HasSomeBinary;
+use Twig\Node\Expression\Binary\InBinary;
+use Twig\Node\Expression\Binary\LessBinary;
+use Twig\Node\Expression\Binary\LessEqualBinary;
+use Twig\Node\Expression\Binary\MatchesBinary;
+use Twig\Node\Expression\Binary\ModBinary;
+use Twig\Node\Expression\Binary\MulBinary;
+use Twig\Node\Expression\Binary\NotEqualBinary;
+use Twig\Node\Expression\Binary\NotInBinary;
+use Twig\Node\Expression\Binary\OrBinary;
+use Twig\Node\Expression\Binary\PowerBinary;
+use Twig\Node\Expression\Binary\RangeBinary;
+use Twig\Node\Expression\Binary\SpaceshipBinary;
+use Twig\Node\Expression\Binary\StartsWithBinary;
+use Twig\Node\Expression\Binary\SubBinary;
+use Twig\Node\Expression\BlockReferenceExpression;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\ParentExpression;
+use Twig\Node\Expression\TestExpression;
+use Twig\Node\Expression\Unary\NegUnary;
+use Twig\Node\Expression\Unary\NotUnary;
+use Twig\Node\Expression\Unary\PosUnary;
+use Twig\Node\MacroNode;
+use Twig\Node\Node;
+use Twig\Node\SetNode;
+use Twig\TypeHint\ArrayType;
+use Twig\TypeHint\TypeFactory;
+use Twig\TypeHint\TypeInterface;
+use Twig\TypeHint\UnionType;
+
+/**
+ * Tries to evaluate types for optimized attribute access.
+ *
+ * This visitor should be used late in priority.
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ *
+ * @internal
+ */
+final class TypeEvaluateNodeVisitor implements NodeVisitorInterface
+{
+    public function enterNode(Node $node, Environment $env): Node
+    {
+        return $node;
+    }
+
+    public function leaveNode(Node $node, Environment $env): ?Node
+    {
+        $possibleTypes = [];
+
+        foreach ($this->getPossibleTypes($node) as $possibleType) {
+            if (!$possibleType instanceof TypeInterface) {
+                $possibleType = TypeFactory::createTypeFromText((string) $possibleType);
+            }
+
+            $possibleTypes[] = $possibleType;
+        }
+
+        if (\count($possibleTypes) !== 1) {
+            $node->setAttribute('typeHint', new UnionType($possibleTypes));
+        } elseif ($possibleTypes !== []) {
+            $node->setAttribute('typeHint', $possibleTypes[0]);
+        }
+
+        if ($node instanceof SetNode) {
+            /** @var array<string, TypeInterface> $typedVariables */
+            $typedVariables = [];
+
+            // capture is always string
+            if ($node->getAttribute('capture')) {
+                $stringType = TypeFactory::createTypeFromText('string');
+                /** @var Node $innerNameNode */
+                foreach ($node->getNode('names') as $innerNameNode) {
+                    $typedVariables[$innerNameNode->getAttribute('name')] = $stringType;
+                }
+            } else {
+                // TODO push state
+                /** @var AssignNameExpression $innerNameNode */
+                foreach ($node->getNode('names') as $nameIndex => $innerNameNode) {
+                    $typedVariables[$innerNameNode->getAttribute('name')] = $node->getNode('values')->getNode($nameIndex)->getAttribute('typeHint');
+                }
+            }
+
+            if ($typedVariables !== []) {
+                $node->setAttribute('typeHint', new ArrayType($typedVariables));
+            }
+        }
+
+        if ($node instanceof ArrayExpression) {
+            $typedVariables = [];
+
+            for ($arrayIterator = $node->count() - 2; $arrayIterator >= 0; $arrayIterator -= 2) {
+                $nameNode = $node->getNode($arrayIterator);
+                $valueNode = $node->getNode($arrayIterator + 1);
+
+                if ($nameNode instanceof ConstantExpression) {
+                    $varName = $nameNode->getAttribute('value');
+
+                    if ($valueNode->hasAttribute('typeHint')) {
+                        $typedVariables[$varName] = $valueNode->getAttribute('typeHint');
+                    }
+                }
+            }
+
+            if ($typedVariables !== []) {
+                $node->setAttribute('typeHint', new ArrayType($typedVariables));
+            }
+        }
+
+        return $node;
+    }
+
+    public function getPriority(): int
+    {
+        return 10;
+    }
+
+    private function getPossibleTypes(Node $node): iterable
+    {
+        if ($node instanceof AutoEscapeNode) {
+            yield 'string';
+        }
+
+        if ($node instanceof ConstantExpression) {
+            yield from $this->getPossibleConstantExpressionTypes($node);
+        }
+
+        if ($node instanceof MacroNode) {
+            yield 'string';
+        }
+
+        if ($node instanceof ArrayExpression) { // VariadicExpression
+            yield 'array';
+            yield '\\ArrayAccess';
+        }
+
+        if ($node instanceof BlockReferenceExpression) {
+            yield 'string';
+        }
+
+        if ($node instanceof ParentExpression) {
+            yield 'string';
+        }
+
+        if ($node instanceof TestExpression) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof NotUnary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof NegUnary) {
+            yield 'integer';
+            yield 'float';
+        }
+
+        if ($node instanceof PosUnary) {
+            yield 'integer';
+            yield 'float';
+        }
+
+        yield from $this->getPossibleTypesOfBinaryExpression($node);
+
+        if (\get_class($node) === Node::class) {
+            /** @var Node $innerNode */
+            foreach ($node as $innerNode) {
+                if (!$innerNode->hasAttribute('typeHint')) {
+                    continue;
+                }
+
+                yield $innerNode->getAttribute('typeHint');
+            }
+        }
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    private function getPossibleConstantExpressionTypes(ConstantExpression $node): iterable
+    {
+        $nodeValue = $node->getAttribute('value');
+
+        if (!\is_object($nodeValue)) {
+            $phpType = \gettype($nodeValue);
+
+            if ($phpType === 'double') {
+                yield 'float';
+            } elseif ($phpType === 'NULL') {
+                yield 'float';
+            } else {
+                yield $phpType;
+            }
+        } else {
+            yield '\\' . \get_class($nodeValue);
+        }
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    private function getPossibleTypesOfBinaryExpression(Node $node): iterable
+    {
+        if ($node instanceof AddBinary) {
+            yield 'integer';
+            yield 'float';
+        }
+
+        if ($node instanceof AndBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof BitwiseAndBinary) {
+            yield 'integer';
+        }
+
+        if ($node instanceof BitwiseOrBinary) {
+            yield 'integer';
+        }
+
+        if ($node instanceof BitwiseXorBinary) {
+            yield 'integer';
+        }
+
+        if ($node instanceof ConcatBinary) {
+            yield 'string';
+        }
+
+        if ($node instanceof DivBinary) {
+            yield 'integer';
+            yield 'float';
+        }
+
+        if ($node instanceof EndsWithBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof EqualBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof FloorDivBinary) {
+            yield 'integer';
+        }
+
+        if ($node instanceof GreaterBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof GreaterEqualBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof HasEveryBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof HasSomeBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof InBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof LessBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof LessEqualBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof MatchesBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof ModBinary) {
+            yield 'integer';
+        }
+
+        if ($node instanceof MulBinary) {
+            yield 'integer';
+            yield 'float';
+        }
+
+        if ($node instanceof NotEqualBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof NotInBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof OrBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof PowerBinary) {
+            yield 'integer';
+            yield 'float';
+        }
+
+        if ($node instanceof RangeBinary) {
+            yield 'array';
+            yield '\\ArrayAccess';
+        }
+
+        if ($node instanceof SpaceshipBinary) {
+            yield 'integer';
+        }
+
+        if ($node instanceof StartsWithBinary) {
+            yield 'boolean';
+        }
+
+        if ($node instanceof SubBinary) {
+            yield 'integer';
+            yield 'float';
+        }
+    }
+}

--- a/src/TokenParser/TypeHintTokenParser.php
+++ b/src/TokenParser/TypeHintTokenParser.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\TokenParser;
+
+use Twig\Error\SyntaxError;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\NameExpression;
+use Twig\Node\Node;
+use Twig\Node\TypeHintNode;
+use Twig\Token;
+
+/**
+ * Keeps track of variable types for accessor generation.
+ *
+ *     {% type interval \DateInterval|null %}
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ * @internal
+ */
+final class TypeHintTokenParser extends AbstractTokenParser
+{
+    public function parse(Token $token): Node
+    {
+        $stream = $this->parser->getStream();
+        $name = $this->parser->getExpressionParser()->parseExpression();
+
+        if (!$name instanceof NameExpression) {
+            throw new SyntaxError('A type hint must refer to a variable with a constant name', $stream->getCurrent()->getLine(), $stream->getSourceContext());
+        }
+
+        $type = $this->parser->getExpressionParser()->parseExpression();
+        $typeValue = null;
+
+        if ($type instanceof NameExpression) {
+            $typeValue = $type->getAttribute('name');
+        }
+
+        if ($type instanceof ConstantExpression) {
+            $typeValue = $type->getAttribute('value');
+        }
+
+        if (!\is_string($typeValue)) {
+            throw new SyntaxError('A type hint must refer to a type with a constant name', $stream->getCurrent()->getLine(), $stream->getSourceContext());
+        }
+
+        $this->parser->getStream()->expect(/* Token::BLOCK_END_TYPE */ 3);
+
+        return new TypeHintNode(
+            $name->getAttribute('name'),
+            $typeValue,
+            $token->getLine(),
+            $this->getTag()
+        );
+    }
+
+    public function getTag(): string
+    {
+        return 'type';
+    }
+}

--- a/src/TypeHint/ArrayType.php
+++ b/src/TypeHint/ArrayType.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Twig\TypeHint;
+
+/**
+ * Describes a type of an associative array.
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+class ArrayType extends Type
+{
+    /**
+     * @var array<TypeInterface>
+     */
+    private array $attributes;
+
+    /**
+     * @param array<TypeInterface> $attributes
+     */
+    public function __construct(array $attributes)
+    {
+        parent::__construct('array');
+        $this->attributes = $attributes;
+    }
+
+    /**
+     * @return array<TypeInterface>
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    public function getAttributeType(string|int $attribute): ?TypeInterface
+    {
+        return $this->attributes[$attribute] ?? null;
+    }
+}

--- a/src/TypeHint/ContextStack.php
+++ b/src/TypeHint/ContextStack.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Twig\TypeHint;
+
+/**
+ * Describes a stack of possible types for a variable.
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+class ContextStack
+{
+    /**
+     * First/major layer non-sharing stacks (with-node e.g. tagged as only)
+     * Second/minor layer for sharing stacks (with-node e.g. not tagged as only)
+     *
+     * @var list<list<array<string, list<TypeInterface>>>>
+     */
+    private array $variables = [[]];
+
+    public function getVariableType(string $name): ?TypeInterface
+    {
+        $result = [];
+
+        foreach ($this->variables[0] as $types) {
+            foreach ($types[$name] ?? [] as $type) {
+                $result[] = $type;
+            }
+        }
+
+        return TypeFactory::createTypeFromCollection($result);
+    }
+
+    public function addVariableType(string $name, TypeInterface $type): void
+    {
+        $this->variables[0][0][$name][] = $type;
+    }
+
+    public function pushMajorStack(): void
+    {
+        \array_unshift($this->variables, []);
+    }
+
+    public function popMajorStack(): void
+    {
+        \array_shift($this->variables);
+    }
+
+    public function pushMinorStack(): void
+    {
+        \array_unshift($this->variables[0], []);
+    }
+
+    public function popMinorStack(): void
+    {
+        \array_shift($this->variables[0]);
+    }
+}

--- a/src/TypeHint/ObjectType.php
+++ b/src/TypeHint/ObjectType.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Twig\TypeHint;
+
+/**
+ * This describes a type of an instance of an object.
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+class ObjectType extends Type
+{
+    private \ReflectionClass $reflectionClass;
+
+    /**
+     * @var array<string, Type>
+     */
+    private array $properties = [];
+
+    /**
+     * @var array<string, Type>
+     */
+    private array $methods = [];
+
+    public function __construct(\ReflectionClass $reflectionClass)
+    {
+        parent::__construct($reflectionClass->getName());
+        $this->reflectionClass = $reflectionClass;
+    }
+
+    public function getAttributeType(string|int $attribute): ?TypeInterface
+    {
+        return $this->getPropertyType((string) $attribute)
+            ?? $this->getMethodType((string) $attribute)
+            ?? $this->getMethodType('get' . $attribute)
+            ?? $this->getMethodType('is' . $attribute)
+            ?? $this->getMethodType('has' . $attribute);
+    }
+
+    private function getPropertyType(string $name): ?TypeInterface
+    {
+        if (\array_key_exists($name, $this->properties)) {
+            return $this->properties[$name];
+        }
+
+        return $this->properties[$name] = $this->createPropertyType($name);
+    }
+
+    private function createPropertyType(string $name): ?TypeInterface
+    {
+        if (!$this->reflectionClass->hasProperty($name)) {
+            return null;
+        }
+
+        try {
+            $property = $this->reflectionClass->getProperty($name);
+
+            if (!$property->isPublic()) {
+                return null;
+            }
+
+            return $this->createType($property->getType());
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function getMethodType(string $name): ?TypeInterface
+    {
+        if (\array_key_exists($name, $this->methods)) {
+            return $this->methods[$name];
+        }
+
+        return $this->methods[$name] = $this->createMethodType($name);
+    }
+
+    private function createMethodType(string $name): ?TypeInterface
+    {
+        if (!$this->reflectionClass->hasMethod($name)) {
+            $this->methods[$name] = null;
+
+            return null;
+        }
+
+        try {
+            $method = $this->reflectionClass->getMethod($name);
+
+            if (!$method->isPublic()) {
+                return null;
+            }
+
+            return $this->createType($method->getReturnType());
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function createType(?\ReflectionType $type): ?TypeInterface
+    {
+        if ($type === null) {
+            return null;
+        }
+
+        return TypeFactory::createTypeFromText((string) $type);
+    }
+}

--- a/src/TypeHint/ObjectType.php
+++ b/src/TypeHint/ObjectType.php
@@ -47,7 +47,7 @@ class ObjectType extends Type
             ?? $this->getMethodType('has' . $attribute);
     }
 
-    private function getPropertyType(string $name): ?TypeInterface
+    public function getPropertyType(string $name): ?TypeInterface
     {
         if (\array_key_exists($name, $this->properties)) {
             return $this->properties[$name];
@@ -75,7 +75,7 @@ class ObjectType extends Type
         }
     }
 
-    private function getMethodType(string $name): ?TypeInterface
+    public function getMethodType(string $name): ?TypeInterface
     {
         if (\array_key_exists($name, $this->methods)) {
             return $this->methods[$name];

--- a/src/TypeHint/Type.php
+++ b/src/TypeHint/Type.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Twig\TypeHint;
+
+/**
+ * Represents any type. Mainly used for scalar and non-object types.
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+class Type implements TypeInterface
+{
+    private string $type;
+
+    public function __construct(string $type)
+    {
+        $this->type = $type;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getAttributeType(string|int $attribute): ?TypeInterface
+    {
+        return null;
+    }
+}

--- a/src/TypeHint/TypeFactory.php
+++ b/src/TypeHint/TypeFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Twig\TypeHint;
+
+/**
+ * Provides an entrypoint to build instances of @see TypeInterface
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+abstract class TypeFactory
+{
+    private static array $plainTypeCache = [];
+
+    private static array $objectTypeCache = [];
+
+    public static function createTypeFromText(string $type): ?TypeInterface
+    {
+        $types = [];
+
+        foreach (\explode('|', $type) as $propertyType) {
+            if (\str_starts_with($propertyType, '\\')) {
+                try {
+                    $types[] = self::createObjectType($propertyType);
+                } catch (\Throwable) {
+                    continue;
+                }
+            } else {
+                $types[] = self::createPlainType($propertyType);
+            }
+        }
+
+        if ($types === []) {
+            return null;
+        }
+
+        return \count($types) === 1 ? $types[0] : new UnionType($types);
+    }
+
+    private static function createPlainType(string $type): Type
+    {
+        return self::$plainTypeCache[$type] ??= new Type($type);
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    private static function createObjectType(string $class): ObjectType
+    {
+        return self::$objectTypeCache[$class] ??= new ObjectType(new \ReflectionClass(\ltrim($class, '\\')));
+    }
+}

--- a/src/TypeHint/TypeFactory.php
+++ b/src/TypeHint/TypeFactory.php
@@ -29,13 +29,13 @@ abstract class TypeFactory
         $types = [];
 
         foreach (\explode('|', $type) as $propertyType) {
-            if (\str_starts_with($propertyType, '\\')) {
-                try {
-                    $types[] = self::createObjectType($propertyType);
-                } catch (\Throwable) {
-                    continue;
-                }
-            } else {
+            if ($propertyType === '') {
+                continue;
+            }
+
+            try {
+                $types[] = self::createObjectType(\ltrim($propertyType, '\\'));
+            } catch (\Throwable) {
                 $types[] = self::createPlainType($propertyType);
             }
         }
@@ -62,6 +62,6 @@ abstract class TypeFactory
      */
     private static function createObjectType(string $class): ObjectType
     {
-        return self::$objectTypeCache[$class] ??= new ObjectType(new \ReflectionClass(\ltrim($class, '\\')));
+        return self::$objectTypeCache[$class] ??= new ObjectType(new \ReflectionClass($class));
     }
 }

--- a/src/TypeHint/TypeFactory.php
+++ b/src/TypeHint/TypeFactory.php
@@ -40,6 +40,11 @@ abstract class TypeFactory
             }
         }
 
+        return static::createTypeFromCollection($types);
+    }
+
+    public static function createTypeFromCollection(array $types): ?TypeInterface
+    {
         if ($types === []) {
             return null;
         }

--- a/src/TypeHint/TypeInterface.php
+++ b/src/TypeHint/TypeInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Twig\TypeHint;
+
+/**
+ * Describe any type, that is used as a typehint and access to its attribute types.
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+interface TypeInterface
+{
+    public function getAttributeType(string|int $attribute): ?TypeInterface;
+}

--- a/src/TypeHint/UnionType.php
+++ b/src/TypeHint/UnionType.php
@@ -65,14 +65,6 @@ final class UnionType implements TypeInterface
             }
         }
 
-        if ($result === []) {
-            return null;
-        }
-
-        if (\count($result) === 1) {
-            return $result[0];
-        }
-
-        return new UnionType($result);
+        return TypeFactory::createTypeFromCollection($result);
     }
 }

--- a/src/TypeHint/UnionType.php
+++ b/src/TypeHint/UnionType.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Twig\TypeHint;
+
+/**
+ * This describes a list of alternative types.
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+final class UnionType implements TypeInterface
+{
+    /**
+     * @var list<TypeInterface>
+     */
+    private array $types;
+
+    /**
+     * @param list<TypeInterface> $types
+     */
+    public function __construct(array $types)
+    {
+        $items = [];
+
+        foreach ($types as $type) {
+            if ($type instanceof UnionType) {
+                foreach ($type->getTypes() as $innerType) {
+                    $items[] = $innerType;
+                }
+            } else {
+                $items[] = $type;
+            }
+        }
+
+        $this->types = $items;
+    }
+
+    /**
+     * @return list<TypeInterface>
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    public function getAttributeType(string|int $attribute): ?TypeInterface
+    {
+        $result = [];
+
+        foreach ($this->types as $type) {
+            $attributeType = $type->getAttributeType($attribute);
+
+            if ($attributeType !== null) {
+                $result[] = $attributeType;
+            }
+        }
+
+        if ($result === []) {
+            return null;
+        }
+
+        if (\count($result) === 1) {
+            return $result[0];
+        }
+
+        return new UnionType($result);
+    }
+}

--- a/tests/Fixtures/tags/type/comment.type-hint.test
+++ b/tests/Fixtures/tags/type/comment.type-hint.test
@@ -1,0 +1,11 @@
+--TEST--
+Add PHP types to variables
+--TEMPLATE--
+{# @var interval \DateInterval #}
+{{ interval.s }}
+--DATA--
+return [
+    'interval' => new \DateInterval('PT6S'),
+]
+--EXPECT--
+6

--- a/tests/Fixtures/tags/type/tag.type-hint.test
+++ b/tests/Fixtures/tags/type/tag.type-hint.test
@@ -1,0 +1,11 @@
+--TEST--
+Add PHP types to variables
+--TEMPLATE--
+{% type interval "\\DateInterval" %}
+{{ interval.s }}
+--DATA--
+return [
+    'interval' => new \DateInterval('PT6S'),
+]
+--EXPECT--
+6

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -131,6 +131,19 @@ class LexerTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testTypeHintFromComment()
+    {
+        $template = '{# @var interval \DateInterval|null #}';
+
+        $lexer = new Lexer(new Environment($this->createMock(LoaderInterface::class)));
+        $stream = $lexer->tokenize(new Source($template, 'index'));
+        $stream->expect(Token::BLOCK_START_TYPE);
+        static::assertSame('type', $stream->expect(Token::NAME_TYPE)->getValue());
+        static::assertSame('interval', $stream->expect(Token::NAME_TYPE)->getValue());
+        static::assertSame('\DateInterval|null', $stream->expect(Token::NAME_TYPE)->getValue());
+        $stream->expect(Token::BLOCK_END_TYPE);
+    }
+
     public function testTypeHintFromBlock()
     {
         $template = '{% type interval "\\\\DateInterval|null" %}';

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -131,6 +131,19 @@ class LexerTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testTypeHintFromBlock()
+    {
+        $template = '{% type interval "\\\\DateInterval|null" %}';
+
+        $lexer = new Lexer(new Environment($this->createMock(LoaderInterface::class)));
+        $stream = $lexer->tokenize(new Source($template, 'index'));
+        $stream->expect(Token::BLOCK_START_TYPE);
+        static::assertSame('type', $stream->expect(Token::NAME_TYPE)->getValue());
+        static::assertSame('interval', $stream->expect(Token::NAME_TYPE)->getValue());
+        static::assertSame('\\DateInterval|null', $stream->expect(Token::STRING_TYPE)->getValue());
+        $stream->expect(Token::BLOCK_END_TYPE);
+    }
+
     public function testLongVerbatim()
     {
         $template = '{% verbatim %}'.str_repeat('*', 100000).'{% endverbatim %}';

--- a/tests/Node/Expression/GetAttrTest.php
+++ b/tests/Node/Expression/GetAttrTest.php
@@ -75,6 +75,22 @@ PHP,
             $optimizedEnv,
         ];
 
+        $tests[] = [
+            $optimizedEnv->parse(
+                $optimizedEnv->tokenize(
+                    new Source("{% set foo = { bar: { baz: 42 } } %}\n{{ foo.bar.baz|raw }}", 'index.twig')
+                )
+            )->getNode('body'),
+            <<<'PHP'
+// line 1
+$context["foo"] = ["bar" => ["baz" => 42]];
+// line 2
+echo ((((($context["foo"] ?? null))["bar"] ?? null))["baz"] ?? null);
+PHP,
+            $optimizedEnv,
+            true,
+        ];
+
         return $tests;
     }
 }

--- a/tests/Node/Expression/GetAttrTest.php
+++ b/tests/Node/Expression/GetAttrTest.php
@@ -70,7 +70,7 @@ class GetAttrTest extends NodeTestCase
             )->getNode('body'),
             <<<'PHP'
 // line 1
-echo ((((["bar" => ["baz" => 42]])["bar"] ?? null))["baz"] ?? null);
+echo ((["bar" => ["baz" => 42]]["bar"] ?? null)["baz"] ?? null);
 PHP,
             $optimizedEnv,
         ];
@@ -85,7 +85,7 @@ PHP,
 // line 1
 $context["foo"] = ["bar" => ["baz" => 42]];
 // line 2
-echo ((((($context["foo"] ?? null))["bar"] ?? null))["baz"] ?? null);
+echo ((($context["foo"] ?? null)["bar"] ?? null)["baz"] ?? null);
 PHP,
             $optimizedEnv,
         ];
@@ -98,7 +98,7 @@ TWIG, 'index.twig')))->getNode('body'),
             <<<'PHP'
 // line 1
 // line 2
-echo ((($context["obj"] ?? null))?->name);
+echo ($context["obj"] ?? null)?->name;
 PHP,
             $optimizedEnv,
         ];
@@ -111,7 +111,7 @@ TWIG, 'index.twig')))->getNode('body'),
             <<<'PHP'
 // line 1
 // line 2
-echo ((($context["obj"] ?? null))?->getname());
+echo (($context["obj"] ?? null)?->getname());
 PHP,
             $optimizedEnv,
         ];
@@ -124,7 +124,7 @@ TWIG, 'index.twig')))->getNode('body'),
             <<<'PHP'
 // line 1
 // line 2
-echo ((($context["obj"] ?? null))?->byName("foobar"));
+echo (($context["obj"] ?? null)?->byName("foobar"));
 PHP,
             $optimizedEnv,
         ];
@@ -137,7 +137,23 @@ TWIG, 'index.twig')))->getNode('body'),
             <<<'PHP'
 // line 1
 // line 2
-echo ((((($context["obj"] ?? null))?->getinstance()))?->getname());
+echo ((($context["obj"] ?? null)?->getinstance())?->getname());
+PHP,
+            $optimizedEnv,
+        ];
+
+        $tests[] = [
+            $optimizedEnv->parse($optimizedEnv->tokenize(new Source(<<<'TWIG'
+{% type obj "\\Twig\\Tests\\Node\\Expression\\ClassWithPublicProperty|\\Twig\\Tests\\Node\\Expression\\ClassWithPublicGetter" %}
+{{ obj.name|raw }}
+TWIG, 'index.twig')))->getNode('body'),
+            <<<'PHP'
+// line 1
+// line 2
+echo match ([($context["obj"] ?? null), true][1]) {
+($context["obj"] ?? null) instanceof \Twig\Tests\Node\Expression\ClassWithPublicProperty => ($context["obj"] ?? null)?->name;
+($context["obj"] ?? null) instanceof \Twig\Tests\Node\Expression\ClassWithPublicGetter => (($context["obj"] ?? null)?->getname());
+};
 PHP,
             $optimizedEnv,
         ];

--- a/tests/Node/TypeHintTest.php
+++ b/tests/Node/TypeHintTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Twig\Tests\Node;
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Twig\Node\TypeHintNode;
+use Twig\Test\NodeTestCase;
+
+class TypeHintTest extends NodeTestCase
+{
+    public function testConstructor()
+    {
+        $node = new TypeHintNode('interval', '\DateInterval|string', 1);
+
+        $this->assertEquals('interval', $node->getAttribute('name'));
+        $this->assertEquals('\DateInterval|string', $node->getAttribute('type'));
+    }
+
+    public function getTests()
+    {
+        $tests = [];
+
+        $node = new TypeHintNode('interval', '\DateInterval|string', 1);
+        $tests[] = [$node, "// line 1"];
+
+        return $tests;
+    }
+}

--- a/tests/NodeVisitor/TypeEvaluateNodeVisitorTest.php
+++ b/tests/NodeVisitor/TypeEvaluateNodeVisitorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Twig\Tests\NodeVisitor;
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Extension\TypeOptimizerExtension;
+use Twig\Loader\LoaderInterface;
+use Twig\Node\Expression\Binary\AddBinary;
+use Twig\Node\Expression\Binary\ConcatBinary;
+use Twig\Node\Expression\BlockReferenceExpression;
+use Twig\Node\PrintNode;
+use Twig\Node\SetNode;
+use Twig\Source;
+use Twig\TypeHint\ArrayType;
+use Twig\TypeHint\Type;
+use Twig\TypeHint\UnionType;
+
+class TypeEvaluateNodeVisitorTest extends TestCase
+{
+    public function testStringTypeOnBlockCalls(): void
+    {
+        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false]);
+        $env->addExtension(new TypeOptimizerExtension());
+
+        $stream = $env->parse($env->tokenize(new Source('{{ block("foo") }}', 'index')));
+
+        $node = $stream->getNode('body')->getNode(0);
+
+        $this->assertInstanceOf(BlockReferenceExpression::class, $node);
+        $this->assertSame('string', $node->getAttribute('typeHint')->getType());
+    }
+
+    public function testStringTypeOnConcat(): void
+    {
+        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false]);
+        $env->addExtension(new TypeOptimizerExtension());
+
+        $stream = $env->parse($env->tokenize(new Source('{{ "foo" ~ "bar" }}', 'index')));
+
+        $node = $stream->getNode('body')->getNode(0);
+
+        $this->assertInstanceOf(PrintNode::class, $node);
+
+        $expr = $node->getNode('expr');
+
+        $this->assertInstanceOf(ConcatBinary::class, $expr);
+        $this->assertSame('string', $expr->getAttribute('typeHint')->getType());
+    }
+
+    public function testNumericTypeOnAddition(): void
+    {
+        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false]);
+        $env->addExtension(new TypeOptimizerExtension());
+
+        $stream = $env->parse($env->tokenize(new Source('{{ 1 + 3 }}', 'index')));
+
+        $node = $stream->getNode('body')->getNode(0);
+
+        $this->assertInstanceOf(PrintNode::class, $node);
+
+        $expr = $node->getNode('expr');
+
+        $this->assertInstanceOf(AddBinary::class, $expr);
+
+        $unionType = $expr->getAttribute('typeHint');
+
+        $this->assertInstanceOf(UnionType::class, $unionType);
+        $this->assertEqualsCanonicalizing(['integer', 'float'], [$unionType->getTypes()[0]->getType(), $unionType->getTypes()[1]->getType()]);
+    }
+
+    public function testSetVariableIsAssignedArrayObject(): void
+    {
+        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false]);
+        $env->addExtension(new TypeOptimizerExtension());
+
+        $stream = $env->parse($env->tokenize(new Source('{% set foo = { bar: 42 } %}', 'index')));
+
+        $node = $stream->getNode('body')->getNode(0);
+        $type = $node->getAttribute('typeHint');
+
+        $this->assertInstanceOf(SetNode::class, $node);
+        $this->assertInstanceOf(ArrayType::class, $type);
+
+        $fooType = $type->getAttributeType('foo');
+
+        $this->assertInstanceOf(ArrayType::class, $fooType);
+
+        $barType = $fooType->getAttributeType('bar');
+
+        $this->assertInstanceOf(Type::class, $barType);
+        $this->assertSame('integer', $barType->getType());
+    }
+}

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -175,6 +175,39 @@ EOF
         $this->addToAssertionCount(1);
     }
 
+    public function testTypeHintWithoutType()
+    {
+        $this->expectException(SyntaxError::class);
+        $this->expectExceptionMessage('Unexpected token "end of statement block" of value "" at line 1.');
+
+        $stream = new TokenStream([
+            new Token(Token::BLOCK_START_TYPE, '', 1),
+            new Token(Token::NAME_TYPE, 'type', 1),
+            new Token(Token::NAME_TYPE, 'interval', 1),
+            new Token(Token::BLOCK_END_TYPE, '', 1),
+            new Token(Token::EOF_TYPE, '', 1),
+        ]);
+        $parser = new Parser(new Environment($this->createMock(LoaderInterface::class)));
+        $parser->parse($stream);
+    }
+
+    public function testTypeHintWithExpressionAsType()
+    {
+        $this->expectException(SyntaxError::class);
+        $this->expectExceptionMessage('A type hint must refer to a type with a constant name at line 1');
+
+        $stream = new TokenStream([
+            new Token(Token::BLOCK_START_TYPE, '', 1),
+            new Token(Token::NAME_TYPE, 'type', 1),
+            new Token(Token::NAME_TYPE, 'interval', 1),
+            new Token(Token::NUMBER_TYPE, 17, 1),
+            new Token(Token::BLOCK_END_TYPE, '', 1),
+            new Token(Token::EOF_TYPE, '', 1),
+        ]);
+        $parser = new Parser(new Environment($this->createMock(LoaderInterface::class)));
+        $parser->parse($stream);
+    }
+
     protected function getParser()
     {
         $parser = new Parser(new Environment($this->createMock(LoaderInterface::class)));


### PR DESCRIPTION
Once upon a time I had to find out why a twig template is slow (350ms). In my SPX icicle graph I saw `twig_get_attribute` being used quite often and is taking some time:

<img width="710" alt="11,5% of exclusive time of twig_get_attribute" src="https://github.com/twigphp/Twig/assets/1133593/284fba61-7f02-4d7f-a81f-d33b1ec2fc81">

At this time I started to dig into what this method does. If I get it right it guesses whatever how to get to the next value by a given attribute as it tries to get one step deeper from the dot-path notation we use everywhere. I see that this is needed for such a dynamically typed language that is the base for this.

A template like this `{{ foo.bar }}` could mean:
1. `$foo->bar`
2. `$foo->bar()`
3. `$foo->getBar()`
4. `$foo->isBar()`
5. `$foo['bar']`

I thought it could be at least cached so the choice does not need to be calculated twice but this is only valid if you have the values to render the template. So I have to use something else to improve the performance. Now imagine all the paths one could take for `{{ foo.bar.thing }}`. This can be a lot but if predict the path to be `$foo->getBar()->getThing()` because you just pass in your structs with getters and you can know it ahead.

For my IDE to support me in programming I use Twig comments with PHP type hints. I thought if this helps me to predict what methods I can call, Twig could use this info as well. PHPStan and Psalm also help me in my daily work as well so maybe we can add some sort of compiler optimizations like we know from C/++:
* Level 0 acts like this before
* Level 1 is preferring predict access but falls back to (generates more code but slow code should be executed less)
* Level 2 is only using predicted access (less code for clear paths and only falling back to null)
* Level 3 is throwing exceptions when paths are not resolvable (code like in level 2 but templates can be validated at compile time).

What I implemented in this pull request is a proof of concept with basic variable type cache for different scopes. These scopes can be influenced by code comments `{# @var type \DateTimeInterface #}`, that you already do, and with a specific block `{% type "DateTimeInterface" %}` to be more specificly integrated into the language so one could differ between IDE hints and language specific hints. I already have scopes by BodyNode and WithNode. Types that can be extracted from simple expressions are understood without type hints (e.g. array expressions). I prepared code, that wants to behave like level 2 optimization but level 1 could be done, when changing `src/Node/Expression/GetAttrExpression.php:51` by removing the `true ||` and using a `createAutoInlineSourceCompiler` instead.

Open todo / questions:
 * I used `match` expression to ensure I have macro and other variables at hand without having to `use` them in closures, that would be better for lower PHP versions. Can we just use it and expect PHP 8 or do we have to use closures and keep track which vars to use?
 * Where to integrate Security/Sandboxing features and checks? I do not know all the caveats and what do look for when testing
 * How would one add support for custom method calls for people doing __call and __get magic?
 * I do not like the TypeFactory but I do not see DI usage in structs. Any suggestions how to change that to fit into the project?
 * Can the expression parser do parsing of PHP Types (union and intersection)? Do we want to support intersection types?
 * Capturing scalar values. I do this but is there any use?
 * Noting down types feels like it should be in the compiler, but the visitor just has env. So I keep track of variables in the env.
 * Type deduplication is still needed `ClassA|ClassA` generates duplicate code
 * Pseudo variables like `loop` have type info
 * Expression analysis of filters and more function and method calls
 * Benchmarking cache building
 * Benchmarking loading bigger cache (level 1)
 * Benchmarking rendering (level 2)

Thank you for @jkrzefski brainstorming the optimization levels
Thank you for reading and looking into this.