### PR TITLE
Use value when printing BackedEnum

### DIFF
--- a/src/Runtime/EscaperRuntime.php
+++ b/src/Runtime/EscaperRuntime.php
@@ -11,6 +11,7 @@
 
 namespace Twig\Runtime;
 
+use BackedEnum;
 use Twig\Error\RuntimeError;
 use Twig\Extension\RuntimeExtensionInterface;
 use Twig\Markup;
@@ -93,7 +94,9 @@ final class EscaperRuntime implements RuntimeExtensionInterface
         }
 
         if (!\is_string($string)) {
-            if (\is_object($string) && method_exists($string, '__toString')) {
+            if ($string instanceof BackedEnum) {
+                return $string->value;
+            } elseif (\is_object($string) && method_exists($string, '__toString')) {
                 if ($autoescape) {
                     $c = $string::class;
                     if (!isset($this->safeClasses[$c])) {

--- a/tests/Fixtures/expressions/backed_int_enum.test
+++ b/tests/Fixtures/expressions/backed_int_enum.test
@@ -1,0 +1,13 @@
+--TEST--
+Twig supports printing backed int enums
+--TEMPLATE--
+{{ status }}
+--DATA--
+enum OrderIntStatus: int
+{
+    case Paid = 1;
+}
+
+return ['status' => OrderIntStatus::Paid]
+--EXPECT--
+1

--- a/tests/Fixtures/expressions/backed_string_enum.test
+++ b/tests/Fixtures/expressions/backed_string_enum.test
@@ -1,0 +1,13 @@
+--TEST--
+Twig supports printing backed string enums
+--TEMPLATE--
+{{ status }}
+--DATA--
+enum OrderStatus: string
+{
+    case Paid = 'paid';
+}
+
+return ['status' => OrderStatus::Paid]
+--EXPECT--
+paid


### PR DESCRIPTION
Let's say you have the following Enum:
```php
enum OrderStatus: string
{
    case Paid = 'paid';
}
```

Currently, we have to write `{{ status.value }}` to display an enum value.

Given that BackedEnums cannot implement `Stringable` / `__toString`, why not handle them in the EscapeRuntime?

Now we can write `{{ status }}` and it will print the value.