### PR TITLE
[Doc] Fix javascript code-block

### DIFF
--- a/doc/recipes.rst
+++ b/doc/recipes.rst
@@ -516,7 +516,7 @@ include in your templates:
     ``interpolateProvider`` service, for instance at the module initialization
     time:
 
-    ..  code-block:: javascript
+    .. code-block:: javascript
 
         angular.module('myApp', []).config(function($interpolateProvider) {
             $interpolateProvider.startSymbol('{[').endSymbol(']}');


### PR DESCRIPTION
Fix code-block syntax (double space)

Visible there: 

<img width="900" alt="Capture d’écran 2024-07-21 à 21 04 22" src="https://github.com/user-attachments/assets/389d8ec5-7caa-4a5c-b8de-f54040462269">

https://twig.symfony.com/doc/3.x/recipes.html#using-twig-and-angularjs-in-the-same-templates