### PR TITLE
Abstract node capture in its own Node

### DIFF
--- a/extra/cache-extra/TokenParser/CacheTokenParser.php
+++ b/extra/cache-extra/TokenParser/CacheTokenParser.php
@@ -13,7 +13,10 @@ namespace Twig\Extra\Cache\TokenParser;
 
 use Twig\Error\SyntaxError;
 use Twig\Extra\Cache\Node\CacheNode;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\FilterExpression;
 use Twig\Node\Node;
+use Twig\Node\PrintNode;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
@@ -54,7 +57,10 @@ class CacheTokenParser extends AbstractTokenParser
         $body = $this->parser->subparse([$this, 'decideCacheEnd'], true);
         $stream->expect(Token::BLOCK_END_TYPE);
 
-        return new CacheNode($key, $ttl, $tags, $body, $token->getLine(), $this->getTag());
+        $body = new CacheNode($key, $ttl, $tags, $body, $token->getLine(), $this->getTag());
+        $body = new FilterExpression($body, new ConstantExpression('raw', $token->getLine()), new Node(), $token->getLine());
+
+        return new PrintNode($body, $token->getLine(), $this->getTag());
     }
 
     public function decideCacheEnd(Token $token): bool

--- a/extra/cache-extra/composer.json
+++ b/extra/cache-extra/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/cache": "^5.0|^6.0|^7.0",
-        "twig/twig": "^3.0"
+        "twig/twig": "^3.9"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^6.4|^7.0"

--- a/src/Node/CaptureNode.php
+++ b/src/Node/CaptureNode.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Node;
+
+use Twig\Compiler;
+
+/**
+ * Represents a node for which we need to capture the output.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class CaptureNode extends Node
+{
+    public function __construct(Node $body, int $lineno, string $tag = null)
+    {
+        parent::__construct(['body' => $body], ['raw' => false, 'with_blocks' => false], $lineno, $tag);
+    }
+
+    public function compile(Compiler $compiler): void
+    {
+        if ($this->getAttribute('with_blocks')) {
+            $compiler->raw("(function () use (&\$context, \$macros, \$blocks) {\n");
+        } else {
+            $compiler->raw("(function () use (&\$context, \$macros) {\n");
+        }
+        $compiler->indent();
+        if ($compiler->getEnvironment()->isDebug()) {
+            $compiler->write("ob_start();\n");
+        } else {
+            $compiler->write("ob_start(function () { return ''; });\n");
+        }
+        $compiler
+            ->write("try {\n")
+            ->indent()
+            ->subcompile($this->getNode('body'))
+            ->raw("\n")
+        ;
+        if ($this->getAttribute('raw')) {
+            $compiler->write("return ob_get_contents();\n");
+        } else {
+            $compiler->write("return ('' === \$tmp = ob_get_contents()) ? '' : new Markup(\$tmp, \$this->env->getCharset());\n");
+        }
+        $compiler
+            ->outdent()
+            ->write("} finally {\n")
+            ->indent()
+            ->write("ob_end_clean();\n")
+            ->outdent()
+            ->write("}\n")
+            ->outdent()
+            ->write('})()')
+        ;
+    }
+}

--- a/src/Node/MacroNode.php
+++ b/src/Node/MacroNode.php
@@ -31,6 +31,8 @@ class MacroNode extends Node
             }
         }
 
+        $body = new CaptureNode($body, $lineno, $tag);
+
         parent::__construct(['body' => $body, 'arguments' => $arguments], ['name' => $name], $lineno, $tag);
     }
 
@@ -81,31 +83,13 @@ class MacroNode extends Node
             ->write('')
             ->string(self::VARARGS_NAME)
             ->raw(' => ')
-        ;
-
-        $compiler
             ->raw("\$__varargs__,\n")
             ->outdent()
             ->write("]);\n\n")
             ->write("\$blocks = [];\n\n")
-        ;
-        if ($compiler->getEnvironment()->isDebug()) {
-            $compiler->write("ob_start();\n");
-        } else {
-            $compiler->write("ob_start(function () { return ''; });\n");
-        }
-        $compiler
-            ->write("try {\n")
-            ->indent()
+            ->write('return ')
             ->subcompile($this->getNode('body'))
-            ->raw("\n")
-            ->write("return ('' === \$tmp = ob_get_contents()) ? '' : new Markup(\$tmp, \$this->env->getCharset());\n")
-            ->outdent()
-            ->write("} finally {\n")
-            ->indent()
-            ->write("ob_end_clean();\n")
-            ->outdent()
-            ->write("}\n")
+            ->raw(";\n")
             ->outdent()
             ->write("}\n\n")
         ;

--- a/src/Node/SetNode.php
+++ b/src/Node/SetNode.php
@@ -23,22 +23,24 @@ class SetNode extends Node implements NodeCaptureInterface
 {
     public function __construct(bool $capture, Node $names, Node $values, int $lineno, string $tag = null)
     {
-        parent::__construct(['names' => $names, 'values' => $values], ['capture' => $capture, 'safe' => false], $lineno, $tag);
-
         /*
          * Optimizes the node when capture is used for a large block of text.
          *
          * {% set foo %}foo{% endset %} is compiled to $context['foo'] = new Twig\Markup("foo");
          */
