### PR TITLE
Fix parse error in generated code when using CaptureNode

### DIFF
--- a/src/Node/CaptureNode.php
+++ b/src/Node/CaptureNode.php
@@ -50,6 +50,8 @@ class CaptureNode extends Node
         }
         if (!$this->getAttribute('raw')) {
             $compiler->raw(") ? '' : new Markup(\$tmp, \$this->env->getCharset());");
+        } else {
+            $compiler->raw(';');
         }
     }
 }


### PR DESCRIPTION
Fix #4092 

Introduced in https://github.com/twigphp/Twig/commit/799355dc823c80467f82670dfca8b57e9cd09622