### PR TITLE
Respect coding standard in documentation

### DIFF
--- a/doc/filters/first.rst
+++ b/doc/filters/first.rst
@@ -9,7 +9,7 @@ a string:
     {{ [1, 2, 3, 4]|first }}
     {# outputs 1 #}
 
-    {{ { a: 1, b: 2, c: 3, d: 4 }|first }}
+    {{ {a: 1, b: 2, c: 3, d: 4}|first }}
     {# outputs 1 #}
 
     {{ '1234'|first }}

--- a/doc/filters/last.rst
+++ b/doc/filters/last.rst
@@ -9,7 +9,7 @@ a string:
     {{ [1, 2, 3, 4]|last }}
     {# outputs 4 #}
 
-    {{ { a: 1, b: 2, c: 3, d: 4 }|last }}
+    {{ {a: 1, b: 2, c: 3, d: 4}|last }}
     {# outputs 4 #}
 
     {{ '1234'|last }}

--- a/doc/filters/merge.rst
+++ b/doc/filters/merge.rst
@@ -17,11 +17,11 @@ The ``merge`` filter also works on hashes:
 
 .. code-block:: twig
 
-    {% set items = { 'apple': 'fruit', 'orange': 'fruit', 'peugeot': 'unknown' } %}
+    {% set items = {'apple': 'fruit', 'orange': 'fruit', 'peugeot': 'unknown'} %}
 
     {% set items = items|merge({ 'peugeot': 'car', 'renault': 'car' }) %}
 
-    {# items now contains { 'apple': 'fruit', 'orange': 'fruit', 'peugeot': 'car', 'renault': 'car' } #}
+    {# items now contains {'apple': 'fruit', 'orange': 'fruit', 'peugeot': 'car', 'renault': 'car'} #}
 
 For hashes, the merging process occurs on the keys: if the key does not
 already exist, it is added but if the key already exists, its value is
@@ -34,12 +34,12 @@ overridden.
 
     .. code-block:: twig
 
-        {% set items = { 'apple': 'fruit', 'orange': 'fruit' } %}
+        {% set items = {'apple': 'fruit', 'orange': 'fruit'} %}
 
-        {% set items = { 'apple': 'unknown' }|merge(items) %}
+        {% set items = {'apple': 'unknown'}|merge(items) %}
 
-        {# items now contains { 'apple': 'fruit', 'orange': 'fruit' } #}
-        
+        {# items now contains {'apple': 'fruit', 'orange': 'fruit'} #}
+
 .. note::
 
     Internally, Twig uses the PHP `array_merge`_ function. It supports

--- a/doc/filters/sort.rst
+++ b/doc/filters/sort.rst
@@ -20,9 +20,9 @@ You can pass an arrow function to sort the array:
 .. code-block:: html+twig
 
     {% set fruits = [
-        { name: 'Apples', quantity: 5 },
-        { name: 'Oranges', quantity: 2 },
-        { name: 'Grapes', quantity: 4 },
+        {name: 'Apples', quantity: 5},
+        {name: 'Oranges', quantity: 2},
+        {name: 'Grapes', quantity: 4},
     ] %}
 
     {% for fruit in fruits|sort((a, b) => a.quantity <=> b.quantity)|column('name') %}

--- a/doc/tags/with.rst
+++ b/doc/tags/with.rst
@@ -18,13 +18,13 @@ is equivalent to the following one:
 
 .. code-block:: twig
 
-    {% with { foo: 42 } %}
+    {% with {foo: 42} %}
         {{ foo }} {# foo is 42 here #}
     {% endwith %}
     foo is not visible here any longer
 
     {# it works with any expression that resolves to a hash #}
-    {% set vars = { foo: 42 } %}
+    {% set vars = {foo: 42} %}
     {% with vars %}
         ...
     {% endwith %}
@@ -35,7 +35,7 @@ disable this behavior by appending the ``only`` keyword:
 .. code-block:: twig
 
     {% set bar = 'bar' %}
-    {% with { foo: 42 } only %}
+    {% with {foo: 42} only %}
         {# only foo is defined #}
         {# bar is not defined #}
     {% endwith %}

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -560,22 +560,22 @@ exist:
   .. code-block:: twig
 
     {# keys as string #}
-    { 'foo': 'foo', 'bar': 'bar' }
+    {'foo': 'foo', 'bar': 'bar'}
 
     {# keys as names (equivalent to the previous hash) #}
-    { foo: 'foo', bar: 'bar' }
+    {foo: 'foo', bar: 'bar'}
 
     {# keys as integer #}
-    { 2: 'foo', 4: 'bar' }
+    {2: 'foo', 4: 'bar'}
 
     {# keys can be omitted if it is the same as the variable name #}
-    { foo }
+    {foo}
     {# is equivalent to the following #}
-    { 'foo': foo }
+    {'foo': foo}
 
     {# keys as expressions (the expression must be enclosed into parentheses) #}
     {% set foo = 'foo' %}
-    { (foo): 'foo', (1 + 1): 'bar', (foo ~ 'b'): 'baz' }
+    {(foo): 'foo', (1 + 1): 'bar', (foo ~ 'b'): 'baz'}
 
 * ``true`` / ``false``: ``true`` represents the true value, ``false``
   represents the false value.
@@ -797,7 +797,7 @@ The following operators don't fit into any of the other categories:
   .. code-block:: twig
 
       {% set numbers = [1, 2, ...moreNumbers] %}
-      {% set ratings = { 'foo': 10, 'bar': 5, ...moreRatings } %}
+      {% set ratings = {'foo': 10, 'bar': 5, ...moreRatings} %}
 
 .. _templates-string-interpolation:
 


### PR DESCRIPTION
From https://twig.symfony.com/doc/3.x/coding_standards.html

```
Put exactly one space after the : sign in hashes and , in arrays and hashes:
{{ [1, 2, 3] }}
{{ {'foo': 'bar'} }}

Do not put any spaces before and after the opening and the closing of arrays and hashes:
{{ [1, 2, 3] }}
{{ {'foo': 'bar'} }}
```