### PR TITLE
Remove redundant "instanceof \Countable" check (minor)

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1180,7 +1180,7 @@ final class CoreExtension extends AbstractExtension
             return iterator_count($thing);
         }
 
-        if (method_exists($thing, '__toString') && !$thing instanceof \Countable) {
+        if (method_exists($thing, '__toString')) {
             return mb_strlen((string) $thing, $env->getCharset());
         }
 


### PR DESCRIPTION
In [CoreExtension::lengthFilter](https://github.com/twigphp/Twig/compare/3.x...smnandre:fix/remove-check-countable?expand=1#diff-29e85e483c6ec4a9c2fd144820b6722c86df60d54175b355d85e806253313c1a), the check L1183 is redundant as "`$thing instanceof \Countable`" is already checked L1175.

```diff
    if ($thing instanceof \Countable || \is_array($thing) || $thing instanceof \SimpleXMLElement) {
        return \count($thing);
    }

    if ($thing instanceof \Traversable) {
        return iterator_count($thing);
    }

-    if (method_exists($thing, '__toString') && !$thing instanceof \Countable) {
+    if (method_exists($thing, '__toString')) {    
        return mb_strlen((string) $thing, $env->getCharset());
    }
```