### PR TITLE
[html-extra] filter classes

### DIFF
--- a/extra/html-extra/HtmlExtension.php
+++ b/extra/html-extra/HtmlExtension.php
@@ -108,6 +108,6 @@ final class HtmlExtension extends AbstractExtension
             }
         }
 
-        return implode(' ', array_unique($classes));
+        return implode(' ', array_unique(array_filter($classes, static function($v) { return '' !== $v; })));
     }
 }

--- a/extra/html-extra/Tests/Fixtures/html_classes.test
+++ b/extra/html-extra/Tests/Fixtures/html_classes.test
@@ -1,12 +1,12 @@
 --TEST--
 "html_classes" function
 --TEMPLATE--
-{{ html_classes('a', {'b': true, 'c': false}, 'd') }}
+{{ html_classes('a', {'b': true, 'c': false}, 'd', false ? 'e', true ? 'f', '0') }}
 {% set class_a = 'a' %}
 {% set class_b = 'b' %}
 {{ html_classes(class_a, {(class_b): true})}}
 --DATA--
 return []
 --EXPECT--
-a b d
+a b d f 0
 a b


### PR DESCRIPTION
A small formatting change to avoid double spaces:

```twig
class="{{ html_classes('a', false ? 'b', true ? 'c') }}"

{# before #}
class="a  c"

{# after #}
class="a c"
```