### PR TITLE
Remove escape

### DIFF
--- a/extra/html-extra/Tests/Fixtures/data_uri.test
+++ b/extra/html-extra/Tests/Fixtures/data_uri.test
@@ -1,7 +1,7 @@
 --TEST--
 "data_uri" filter
 --TEMPLATE--
-{{ 'foobar#'|data_uri(parameters={charset: "utf-8", foo: "\$bar"}) }}
+{{ 'foobar#'|data_uri(parameters={charset: "utf-8", foo: "$bar"}) }}
 {{ '<b>foobar</b>'|data_uri(mime="text/html", parameters={charset: "ascii"}) }}
 <img src="{{ sf_logo|data_uri }}" />
 --DATA--


### PR DESCRIPTION
Interestingly this didn’t fail on the branch that introduced the change. Are we sure the integration tests work at all? 

See [failing job](https://github.com/twigphp/Twig/actions/runs/10341129793) on merge to main.