### PR TITLE
Deprecate NameExpression internal methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,9 +5,11 @@
  * Deprecate the second argument of `Twig\Node\Expression\CallExpression::compileArguments()`
  * Deprecate `Twig\ExpressionParser\parseHashExpression()` in favor of
    `Twig\ExpressionParser::parseMappingExpression()`
- * Deprecate `Twig\ExpressionParser\parseArrayExpression()`` in favor of
+ * Deprecate `Twig\ExpressionParser\parseArrayExpression()` in favor of
    `Twig\ExpressionParser::parseSequenceExpression()`
  * Add `sequence` and `mapping` tests
+ * Deprecate `Twig\Node\Expression\NameExpression::isSimple()` and
+    `Twig\Node\Expression\NameExpression::isSpecial()`
 
 # 3.10.3 (2024-05-16)
 

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -39,6 +39,10 @@ Nodes
   ``Twig\Node\Expression\CallExpression::compileArguments()`` method is
   deprecated.
 
+* The ``Twig\Node\Expression\NameExpression::isSimple()`` and
+  ``Twig\Node\Expression\NameExpression::isSpecial()`` methods are deprecated as 
+  of Twig 3.11 and will be removed in Twig 4.0.
+
 Node Visitors
 -------------
 

--- a/src/Node/Expression/NameExpression.php
+++ b/src/Node/Expression/NameExpression.php
@@ -34,7 +34,7 @@ class NameExpression extends AbstractExpression
         $compiler->addDebugInfo($this);
 
         if ($this->getAttribute('is_defined_test')) {
-            if ($this->isSpecial()) {
+            if (isset($this->specialVars[$name])) {
                 $compiler->repr(true);
             } elseif (\PHP_VERSION_ID >= 70400) {
                 $compiler
@@ -51,7 +51,7 @@ class NameExpression extends AbstractExpression
                     ->raw(', $context))')
                 ;
             }
-        } elseif ($this->isSpecial()) {
+        } elseif (isset($this->specialVars[$name])) {
             $compiler->raw($this->specialVars[$name]);
         } elseif ($this->getAttribute('always_defined')) {
             $compiler
@@ -85,13 +85,23 @@ class NameExpression extends AbstractExpression
         }
     }
 
+    /**
+     * @deprecated since Twig 3.11 (to be removed in 4.0)
+     */
     public function isSpecial()
     {
+        trigger_deprecation('twig/twig', '3.11', 'The "%s()" method is deprecated and will be removed in Twig 4.0.', __METHOD__);
+
         return isset($this->specialVars[$this->getAttribute('name')]);
     }
 
+    /**
+     * @deprecated since Twig 3.11 (to be removed in 4.0)
+     */
     public function isSimple()
     {
+        trigger_deprecation('twig/twig', '3.11', 'The "%s()" method is deprecated and will be removed in Twig 4.0.', __METHOD__);
+
         return !$this->isSpecial() && !$this->getAttribute('is_defined_test');
     }
 }


### PR DESCRIPTION
Deprecate two methods from `Twig\Node\Expression\NameExpression`:
* `isSimple()`: did not find any usage in Twig (or even Symfony) repositories
* `isSpecial()`: inlined for better performance ($name is available in the method)