### PR TITLE
Fix param name in docblock (minor)

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -337,8 +337,8 @@ class Environment
      * This method is for internal use only and should never be called
      * directly.
      *
-     * @param string $name  The template name
-     * @param int    $index The index if it is an embedded template
+     * @param string   $name  The template name
+     * @param int|null $index The index if it is an embedded template
      *
      * @throws LoaderError  When the template cannot be found
      * @throws RuntimeError When a previously generated cache is corrupted
@@ -395,8 +395,8 @@ class Environment
      *
      * This method should not be used as a generic way to load templates.
      *
-     * @param string $template The template source
-     * @param string $name     An optional name of the template to be used in error messages
+     * @param string      $template The template source
+     * @param string|null $name     An optional name of the template to be used in error messages
      *
      * @throws LoaderError When the template cannot be found
      * @throws SyntaxError When an error occurred during compilation

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -89,8 +89,8 @@ final class CoreExtension extends AbstractExtension
     /**
      * Sets the default format to be used by the date filter.
      *
-     * @param string $format             The default date format string
-     * @param string $dateIntervalFormat The default date interval format string
+     * @param string|null $format             The default date format string
+     * @param string|null $dateIntervalFormat The default date interval format string
      */
     public function setDateFormat($format = null, $dateIntervalFormat = null)
     {
@@ -581,10 +581,10 @@ final class CoreExtension extends AbstractExtension
      * be used. Supplying any of the parameters will override the defaults set in the
      * environment object.
      *
-     * @param mixed  $number       A float/int/string of the number to format
-     * @param int    $decimal      the number of decimal points to display
-     * @param string $decimalPoint the character(s) to use for the decimal point
-     * @param string $thousandSep  the character(s) to use for the thousands separator
+     * @param mixed       $number       A float/int/string of the number to format
+     * @param int|null    $decimal      the number of decimal points to display
+     * @param string|null $decimalPoint the character(s) to use for the decimal point
+     * @param string|null $thousandSep  the character(s) to use for the thousands separator
      *
      * @return string The formatted number
      *
@@ -787,7 +787,7 @@ final class CoreExtension extends AbstractExtension
      *
      * @param string|null $value     A string
      * @param string      $delimiter The delimiter
-     * @param int         $limit     The limit
+     * @param int|null    $limit     The limit
      *
      * @return array The split string as an array
      *
@@ -1218,7 +1218,7 @@ final class CoreExtension extends AbstractExtension
      * Strips HTML and PHP tags from a string.
      *
      * @param string|null          $string
-     * @param string[]|string|null $string
+     * @param string[]|string|null $allowable_tags
      *
      * @return string
      *
@@ -1729,8 +1729,8 @@ final class CoreExtension extends AbstractExtension
      * </pre>
      *
      * @param array|\Traversable $array An array
-     * @param mixed              $name  The column name
-     * @param mixed              $index The column to use as the index/keys for the returned array
+     * @param int|string         $name  The column name
+     * @param int|string|null    $index The column to use as the index/keys for the returned array
      *
      * @return array The array of values
      *

--- a/src/Extension/StringLoaderExtension.php
+++ b/src/Extension/StringLoaderExtension.php
@@ -29,8 +29,8 @@ final class StringLoaderExtension extends AbstractExtension
      *
      *     {{ include(template_from_string("Hello {{ name }}")) }}
      *
-     * @param string $template A template as a string or object implementing __toString()
-     * @param string $name     An optional name of the template to be used in error messages
+     * @param string      $template A template as a string or object implementing __toString()
+     * @param string|null $name     An optional name of the template to be used in error messages
      *
      * @internal
      */


### PR DESCRIPTION
Fix wrong var name in Docblock

[CoreExtension::striptags()](https://github.com/twigphp/Twig/commit/dd81f28507de5c45b99e91dafa5a9908c2686dde#diff-29e85e483c6ec4a9c2fd144820b6722c86df60d54175b355d85e806253313c1aL1221)
```diff
     * Strips HTML and PHP tags from a string.
     *
     * @param string|null          $string
-     * @param string[]|string|null $string
+     * @param string[]|string|null $allowable_tags
     *
     */
    public static function striptags($string, $allowable_tags = null)
    {
```

--

Also added some missing nullable in @param annotations, not sure if expected :| 