-        if ($this->getAttribute('capture')) {
-            $this->setAttribute('safe', true);
-
-            $values = $this->getNode('values');
+        $safe = false;
+        if ($capture) {
+            $safe = true;
             if ($values instanceof TextNode) {
-                $this->setNode('values', new ConstantExpression($values->getAttribute('data'), $values->getTemplateLine()));
-                $this->setAttribute('capture', false);
+                $values = new ConstantExpression($values->getAttribute('data'), $values->getTemplateLine());
+                $capture = false;
+            } else {
+                $values = new CaptureNode($values, $values->getTemplateLine());
+                $values->setAttribute('with_blocks', true);
             }
         }
+
+        parent::__construct(['names' => $names, 'values' => $values], ['capture' => $capture, 'safe' => $safe], $lineno, $tag);
     }
 
     public function compile(Compiler $compiler): void
@@ -56,27 +58,13 @@ class SetNode extends Node implements NodeCaptureInterface
             }
             $compiler->raw(')');
         } else {
-            if ($this->getAttribute('capture')) {
-                if ($compiler->getEnvironment()->isDebug()) {
-                    $compiler->write("ob_start();\n");
-                } else {
-                    $compiler->write("ob_start(function () { return ''; });\n");
-                }
-                $compiler
-                    ->subcompile($this->getNode('values'))
-                ;
-            }
-
             $compiler->subcompile($this->getNode('names'), false);
-
-            if ($this->getAttribute('capture')) {
-                $compiler->raw(" = ('' === \$tmp = ob_get_clean()) ? '' : new Markup(\$tmp, \$this->env->getCharset())");
-            }
         }
+        $compiler->raw(' = ');
 
-        if (!$this->getAttribute('capture')) {
-            $compiler->raw(' = ');
-
+        if ($this->getAttribute('capture')) {
+            $compiler->subcompile($this->getNode('values'));
+        } else {
             if (\count($this->getNode('names')) > 1) {
                 $compiler->write('[');
                 foreach ($this->getNode('values') as $idx => $value) {

--- a/tests/Node/MacroTest.php
+++ b/tests/Node/MacroTest.php
@@ -26,7 +26,7 @@ class MacroTest extends NodeTestCase
         $arguments = new Node([new NameExpression('foo', 1)], [], 1);
         $node = new MacroNode('foo', $body, $arguments, 1);
 
-        $this->assertEquals($body, $node->getNode('body'));
+        $this->assertEquals($body, $node->getNode('body')->getNode('body'));
         $this->assertEquals($arguments, $node->getNode('arguments'));
         $this->assertEquals('foo', $node->getAttribute('name'));
     }
@@ -54,14 +54,16 @@ public function macro_foo(\$__foo__ = null, \$__bar__ = "Foo", ...\$__varargs__)
 
     \$blocks = [];
 
-    ob_start(function () { return ''; });
-    try {
-        echo "foo";
+    return (function () use (&\$context, \$macros) {
+        ob_start(function () { return ''; });
+        try {
+            echo "foo";
 
-        return ('' === \$tmp = ob_get_contents()) ? '' : new Markup(\$tmp, \$this->env->getCharset());
-    } finally {
-        ob_end_clean();
-    }
+            return ('' === \$tmp = ob_get_contents()) ? '' : new Markup(\$tmp, \$this->env->getCharset());
+        } finally {
+            ob_end_clean();
+        }
+    })();
 }
 EOF
             ],

--- a/tests/Node/SetTest.php
+++ b/tests/Node/SetTest.php
@@ -51,9 +51,16 @@ EOF
         $node = new SetNode(true, $names, $values, 1);
         $tests[] = [$node, <<<EOF
 // line 1
-ob_start(function () { return ''; });
-echo "foo";
-\$context["foo"] = ('' === \$tmp = ob_get_clean()) ? '' : new Markup(\$tmp, \$this->env->getCharset());
+\$context["foo"] = (function () use (&\$context, \$macros, \$blocks) {
+    ob_start(function () { return ''; });
+    try {
+        echo "foo";
+
+        return ('' === \$tmp = ob_get_contents()) ? '' : new Markup(\$tmp, \$this->env->getCharset());
+    } finally {
+        ob_end_clean();
+    }
+})();
 EOF
         ];
 


### PR DESCRIPTION
To prepare the work for #3950, I'd like to abstract the usage of `echo` into a single node that can be reused by other nodes.

The cache node is a good example of defining something that is more semantic are reusable as well. The node itself now just generates the wrapper that can then be returned, echoed, yielded, ...

