### PR TITLE
[Doc] Modernize Class name in examples

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -338,11 +338,11 @@ compilation. This is useful if your test can be compiled into PHP primitives.
 This is used by many of the tests built into Twig::
 
     namespace App;
-    
+
     use Twig\Environment;
     use Twig\Node\Expression\TestExpression;
     use Twig\TwigTest;
-    
+
     $twig = new Environment($loader);
     $test = new TwigTest(
         'odd',
@@ -456,14 +456,14 @@ Add a tag by calling the ``addTokenParser`` method on the ``\Twig\Environment``
 instance::
 
     $twig = new \Twig\Environment($loader);
-    $twig->addTokenParser(new Project_Set_TokenParser());
+    $twig->addTokenParser(new CustomSetTokenParser());
 
 Defining a Token Parser
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Now, let's see the actual code of this class::
 
-    class Project_Set_TokenParser extends \Twig\TokenParser\AbstractTokenParser
+    class CustomSetTokenParser extends \Twig\TokenParser\AbstractTokenParser
     {
         public function parse(\Twig\Token $token)
         {
@@ -475,7 +475,7 @@ Now, let's see the actual code of this class::
             $value = $parser->getExpressionParser()->parseExpression();
             $stream->expect(\Twig\Token::BLOCK_END_TYPE);
 
-            return new Project_Set_Node($name, $value, $token->getLine(), $this->getTag());
+            return new CustomSetNode($name, $value, $token->getLine(), $this->getTag());
         }
 
         public function getTag()
@@ -488,7 +488,7 @@ The ``getTag()`` method must return the tag we want to parse, here ``set``.
 
 The ``parse()`` method is invoked whenever the parser encounters a ``set``
 tag. It should return a ``\Twig\Node\Node`` instance that represents the node (the
-``Project_Set_Node`` calls creating is explained in the next section).
+``CustomSetNode`` calls creating is explained in the next section).
 
 The parsing process is simplified thanks to a bunch of methods you can call
 from the token stream (``$this->parser->getStream()``):
@@ -518,9 +518,9 @@ the ``set`` tag.
 Defining a Node
 ~~~~~~~~~~~~~~~
 
-The ``Project_Set_Node`` class itself is quite short::
+The ``CustomSetNode`` class itself is quite short::
 
-    class Project_Set_Node extends \Twig\Node\Node
+    class CustomSetNode extends \Twig\Node\Node
     {
         public function __construct($name, \Twig\Node\Expression\AbstractExpression $value, $line, $tag = null)
         {
@@ -631,7 +631,7 @@ To keep your extension class clean and lean, inherit from the built-in
 ``\Twig\Extension\AbstractExtension`` class instead of implementing the interface as it provides
 empty implementations for all methods::
 
-    class Project_Twig_Extension extends \Twig\Extension\AbstractExtension
+    class CustomTwigExtension extends \Twig\Extension\AbstractExtension
     {
     }
 
@@ -644,7 +644,7 @@ You can register an extension by using the ``addExtension()`` method on your
 main ``Environment`` object::
 
     $twig = new \Twig\Environment($loader);
-    $twig->addExtension(new Project_Twig_Extension());
+    $twig->addExtension(new CustomTwigExtension());
 
 .. tip::
 
@@ -656,7 +656,7 @@ Globals
 Global variables can be registered in an extension via the ``getGlobals()``
 method::
 
-    class Project_Twig_Extension extends \Twig\Extension\AbstractExtension implements \Twig\Extension\GlobalsInterface
+    class CustomTwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\Extension\GlobalsInterface
     {
         public function getGlobals(): array
         {
@@ -674,7 +674,7 @@ Functions
 Functions can be registered in an extension via the ``getFunctions()``
 method::
 
-    class Project_Twig_Extension extends \Twig\Extension\AbstractExtension
+    class CustomTwigExtension extends \Twig\Extension\AbstractExtension
     {
         public function getFunctions()
         {
@@ -693,7 +693,7 @@ To add a filter to an extension, you need to override the ``getFilters()``
 method. This method must return an array of filters to add to the Twig
 environment::
 
-    class Project_Twig_Extension extends \Twig\Extension\AbstractExtension
+    class CustomTwigExtension extends \Twig\Extension\AbstractExtension
     {
         public function getFilters()
         {
@@ -712,18 +712,18 @@ Adding a tag in an extension can be done by overriding the
 ``getTokenParsers()`` method. This method must return an array of tags to add
 to the Twig environment::
 
-    class Project_Twig_Extension extends \Twig\Extension\AbstractExtension
+    class CustomTwigExtension extends \Twig\Extension\AbstractExtension
     {
         public function getTokenParsers()
         {
-            return [new Project_Set_TokenParser()];
+            return [new CustomSetTokenParser()];
         }
 
         // ...
     }
 
 In the above code, we have added a single new tag, defined by the
-``Project_Set_TokenParser`` class. The ``Project_Set_TokenParser`` class is
+``CustomSetTokenParser`` class. The ``CustomSetTokenParser`` class is
 responsible for parsing the tag and compiling it to PHP.
 
 Operators
@@ -732,7 +732,7 @@ Operators
 The ``getOperators()`` methods lets you add new operators. Here is how to add
 the ``!``, ``||``, and ``&&`` operators::
 
-    class Project_Twig_Extension extends \Twig\Extension\AbstractExtension
+    class CustomTwigExtension extends \Twig\Extension\AbstractExtension
     {
         public function getOperators()
         {
@@ -755,7 +755,7 @@ Tests
 
 The ``getTests()`` method lets you add new test functions::
 
-    class Project_Twig_Extension extends \Twig\Extension\AbstractExtension
+    class CustomTwigExtension extends \Twig\Extension\AbstractExtension
     {
         public function getTests()
         {
@@ -784,7 +784,7 @@ any valid PHP callable:
 
 The simplest way to use methods is to define them on the extension itself::
 
-    class Project_Twig_Extension extends \Twig\Extension\AbstractExtension
+    class CustomTwigExtension extends \Twig\Extension\AbstractExtension
     {
         private $rot13Provider;
 
@@ -822,7 +822,7 @@ must be autoload-able)::
             // implement the logic to create an instance of $class
             // and inject its dependencies
             // most of the time, it means using your dependency injection container
-            if ('Project_Twig_RuntimeExtension' === $class) {
+            if ('CustomRuntimeExtension' === $class) {
                 return new $class(new Rot13Provider());
             } else {
                 // ...
@@ -838,9 +838,9 @@ must be autoload-able)::
     (``\Twig\RuntimeLoader\ContainerRuntimeLoader``).
 
 It is now possible to move the runtime logic to a new
-``Project_Twig_RuntimeExtension`` class and use it directly in the extension::
+``CustomRuntimeExtension`` class and use it directly in the extension::
 
-    class Project_Twig_RuntimeExtension
+    class CustomRuntimeExtension
     {
         private $rot13Provider;
 
@@ -855,14 +855,14 @@ It is now possible to move the runtime logic to a new
         }
     }
 
-    class Project_Twig_Extension extends \Twig\Extension\AbstractExtension
+    class CustomTwigExtension extends \Twig\Extension\AbstractExtension
     {
         public function getFunctions()
         {
             return [
-                new \Twig\TwigFunction('rot13', ['Project_Twig_RuntimeExtension', 'rot13']),
+                new \Twig\TwigFunction('rot13', ['CustomRuntimeExtension', 'rot13']),
                 // or
-                new \Twig\TwigFunction('rot13', 'Project_Twig_RuntimeExtension::rot13'),
+                new \Twig\TwigFunction('rot13', 'CustomRuntimeExtension::rot13'),
             ];
         }
     }
@@ -890,15 +890,17 @@ structure in your test directory::
 
 The ``IntegrationTest.php`` file should look like this::
 
+    namespace Project\Tests;
+
     use Twig\Test\IntegrationTestCase;
 
-    class Project_Tests_IntegrationTest extends IntegrationTestCase
+    class IntegrationTest extends IntegrationTestCase
     {
         public function getExtensions()
         {
             return [
-                new Project_Twig_Extension1(),
-                new Project_Twig_Extension2(),
+                new CustomTwigExtension1(),
+                new CustomTwigExtension2(),
             ];
         }
 


### PR DESCRIPTION
From "Project_Twig_Extension" to "CustomExtension"

Just a suggestion, feel free to close if you want to keep it like this :)

I found those namings only in "advanced"