### PR TITLE
Ensure Lexer:: is always initialized

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -71,8 +71,6 @@ class Lexer
             return;
         }
 
-        $this->isInitialized = true;
-
         // when PHP 7.3 is the min version, we will be able to remove the '#' part in preg_quote as it's part of the default
         $this->regexes = [
             // }}
@@ -160,6 +158,8 @@ class Lexer
             'interpolation_start' => '{'.preg_quote($this->options['interpolation'][0], '#').'\s*}A',
             'interpolation_end' => '{\s*'.preg_quote($this->options['interpolation'][1], '#').'}A',
         ];
+
+        $this->isInitialized = true;
     }
 
     public function tokenize(Source $source): TokenStream


### PR DESCRIPTION
I'm using Symfony Bridge `LintCommand` with `--show-deprecations` flag.

While Twig is initializing, if an deprecation error is thrown by `Lexer::getOperatorRegex()` method, the `Lexer::$regexes` will remain `null` but `$isInitialized` will be set to TRUE.

This PR ensures that `$regexes` will be initialized.