### PR TITLE
fix the set of installed packages for TwigExtraBundle on PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
             - name: "PHPUnit version"
               run: vendor/bin/simple-phpunit --version
 
+            - name: "Prevent installing symfony/translation-contract 3.0"
+              if: "matrix.extension == 'twig-extra-bundle'"
+              working-directory: extra/${{ matrix.extension }}
+              run: "composer require --no-update 'symfony/translation-contracts:^1.1|^2.0'"
+
             - name: "Composer install ${{ matrix.extension }}"
               working-directory: extra/${{ matrix.extension }}
               run: composer install


### PR DESCRIPTION
Prevents symfony/translation-contracts 3 to be installed together with symfony/string 5.4.0-RC1 (see https://github.com/twigphp/Twig/actions/runs/9804849131/job/27073398023#step:8:117). Stable releases of the String component don't suffer from this incompatibility because of symfony/symfony#44246.