### PR TITLE
Fix exception when timezone is false

### DIFF
--- a/extra/intl-extra/IntlExtension.php
+++ b/extra/intl-extra/IntlExtension.php
@@ -372,7 +372,7 @@ final class IntlExtension extends AbstractExtension
         $date = CoreExtension::dateConverter($env, $date, $timezone);
 
         $formatterTimezone = $timezone;
-        if (null === $formatterTimezone) {
+        if (null === $formatterTimezone || false === $formatterTimezone) {
             $formatterTimezone = $date->getTimezone();
         } elseif (\is_string($formatterTimezone)) {
             $formatterTimezone = new \DateTimeZone($timezone);

--- a/extra/intl-extra/Tests/IntlExtensionTest.php
+++ b/extra/intl-extra/Tests/IntlExtensionTest.php
@@ -45,6 +45,20 @@ class IntlExtensionTest extends TestCase
         );
     }
 
+    public function testFormatterWithoutProtoSkipTimezoneConverter()
+    {
+        $ext = new IntlExtension();
+        $env = new Environment(new ArrayLoader());
+        // EET is always +2 without changes for daylight saving time
+        // so it has a fixed difference to UTC
+        $env->getExtension(CoreExtension::class)->setTimezone('EET');
+
+        $this->assertStringStartsWith(
+            'Feb 20, 2020, 1:37:00',
+            $ext->formatDateTime($env, new \DateTime('2020-02-20T13:37:00+00:00', new \DateTimeZone('UTC')), 'medium', 'medium', '', false)
+        );
+    }
+
     public function testFormatterProto()
     {
         $dateFormatterProto = new \IntlDateFormatter('fr', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, new \DateTimeZone('Europe/Paris'));


### PR DESCRIPTION
When passing `false` in the timezone param, twig returns an exception:

> An exception has been thrown during the rendering of a template ("Twig\Extra\Intl\IntlExtension::createDateFormatter(): Argument 5 ($timezone) must be of type ?DateTimeZone, bool given

Passing `false` is supported and allows to skip the timezone conversion.

Regression introduced by https://github.com/twigphp/Twig/pull/3903