### PR TITLE
Fix integration tests when a test has more than on data/expect section and deprecations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 # 3.11.1 (2024-XX-XX)
 
- * n/a
+ * Fix integration tests when a test has more than on data/expect section and deprecations
 
 # 3.11.0 (2024-08-08)
 

--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -156,13 +156,16 @@ abstract class IntegrationTestCase extends TestCase
             }
         }
 
-        $loader = new ArrayLoader($templates);
-
         foreach ($outputs as $i => $match) {
             $config = array_merge([
                 'cache' => false,
                 'strict_variables' => true,
             ], $match[2] ? eval($match[2].';') : []);
+            // make sure that template are always compiled even if they are the same (useful when testing with more than one data/expect sections)
+            foreach ($templates as $j => $template) {
+                $templates[$j] = $template.str_repeat(' ', $i);
+            }
+            $loader = new ArrayLoader($templates);
             $twig = new Environment($loader, $config);
             $twig->addGlobal('global', 'global');
             foreach ($this->getRuntimeLoaders() as $runtimeLoader) {

--- a/tests/Fixtures/functions/deprecated.test
+++ b/tests/Fixtures/functions/deprecated.test
@@ -1,0 +1,21 @@
+--TEST--
+Functions can be deprecated_function
+--DEPRECATION--
+Since foo/bar 1.1: Twig Function "deprecated_function" is deprecated. Use "not_deprecated_function" instead in index.twig at line 2.
+Since foo/bar 1.1: Twig Function "deprecated_function" is deprecated. Use "not_deprecated_function" instead in index.twig at line 4.
+--TEMPLATE--
+{{ deprecated_function() }}
+
+{{ deprecated_function() }}
+--DATA--
+return []
+--EXPECT--
+foo
+
+foo
+--DATA--
+return []
+--EXPECT--
+foo
+
+foo

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -185,6 +185,7 @@ class TwigTestExtension extends AbstractExtension
             new TwigFunction('*_path', [$this, 'dynamic_path']),
             new TwigFunction('*_foo_*_bar', [$this, 'dynamic_foo']),
             new TwigFunction('anon_foo', function ($name) { return '*'.$name.'*'; }),
+            new TwigFunction('deprecated_function', function () { return 'foo'; }, ['deprecated' => '1.1', 'deprecating_package' => 'foo/bar', 'alternative' => 'not_deprecated_function']),
         ];
     }
 


### PR DESCRIPTION
Fixes #4186

As deprecations are emitted at compile time, we need to make sure templates are always compiled even when we have more than one data/expect section (in which case the templates are the same). The trick here is to add some whitespace at the end of the template.
