### PR TITLE
[Doc] Fix code syntax in deprecated.rst

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -27,10 +27,10 @@ Extensions
   ``Twig\Runtime\EscaperRuntime`` class instead:
   
   Before:
-  $twig->getExtension(EscaperExtension::class)->METHOD()
+  ``$twig->getExtension(EscaperExtension::class)->METHOD();``
   
   After:
-  $twig->getRuntime(EscaperRuntime::class)->METHOD();
+  ``$twig->getRuntime(EscaperRuntime::class)->METHOD();``
 
 Nodes
 -----


### PR DESCRIPTION
Add missing backticks

https://twig.symfony.com/doc/3.x/deprecated.html#extensions

<img width="846" alt="Capture d’écran 2024-07-27 à 14 22 26" src="https://github.com/user-attachments/assets/4dfaa859-778e-4a34-86a9-acc2eb9eccb6">
