### PR TITLE
synchronize sourceContext

### DIFF
--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -138,6 +138,9 @@ class Node implements \Countable, \IteratorAggregate
 
     public function setNode(string $name, self $node): void
     {
+        if (null !== $this->sourceContext) {
+            $node->setSourceContext($this->sourceContext);
+        }
         $this->nodes[$name] = $node;
     }
 


### PR DESCRIPTION
I have some debugging extensions that need the template name from various nodes in a `NodeVisitor`. Currently this is guaranteed for the nodes created from parsing the template. This ensures that the `SourceContext` is also set for nodes created by `NodeVisitors` modifying the node tree.

I am not sure if it is a good idea to always set the `SourceContext` on a child node or if this should only set it if it is not set.