### PR TITLE
[4.0] Support string literals

### DIFF
--- a/tests/Fixtures/tests/constant.test
+++ b/tests/Fixtures/tests/constant.test
@@ -4,10 +4,12 @@
 {{ 8 is constant('E_NOTICE') ? 'ok' : 'no' }}
 {{ 'bar' is constant('Twig\\Tests\\TwigTestFoo::BAR_NAME') ? 'ok' : 'no' }}
 {{ value is constant('Twig\\Tests\\TwigTestFoo::BAR_NAME') ? 'ok' : 'no' }}
+{{ value is constant(`Twig\Tests\TwigTestFoo::BAR_NAME`) ? 'ok' : 'no' }}
 {{ 2 is constant('ARRAY_AS_PROPS', object) ? 'ok' : 'no' }}
 --DATA--
 return ['value' => 'bar', 'object' => new \ArrayObject(['hi'])]
 --EXPECT--
+ok
 ok
 ok
 ok

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -401,4 +401,19 @@ bar
         yield ['{{ ='];
         yield ['{{ ..'];
     }
+
+    public function testStringLiterals()
+    {
+        $template = '{{ `My\Name\Space` }}';
+
+        $lexer = new Lexer(new Environment($this->createMock(LoaderInterface::class)));
+        $stream = $lexer->tokenize(new Source($template, 'index'));
+        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::STRING_TYPE, 'My\Name\Space');
+        $stream->expect(Token::VAR_END_TYPE);
+
+        // add a dummy assertion here to satisfy PHPUnit, the only thing we want to test is that the code above
+        // can be executed without throwing any exceptions
+        $this->addToAssertionCount(1);
+    }
 }


### PR DESCRIPTION
After posting this as an idea in https://github.com/twigphp/Twig/issues/3951#issuecomment-2211747927 I tried to implement it. It looks like it's quite doable. But maybe I'm missing something.

---

This allows to write a string literal using backticks. When using a literal, you don't need to escape backslashes. This is ideal for situation where you want to reference a fully qualified class name. For example in a `constant` function.

For example, before you had to write:
```twig
{{ constant("App\\Entity\\Class::Constant") }}
```

Now you can write:
```twig
{{ constant(`App\Entity\Class::Constant`) }}
```

Besides easier to read, there is another huge benefit: when doing a text search for a fully qualified class name, it will show up.