### PR TITLE
Simplify sandbox tests

### DIFF
--- a/src/Extension/SandboxExtension.php
+++ b/src/Extension/SandboxExtension.php
@@ -82,11 +82,7 @@ final class SandboxExtension extends AbstractExtension
         return $this->policy;
     }
 
-<<<<<<< HEAD
-    public function checkSecurity($tags, $filters, $functions): void
-=======
-    public function checkSecurity($tags, $filters, $functions, Source $source = null)
->>>>>>> 2.x
+    public function checkSecurity($tags, $filters, $functions, Source $source = null): void
     {
         if ($this->isSandboxed($source)) {
             $this->policy->checkSecurity($tags, $filters, $functions);

--- a/tests/Extension/SandboxTest.php
+++ b/tests/Extension/SandboxTest.php
@@ -437,6 +437,8 @@ EOF
         } catch (SecurityError $e) {
             $this->fail('checkMethodAllowed is exiting prematurely after matching a child class and not seeing a method allowed on its parent class later in the list');
         }
+
+        $this->expectNotToPerformAssertions();
     }
 
     protected function getEnvironment($sandboxed, $options, $templates, $tags = [], $filters = [], $methods = [], $properties = [], $functions = [], $sourcePolicy = null)

--- a/tests/Extension/SandboxTest.php
+++ b/tests/Extension/SandboxTest.php
@@ -84,8 +84,7 @@ class SandboxTest extends TestCase
         try {
             $twig->load('1_basic1')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed method is called');
-        } catch (SecurityError $e) {
-            $this->assertInstanceOf(SecurityNotAllowedMethodError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedMethodError');
+        } catch (SecurityNotAllowedMethodError $e) {
             $this->assertEquals('Twig\Tests\Extension\FooObject', $e->getClassName(), 'Exception should be raised on the "Twig\Tests\Extension\FooObject" class');
             $this->assertEquals('foo', $e->getMethodName(), 'Exception should be raised on the "foo" method');
         }
@@ -110,8 +109,7 @@ class SandboxTest extends TestCase
         try {
             $twig->load('1_basic2_include_template_from_string_sandboxed')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed filter is called');
-        } catch (SecurityError $e) {
-            $this->assertInstanceOf('\Twig\Sandbox\SecurityNotAllowedFilterError', $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFilterError');
+        } catch (SecurityNotAllowedFilterError $e) {
             $this->assertEquals('upper', $e->getFilterName(), 'Exception should be raised on the "upper" filter');
         }
     }
@@ -123,8 +121,7 @@ class SandboxTest extends TestCase
         try {
             $twig->load('1_basic2_include_template_from_string_sandboxed')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed filter is called');
-        } catch (SecurityError $e) {
-            $this->assertInstanceOf('\Twig\Sandbox\SecurityNotAllowedFilterError', $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFilterError');
+        } catch (SecurityNotAllowedFilterError $e) {
             $this->assertEquals('upper', $e->getFilterName(), 'Exception should be raised on the "upper" filter');
         }
     }
@@ -143,8 +140,7 @@ class SandboxTest extends TestCase
         try {
             $twig->load('1_basic2_include_template_from_string')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed filter is called');
-        } catch (SecurityError $e) {
-            $this->assertInstanceOf('\Twig\Sandbox\SecurityNotAllowedFilterError', $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFilterError');
+        } catch (SecurityNotAllowedFilterError $e) {
             $this->assertEquals('upper', $e->getFilterName(), 'Exception should be raised on the "upper" filter');
         }
     }
@@ -155,8 +151,7 @@ class SandboxTest extends TestCase
         try {
             $twig->load('1_basic2')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed filter is called');
-        } catch (SecurityError $e) {
-            $this->assertInstanceOf(SecurityNotAllowedFilterError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFilterError');
+        } catch (SecurityNotAllowedFilterError $e) {
             $this->assertEquals('upper', $e->getFilterName(), 'Exception should be raised on the "upper" filter');
         }
     }
@@ -167,8 +162,7 @@ class SandboxTest extends TestCase
         try {
             $twig->load('1_basic3')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed tag is used in the template');
-        } catch (SecurityError $e) {
-            $this->assertInstanceOf(SecurityNotAllowedTagError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedTagError');
+        } catch (SecurityNotAllowedTagError $e) {
             $this->assertEquals('if', $e->getTagName(), 'Exception should be raised on the "if" tag');
         }
     }
@@ -179,8 +173,7 @@ class SandboxTest extends TestCase
         try {
             $twig->load('1_basic4')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed property is called in the template');
-        } catch (SecurityError $e) {
-            $this->assertInstanceOf(SecurityNotAllowedPropertyError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedPropertyError');
+        } catch (SecurityNotAllowedPropertyError $e) {
             $this->assertEquals('Twig\Tests\Extension\FooObject', $e->getClassName(), 'Exception should be raised on the "Twig\Tests\Extension\FooObject" class');
             $this->assertEquals('bar', $e->getPropertyName(), 'Exception should be raised on the "bar" property');
         }
@@ -195,8 +188,7 @@ class SandboxTest extends TestCase
         try {
             $twig->load('index')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed method (__toString()) is called in the template');
-        } catch (SecurityError $e) {
-            $this->assertInstanceOf(SecurityNotAllowedMethodError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedMethodError');
+        } catch (SecurityNotAllowedMethodError $e) {
             $this->assertEquals('Twig\Tests\Extension\FooObject', $e->getClassName(), 'Exception should be raised on the "Twig\Tests\Extension\FooObject" class');
             $this->assertEquals('__tostring', $e->getMethodName(), 'Exception should be raised on the "__toString" method');
         }
@@ -268,8 +260,7 @@ class SandboxTest extends TestCase
         try {
             $twig->load('1_basic7')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if an unallowed function is called in the template');
-        } catch (SecurityError $e) {
-            $this->assertInstanceOf(SecurityNotAllowedFunctionError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFunctionError');
+        } catch (SecurityNotAllowedFunctionError $e) {
             $this->assertEquals('cycle', $e->getFunctionName(), 'Exception should be raised on the "cycle" function');
         }
     }
@@ -280,8 +271,7 @@ class SandboxTest extends TestCase
         try {
             $twig->load('1_range_operator')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception if the unallowed range operator is called');
-        } catch (SecurityError $e) {
-            $this->assertInstanceOf(SecurityNotAllowedFunctionError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedFunctionError');
+        } catch (SecurityNotAllowedFunctionError $e) {
             $this->assertEquals('range', $e->getFunctionName(), 'Exception should be raised on the "range" function');
         }
     }
@@ -355,8 +345,7 @@ class SandboxTest extends TestCase
         try {
             $twig->load('3_basic')->render(self::$params);
             $this->fail('Sandbox throws a SecurityError exception when the included file is sandboxed');
-        } catch (SecurityError $e) {
-            $this->assertInstanceOf(SecurityNotAllowedTagError::class, $e, 'Exception should be an instance of Twig_Sandbox_SecurityNotAllowedTagError');
+        } catch (SecurityNotAllowedTagError $e) {
             $this->assertEquals('sandbox', $e->getTagName());
         }
     }


### PR DESCRIPTION
This allows to remove some unneeded assertions and fix static analysis checks.
