### PR TITLE
[html-extra] rename `html_classes()` to `html_attr()`

### DIFF
--- a/extra/html-extra/HtmlExtension.php
+++ b/extra/html-extra/HtmlExtension.php
@@ -36,7 +36,11 @@ final class HtmlExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('html_classes', [self::class, 'htmlClasses']),
+            new TwigFunction('html_attr', [self::class, 'htmlAttr']),
+            new TwigFunction('html_classes', [self::class, 'htmlAttr'], [
+                'deprecated' => true,
+                'alternative' => 'html_attr',
+            ]),
         ];
     }
 
@@ -75,7 +79,7 @@ final class HtmlExtension extends AbstractExtension
             $repr .= ';'.$key.'='.rawurlencode($value);
         }
 
-        if (0 === strpos($mime, 'text/')) {
+        if (str_starts_with($mime, 'text/')) {
             $repr .= ','.rawurlencode($data);
         } else {
             $repr .= ';base64,'.base64_encode($data);
@@ -87,7 +91,7 @@ final class HtmlExtension extends AbstractExtension
     /**
      * @internal
      */
-    public static function htmlClasses(...$args): string
+    public static function htmlAttr(...$args): string
     {
         $classes = [];
         foreach ($args as $i => $arg) {
@@ -96,7 +100,7 @@ final class HtmlExtension extends AbstractExtension
             } elseif (\is_array($arg)) {
                 foreach ($arg as $class => $condition) {
                     if (!\is_string($class)) {
-                        throw new RuntimeError(sprintf('The html_classes function argument %d (key %d) should be a string, got "%s".', $i, $class, \gettype($class)));
+                        throw new RuntimeError(sprintf('The html_attr function argument %d (key %d) should be a string, got "%s".', $i, $class, \gettype($class)));
                     }
                     if (!$condition) {
                         continue;
@@ -104,7 +108,7 @@ final class HtmlExtension extends AbstractExtension
                     $classes[] = $class;
                 }
             } else {
-                throw new RuntimeError(sprintf('The html_classes function argument %d should be either a string or an array, got "%s".', $i, \gettype($arg)));
+                throw new RuntimeError(sprintf('The html_attr function argument %d should be either a string or an array, got "%s".', $i, \gettype($arg)));
             }
         }
 

--- a/extra/html-extra/README.md
+++ b/extra/html-extra/README.md
@@ -6,8 +6,8 @@ This package is a Twig extension that provides the following:
  * [`data_uri`][1] filter: generates a URL using the data scheme as defined in
    RFC 2397;
 
- * [`html_classes`][2] function: returns a string by conditionally joining class
-   names together.
+ * [`html_attr`][2] function: returns a string by conditionally joining attribute
+   values together.
 
 [1]: https://twig.symfony.com/data_uri
 [2]: https://twig.symfony.com/html_classes

--- a/extra/html-extra/Resources/functions.php
+++ b/extra/html-extra/Resources/functions.php
@@ -20,5 +20,5 @@ function twig_html_classes(...$args): string
 {
     trigger_deprecation('twig/html-extra', '3.9.0', 'Using the internal "%s" function is deprecated.', __FUNCTION__);
 
-    return HtmlExtension::htmlClasses(...$args);
+    return HtmlExtension::htmlAttr(...$args);
 }

--- a/extra/html-extra/Tests/Fixtures/html_attr.test
+++ b/extra/html-extra/Tests/Fixtures/html_attr.test
@@ -1,0 +1,12 @@
+--TEST--
+"html_attr" function
+--TEMPLATE--
+{{ html_attr('a', {'b': true, 'c': false}, 'd') }}
+{% set class_a = 'a' %}
+{% set class_b = 'b' %}
+{{ html_attr(class_a, {(class_b): true})}}
+--DATA--
+return []
+--EXPECT--
+a b d
+a b

--- a/extra/html-extra/Tests/Fixtures/html_attr_with_unsupported_arg.test
+++ b/extra/html-extra/Tests/Fixtures/html_attr_with_unsupported_arg.test
@@ -1,0 +1,8 @@
+--TEST--
+"html_attr" function
+--TEMPLATE--
+{{ html_attr(true) }}
+--DATA--
+return []
+--EXCEPTION--
+Twig\Error\RuntimeError: The html_attr function argument 0 should be either a string or an array, got "boolean" in "index.twig" at line 2.

--- a/extra/html-extra/Tests/Fixtures/html_attr_with_unsupported_key.test
+++ b/extra/html-extra/Tests/Fixtures/html_attr_with_unsupported_key.test
@@ -1,0 +1,8 @@
+--TEST--
+"html_attr" function
+--TEMPLATE--
+{{ html_attr(['foo']) }}
+--DATA--
+return []
+--EXCEPTION--
+Twig\Error\RuntimeError: The html_attr function argument 0 (key 0) should be a string, got "integer" in "index.twig" at line 2.

--- a/extra/html-extra/Tests/Fixtures/html_classes.legacy.test
+++ b/extra/html-extra/Tests/Fixtures/html_classes.legacy.test
@@ -1,12 +1,10 @@
 --TEST--
 "html_classes" function
+--DEPRECATION--
+Twig Function "html_classes" is deprecated. Use "html_attr" instead in index.twig at line 2.
 --TEMPLATE--
 {{ html_classes('a', {'b': true, 'c': false}, 'd') }}
-{% set class_a = 'a' %}
-{% set class_b = 'b' %}
-{{ html_classes(class_a, {(class_b): true})}}
 --DATA--
 return []
 --EXPECT--
 a b d
-a b

--- a/extra/html-extra/Tests/Fixtures/html_classes_with_unsupported_arg.test
+++ b/extra/html-extra/Tests/Fixtures/html_classes_with_unsupported_arg.test
@@ -1,8 +1,0 @@
---TEST--
-"html_classes" function
---TEMPLATE--
-{{ html_classes(true) }}
---DATA--
-return []
---EXCEPTION--
-Twig\Error\RuntimeError: The html_classes function argument 0 should be either a string or an array, got "boolean" in "index.twig" at line 2.

--- a/extra/html-extra/Tests/Fixtures/html_classes_with_unsupported_key.test
+++ b/extra/html-extra/Tests/Fixtures/html_classes_with_unsupported_key.test
@@ -1,8 +1,0 @@
---TEST--
-"html_classes" function
---TEMPLATE--
-{{ html_classes(['foo']) }}
---DATA--
-return []
---EXCEPTION--
-Twig\Error\RuntimeError: The html_classes function argument 0 (key 0) should be a string, got "integer" in "index.twig" at line 2.

--- a/extra/html-extra/Tests/LegacyFunctionsTest.php
+++ b/extra/html-extra/Tests/LegacyFunctionsTest.php
@@ -21,6 +21,6 @@ class LegacyFunctionsTest extends TestCase
 {
     public function testHtmlToMarkdown()
     {
-        $this->assertSame(HtmlExtension::htmlClasses(['charset' => 'utf-8']), \twig_html_classes(['charset' => 'utf-8']));
+        $this->assertSame(HtmlExtension::htmlAttr(['charset' => 'utf-8']), twig_html_classes(['charset' => 'utf-8']));
     }
 }


### PR DESCRIPTION
This function can be used for any html attribute (ie `data-action`, `data-controller`).