### PR TITLE
Mark implicit macro argument default values as such with an attribute in AST

### DIFF
--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -642,7 +642,7 @@ class ExpressionParser
                 if (null === $name) {
                     $name = $value->getAttribute('name');
                     $value = new ConstantExpression(null, $this->parser->getCurrentToken()->getLine());
-                    $value->setAttribute('isImplicit', true);
+                    $value->setAttribute('is_implicit', true);
                 }
                 $args[$name] = $value;
             } else {

--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -591,7 +591,7 @@ class ExpressionParser
      * Parses arguments.
      *
      * @param bool $namedArguments Whether to allow named arguments or not
-     * @param bool $definition     Whether we are parsing arguments for a function definition
+     * @param bool $definition     Whether we are parsing arguments for a function (or macro) definition
      *
      * @return Node
      *
@@ -642,6 +642,7 @@ class ExpressionParser
                 if (null === $name) {
                     $name = $value->getAttribute('name');
                     $value = new ConstantExpression(null, $this->parser->getCurrentToken()->getLine());
+                    $value->setAttribute('isImplicit', true);
                 }
                 $args[$name] = $value;
             } else {

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -178,7 +178,7 @@ EOF
 
     public function testImplicitMacroArgumentDefaultValues()
     {
-        $template = '{% macro marco (po, lo = null) %}{% endmacro %}';
+        $template = '{% macro marco (po, lo = true) %}{% endmacro %}';
         $lexer = new Lexer(new Environment($this->createMock(LoaderInterface::class)));
         $stream = $lexer->tokenize(new Source($template, 'index'));
 
@@ -189,22 +189,12 @@ EOF
             ->getNode('arguments')
         ;
 
-        self::assertTrue(
-            $argumentNodes->getNode('po')->hasAttribute('isImplicit')
-        );
-        self::assertTrue(
-            $argumentNodes->getNode('po')->getAttribute('isImplicit')
-        );
-        self::assertNull(
-            $argumentNodes->getNode('po')->getAttribute('value')
-        );
+        $this->assertTrue($argumentNodes->getNode('po')->hasAttribute('is_implicit'));
+        $this->assertTrue($argumentNodes->getNode('po')->getAttribute('is_implicit'));
+        $this->assertNull($argumentNodes->getNode('po')->getAttribute('value'));
 
-        self::assertFalse(
-            $argumentNodes->getNode('lo')->hasAttribute('isImplicit')
-        );
-        self::assertNull(
-            $argumentNodes->getNode('lo')->getAttribute('value')
-        );
+        $this->assertFalse($argumentNodes->getNode('lo')->hasAttribute('is_implicit'));
+        $this->assertSame(true, $argumentNodes->getNode('lo')->getAttribute('value'));
     }
 
     protected function getParser()

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -14,6 +14,7 @@ namespace Twig\Tests;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
 use Twig\Error\SyntaxError;
+use Twig\Lexer;
 use Twig\Loader\LoaderInterface;
 use Twig\Node\Node;
 use Twig\Node\SetNode;
@@ -173,6 +174,37 @@ EOF
         // The getVarName() must not depend on the template loaders,
         // If this test does not throw any exception, that's good.
         $this->addToAssertionCount(1);
+    }
+
+    public function testImplicitMacroArgumentDefaultValues()
+    {
+        $template = '{% macro marco (po, lo = null) %}{% endmacro %}';
+        $lexer = new Lexer(new Environment($this->createMock(LoaderInterface::class)));
+        $stream = $lexer->tokenize(new Source($template, 'index'));
+
+        $argumentNodes = $this->getParser()
+            ->parse($stream)
+            ->getNode('macros')
+            ->getNode('marco')
+            ->getNode('arguments')
+        ;
+
+        self::assertTrue(
+            $argumentNodes->getNode('po')->hasAttribute('isImplicit')
+        );
+        self::assertTrue(
+            $argumentNodes->getNode('po')->getAttribute('isImplicit')
+        );
+        self::assertNull(
+            $argumentNodes->getNode('po')->getAttribute('value')
+        );
+
+        self::assertFalse(
+            $argumentNodes->getNode('lo')->hasAttribute('isImplicit')
+        );
+        self::assertNull(
+            $argumentNodes->getNode('lo')->getAttribute('value')
+        );
     }
 
     protected function getParser()


### PR DESCRIPTION
This change causes no difference to compiled templates or to macro argument semantics.

Consider the following macro:
```twig
{% macro marco(po, lo = null) %}{% endmacro %}
```

With this change, the `ConstantExpression` for argument `po` will have an attribute `is_implicit`, whose value will be `true`. (Note that `lo` will not have that attribute.)

This allows node visitors to distinguish between arguments that do and those that do not have explicit default values even if the value is `null`.

This is useful for [static code analysis](https://github.com/twigphp/Twig/issues/4003).

For example, a static analysis tool might consider arguments with no explicit default value as non-optional.