### PR TITLE
Disable the drupal integration tests in the 4.x branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
               run: ../../vendor/bin/simple-phpunit
 
     integration-tests:
+        if: "false" # TODO re-enable that job when Drupal does not use features deprecated in 3.x anymore
         needs:
             - 'tests'
 


### PR DESCRIPTION
Drupal uses the AbstractNodeVisitor which is deprecated in 3.x and removed in 4.x, so the job fails all the time. This should be re-enabled once Drupal can be tested against Twig 4.x.