### PR TITLE
[Tests] Fix EscaperRuntime namespace

### DIFF
--- a/tests/Runtime/EscaperRuntimeTest.php
+++ b/tests/Runtime/EscaperRuntimeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Twig\Tests;
+namespace Twig\Tests\Runtime;
 
 /*
  * This file is part of Twig.
@@ -353,7 +353,7 @@ class EscaperRuntimeTest extends TestCase
     public function testCustomEscaper($expected, $string, $strategy, $charset)
     {
         $escaper = new EscaperRuntime();
-        $escaper->setEscaper('foo', 'Twig\Tests\escaper');
+        $escaper->setEscaper('foo', 'Twig\Tests\Runtime\escaper');
         $this->assertSame($expected, $escaper->escape($string, $strategy, $charset));
     }
 
@@ -381,10 +381,10 @@ class EscaperRuntimeTest extends TestCase
     public function provideObjectsForEscaping()
     {
         return [
-            ['&lt;br /&gt;', '<br />', ['\Twig\Tests\Extension_TestClass' => ['js']]],
-            ['<br />', '\u003Cbr\u0020\/\u003E', ['\Twig\Tests\Extension_TestClass' => ['html']]],
-            ['&lt;br /&gt;', '<br />', ['\Twig\Tests\Extension_SafeHtmlInterface' => ['js']]],
-            ['<br />', '<br />', ['\Twig\Tests\Extension_SafeHtmlInterface' => ['all']]],
+            ['&lt;br /&gt;', '<br />', ['\Twig\Tests\Runtime\Extension_TestClass' => ['js']]],
+            ['<br />', '\u003Cbr\u0020\/\u003E', ['\Twig\Tests\Runtime\Extension_TestClass' => ['html']]],
+            ['&lt;br /&gt;', '<br />', ['\Twig\Tests\Runtime\Extension_SafeHtmlInterface' => ['js']]],
+            ['<br />', '<br />', ['\Twig\Tests\Runtime\Extension_SafeHtmlInterface' => ['all']]],
         ];
     }
 }


### PR DESCRIPTION
From `Twig\Tests` to `Twig\Tests\Runtime`