### PR TITLE
Remove remaining const optimizations

### DIFF
--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -252,7 +252,7 @@ class ExpressionParser
                 break;
 
             case Token::STRING_TYPE:
-            case /* Token::INTERPOLATION_START_TYPE */ 10:
+            case Token::INTERPOLATION_START_TYPE:
                 $node = $this->parseStringExpression();
                 break;
 
@@ -304,9 +304,9 @@ class ExpressionParser
             if ($nextCanBeString && $token = $stream->nextIf(Token::STRING_TYPE)) {
                 $nodes[] = new ConstantExpression($token->getValue(), $token->getLine());
                 $nextCanBeString = false;
-            } elseif ($stream->nextIf(/* Token::INTERPOLATION_START_TYPE */ 10)) {
+            } elseif ($stream->nextIf(Token::INTERPOLATION_START_TYPE)) {
                 $nodes[] = $this->parseExpression();
-                $stream->expect(/* Token::INTERPOLATION_END_TYPE */ 11);
+                $stream->expect(Token::INTERPOLATION_END_TYPE);
                 $nextCanBeString = true;
             } else {
                 break;
@@ -775,7 +775,7 @@ class ExpressionParser
         $name = $stream->expect(Token::NAME_TYPE)->getValue();
 
         if (!$test = $this->env->getTest($name)) {
-            if ($stream->test(/* Token::NAME_TYPE */ 5)) {
+            if ($stream->test(Token::NAME_TYPE)) {
                 // try 2-words tests
                 $name = $name.' '.$this->parser->getCurrentToken()->getValue();
 

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -215,7 +215,7 @@ class Lexer
             }
         }
 
-        $this->pushToken(/* Token::EOF_TYPE */ -1);
+        $this->pushToken(Token::EOF_TYPE);
 
         if (!empty($this->brackets)) {
             [$expect, $lineno] = array_pop($this->brackets);
@@ -276,14 +276,14 @@ class Lexer
                     $this->moveCursor($match[0]);
                     $this->lineno = (int) $match[1];
                 } else {
-                    $this->pushToken(/* Token::BLOCK_START_TYPE */ 1);
+                    $this->pushToken(Token::BLOCK_START_TYPE);
                     $this->pushState(self::STATE_BLOCK);
                     $this->currentVarBlockLine = $this->lineno;
                 }
                 break;
 
             case $this->options['tag_variable'][0]:
-                $this->pushToken(/* Token::VAR_START_TYPE */ 2);
+                $this->pushToken(Token::VAR_START_TYPE);
                 $this->pushState(self::STATE_VAR);
                 $this->currentVarBlockLine = $this->lineno;
                 break;
@@ -293,7 +293,7 @@ class Lexer
     private function lexBlock(): void
     {
         if (empty($this->brackets) && preg_match($this->regexes['lex_block'], $this->code, $match, 0, $this->cursor)) {
-            $this->pushToken(/* Token::BLOCK_END_TYPE */ 3);
+            $this->pushToken(Token::BLOCK_END_TYPE);
             $this->moveCursor($match[0]);
             $this->popState();
         } else {
@@ -304,7 +304,7 @@ class Lexer
     private function lexVar(): void
     {
         if (empty($this->brackets) && preg_match($this->regexes['lex_var'], $this->code, $match, 0, $this->cursor)) {
-            $this->pushToken(/* Token::VAR_END_TYPE */ 4);
+            $this->pushToken(Token::VAR_END_TYPE);
             $this->moveCursor($match[0]);
             $this->popState();
         } else {
@@ -484,7 +484,7 @@ class Lexer
     {
         if (preg_match($this->regexes['interpolation_start'], $this->code, $match, 0, $this->cursor)) {
             $this->brackets[] = [$this->options['interpolation'][0], $this->lineno];
-            $this->pushToken(/* Token::INTERPOLATION_START_TYPE */ 10);
+            $this->pushToken(Token::INTERPOLATION_START_TYPE);
             $this->moveCursor($match[0]);
             $this->pushState(self::STATE_INTERPOLATION);
         } elseif (preg_match(self::REGEX_DQ_STRING_PART, $this->code, $match, 0, $this->cursor) && '' !== $match[0]) {
@@ -509,7 +509,7 @@ class Lexer
         $bracket = end($this->brackets);
         if ($this->options['interpolation'][0] === $bracket[0] && preg_match($this->regexes['interpolation_end'], $this->code, $match, 0, $this->cursor)) {
             array_pop($this->brackets);
-            $this->pushToken(/* Token::INTERPOLATION_END_TYPE */ 11);
+            $this->pushToken(Token::INTERPOLATION_END_TYPE);
             $this->moveCursor($match[0]);
             $this->popState();
         } else {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -126,14 +126,14 @@ class Parser
                     $rv[] = new TextNode($token->getValue(), $token->getLine());
                     break;
 
-                case /* Token::VAR_START_TYPE */ 2:
+                case Token::VAR_START_TYPE:
                     $token = $this->stream->next();
                     $expr = $this->expressionParser->parseExpression();
-                    $this->stream->expect(/* Token::VAR_END_TYPE */ 4);
+                    $this->stream->expect(Token::VAR_END_TYPE);
                     $rv[] = new PrintNode($expr, $token->getLine());
                     break;
 
-                case /* Token::BLOCK_START_TYPE */ 1:
+                case Token::BLOCK_START_TYPE:
                     $this->stream->next();
                     $token = $this->getCurrentToken();
 

--- a/src/TokenParser/AutoEscapeTokenParser.php
+++ b/src/TokenParser/AutoEscapeTokenParser.php
@@ -29,7 +29,7 @@ final class AutoEscapeTokenParser extends AbstractTokenParser
         $lineno = $token->getLine();
         $stream = $this->parser->getStream();
 
-        if ($stream->test(/* Token::BLOCK_END_TYPE */ 3)) {
+        if ($stream->test(Token::BLOCK_END_TYPE)) {
             $value = 'html';
         } else {
             $expr = $this->parser->getExpressionParser()->parseExpression();
@@ -39,9 +39,9 @@ final class AutoEscapeTokenParser extends AbstractTokenParser
             $value = $expr->getAttribute('value');
         }
 
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return new AutoEscapeNode($value, $body, $lineno, $this->getTag());
     }

--- a/src/TokenParser/BlockTokenParser.php
+++ b/src/TokenParser/BlockTokenParser.php
@@ -43,7 +43,7 @@ final class BlockTokenParser extends AbstractTokenParser
         $this->parser->pushLocalScope();
         $this->parser->pushBlockStack($name);
 
-        if ($stream->nextIf(/* Token::BLOCK_END_TYPE */ 3)) {
+        if ($stream->nextIf(Token::BLOCK_END_TYPE)) {
             $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
             if ($token = $stream->nextIf(Token::NAME_TYPE)) {
                 $value = $token->getValue();
@@ -57,7 +57,7 @@ final class BlockTokenParser extends AbstractTokenParser
                 new PrintNode($this->parser->getExpressionParser()->parseExpression(), $lineno),
             ]);
         }
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         $block->setNode('body', $body);
         $this->parser->popBlockStack();

--- a/src/TokenParser/DoTokenParser.php
+++ b/src/TokenParser/DoTokenParser.php
@@ -26,7 +26,7 @@ final class DoTokenParser extends AbstractTokenParser
     {
         $expr = $this->parser->getExpressionParser()->parseExpression();
 
-        $this->parser->getStream()->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         return new DoNode($expr, $token->getLine(), $this->getTag());
     }

--- a/src/TokenParser/EmbedTokenParser.php
+++ b/src/TokenParser/EmbedTokenParser.php
@@ -41,10 +41,10 @@ final class EmbedTokenParser extends IncludeTokenParser
 
         // inject a fake parent to make the parent() function work
         $stream->injectTokens([
-            new Token(/* Token::BLOCK_START_TYPE */ 1, '', $token->getLine()),
+            new Token(Token::BLOCK_START_TYPE, '', $token->getLine()),
             new Token(Token::NAME_TYPE, 'extends', $token->getLine()),
             $parentToken,
-            new Token(/* Token::BLOCK_END_TYPE */ 3, '', $token->getLine()),
+            new Token(Token::BLOCK_END_TYPE, '', $token->getLine()),
         ]);
 
         $module = $this->parser->parse($stream, [$this, 'decideBlockEnd'], true);
@@ -56,7 +56,7 @@ final class EmbedTokenParser extends IncludeTokenParser
 
         $this->parser->embedTemplate($module);
 
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return new EmbedNode($module->getTemplateName(), $module->getAttribute('index'), $variables, $only, $ignoreMissing, $token->getLine(), $this->getTag());
     }

--- a/src/TokenParser/ExtendsTokenParser.php
+++ b/src/TokenParser/ExtendsTokenParser.php
@@ -40,7 +40,7 @@ final class ExtendsTokenParser extends AbstractTokenParser
         }
         $this->parser->setParent($this->parser->getExpressionParser()->parseExpression());
 
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return new Node();
     }

--- a/src/TokenParser/FlushTokenParser.php
+++ b/src/TokenParser/FlushTokenParser.php
@@ -26,7 +26,7 @@ final class FlushTokenParser extends AbstractTokenParser
 {
     public function parse(Token $token): Node
     {
-        $this->parser->getStream()->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         return new FlushNode($token->getLine(), $this->getTag());
     }

--- a/src/TokenParser/ForTokenParser.php
+++ b/src/TokenParser/ForTokenParser.php
@@ -38,15 +38,15 @@ final class ForTokenParser extends AbstractTokenParser
         $stream->expect(Token::OPERATOR_TYPE, 'in');
         $seq = $this->parser->getExpressionParser()->parseExpression();
 
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse([$this, 'decideForFork']);
         if ('else' == $stream->next()->getValue()) {
-            $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+            $stream->expect(Token::BLOCK_END_TYPE);
             $else = $this->parser->subparse([$this, 'decideForEnd'], true);
         } else {
             $else = null;
         }
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         if (\count($targets) > 1) {
             $keyTarget = $targets->getNode('0');

--- a/src/TokenParser/FromTokenParser.php
+++ b/src/TokenParser/FromTokenParser.php
@@ -47,7 +47,7 @@ final class FromTokenParser extends AbstractTokenParser
             }
         }
 
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         $var = new AssignNameExpression($this->parser->getVarName(), $token->getLine());
         $node = new ImportNode($macro, $var, $token->getLine(), $this->getTag(), $this->parser->isMainScope());

--- a/src/TokenParser/IfTokenParser.php
+++ b/src/TokenParser/IfTokenParser.php
@@ -37,7 +37,7 @@ final class IfTokenParser extends AbstractTokenParser
         $lineno = $token->getLine();
         $expr = $this->parser->getExpressionParser()->parseExpression();
         $stream = $this->parser->getStream();
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse([$this, 'decideIfFork']);
         $tests = [$expr, $body];
         $else = null;
@@ -46,13 +46,13 @@ final class IfTokenParser extends AbstractTokenParser
         while (!$end) {
             switch ($stream->next()->getValue()) {
                 case 'else':
-                    $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+                    $stream->expect(Token::BLOCK_END_TYPE);
                     $else = $this->parser->subparse([$this, 'decideIfEnd']);
                     break;
 
                 case 'elseif':
                     $expr = $this->parser->getExpressionParser()->parseExpression();
-                    $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+                    $stream->expect(Token::BLOCK_END_TYPE);
                     $body = $this->parser->subparse([$this, 'decideIfFork']);
                     $tests[] = $expr;
                     $tests[] = $body;
@@ -67,7 +67,7 @@ final class IfTokenParser extends AbstractTokenParser
             }
         }
 
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return new IfNode(new Node($tests), $else, $lineno, $this->getTag());
     }

--- a/src/TokenParser/ImportTokenParser.php
+++ b/src/TokenParser/ImportTokenParser.php
@@ -30,7 +30,7 @@ final class ImportTokenParser extends AbstractTokenParser
         $macro = $this->parser->getExpressionParser()->parseExpression();
         $this->parser->getStream()->expect(Token::NAME_TYPE, 'as');
         $var = new AssignNameExpression($this->parser->getStream()->expect(Token::NAME_TYPE)->getValue(), $token->getLine());
-        $this->parser->getStream()->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         $this->parser->addImportedSymbol('template', $var->getAttribute('name'));
 

--- a/src/TokenParser/IncludeTokenParser.php
+++ b/src/TokenParser/IncludeTokenParser.php
@@ -57,7 +57,7 @@ class IncludeTokenParser extends AbstractTokenParser
             $only = true;
         }
 
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return [$variables, $only, $ignoreMissing];
     }

--- a/src/TokenParser/MacroTokenParser.php
+++ b/src/TokenParser/MacroTokenParser.php
@@ -36,7 +36,7 @@ final class MacroTokenParser extends AbstractTokenParser
 
         $arguments = $this->parser->getExpressionParser()->parseArguments(true, true);
 
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
         $this->parser->pushLocalScope();
         $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
         if ($token = $stream->nextIf(Token::NAME_TYPE)) {
@@ -47,7 +47,7 @@ final class MacroTokenParser extends AbstractTokenParser
             }
         }
         $this->parser->popLocalScope();
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         $this->parser->setMacro($name, new MacroNode($name, new BodyNode([$body]), $arguments, $lineno, $this->getTag()));
 

--- a/src/TokenParser/SandboxTokenParser.php
+++ b/src/TokenParser/SandboxTokenParser.php
@@ -34,9 +34,9 @@ final class SandboxTokenParser extends AbstractTokenParser
     public function parse(Token $token): Node
     {
         $stream = $this->parser->getStream();
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         // in a sandbox tag, only include tags are allowed
         if (!$body instanceof IncludeNode) {

--- a/src/TokenParser/SetTokenParser.php
+++ b/src/TokenParser/SetTokenParser.php
@@ -40,7 +40,7 @@ final class SetTokenParser extends AbstractTokenParser
         if ($stream->nextIf(Token::OPERATOR_TYPE, '=')) {
             $values = $this->parser->getExpressionParser()->parseMultitargetExpression();
 
-            $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+            $stream->expect(Token::BLOCK_END_TYPE);
 
             if (\count($names) !== \count($values)) {
                 throw new SyntaxError('When using set, you must have the same number of variables and assignments.', $stream->getCurrent()->getLine(), $stream->getSourceContext());
@@ -52,10 +52,10 @@ final class SetTokenParser extends AbstractTokenParser
                 throw new SyntaxError('When using set with a block, you cannot have a multi-target.', $stream->getCurrent()->getLine(), $stream->getSourceContext());
             }
 
-            $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+            $stream->expect(Token::BLOCK_END_TYPE);
 
             $values = $this->parser->subparse([$this, 'decideBlockEnd'], true);
-            $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+            $stream->expect(Token::BLOCK_END_TYPE);
         }
 
         return new SetNode($capture, $names, $values, $lineno, $this->getTag());

--- a/src/TokenParser/UseTokenParser.php
+++ b/src/TokenParser/UseTokenParser.php
@@ -59,7 +59,7 @@ final class UseTokenParser extends AbstractTokenParser
             }
         }
 
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         $this->parser->addTrait(new Node(['template' => $template, 'targets' => new Node($targets)]));
 

--- a/src/TokenParser/WithTokenParser.php
+++ b/src/TokenParser/WithTokenParser.php
@@ -30,16 +30,16 @@ final class WithTokenParser extends AbstractTokenParser
 
         $variables = null;
         $only = false;
-        if (!$stream->test(/* Token::BLOCK_END_TYPE */ 3)) {
+        if (!$stream->test(Token::BLOCK_END_TYPE)) {
             $variables = $this->parser->getExpressionParser()->parseExpression();
             $only = (bool) $stream->nextIf(Token::NAME_TYPE, 'only');
         }
 
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         $body = $this->parser->subparse([$this, 'decideWithEnd'], true);
 
-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return new WithNode($body, $variables, $only, $token->getLine(), $this->getTag());
     }

--- a/src/TokenStream.php
+++ b/src/TokenStream.php
@@ -110,7 +110,7 @@ final class TokenStream
      */
     public function isEOF(): bool
     {
-        return /* Token::EOF_TYPE */ -1 === $this->tokens[$this->current]->getType();
+        return Token::EOF_TYPE === $this->tokens[$this->current]->getType();
     }
 
     public function getCurrent(): Token


### PR DESCRIPTION
After #4198, some Token:: constant optimizations remained.

This PR removes them.. **in case** this was not intended