### PR TITLE
Pass charset to escaper callback again

### DIFF
--- a/src/Extension/EscaperExtension.php
+++ b/src/Extension/EscaperExtension.php
@@ -132,7 +132,7 @@ final class EscaperExtension extends AbstractExtension
 
         $this->escapers[$strategy] = $callable;
         $callable = function ($string, $charset) use ($callable) {
-            return $callable($this->environment, $string);
+            return $callable($this->environment, $string, $this->environment->getCharset());
         };
 
         $this->escaper->setEscaper($strategy, $callable);


### PR DESCRIPTION
Fixes #4087

This restores the behaviour of `3.9.x` where the `$charset` was passed to the escaper callback.