### PR TITLE
Add missing return types in 4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 4.0.0 (2024-XX-XX)
 
+ * Add return types to all ExtensionInterface methods (`getFunctions()`, `getFilters()`, etc.)
  * Add support for recursive loops (via the `loop()` function)
  * Add `loop.changed`, `loop.previous`, `loop.next`, and `loop.cycle` variables
  * Make `loop.last` always available (even for non-countable iterators)

--- a/extra/cssinliner-extra/CssInlinerExtension.php
+++ b/extra/cssinliner-extra/CssInlinerExtension.php
@@ -17,7 +17,7 @@ use Twig\TwigFilter;
 
 class CssInlinerExtension extends AbstractExtension
 {
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('inline_css', self::inlineCss(...), ['is_safe' => ['all']]),

--- a/extra/inky-extra/InkyExtension.php
+++ b/extra/inky-extra/InkyExtension.php
@@ -17,7 +17,7 @@ use Twig\TwigFilter;
 
 class InkyExtension extends AbstractExtension
 {
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('inky_to_html', self::inky(...), ['is_safe' => ['html']]),

--- a/extra/intl-extra/IntlExtension.php
+++ b/extra/intl-extra/IntlExtension.php
@@ -156,7 +156,7 @@ final class IntlExtension extends AbstractExtension
         $this->numberFormatterPrototype = $numberFormatterPrototype;
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             // internationalized names
@@ -177,7 +177,7 @@ final class IntlExtension extends AbstractExtension
         ];
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             // internationalized names

--- a/extra/markdown-extra/MarkdownExtension.php
+++ b/extra/markdown-extra/MarkdownExtension.php
@@ -17,7 +17,7 @@ use Twig\TwigFilter;
 
 final class MarkdownExtension extends AbstractExtension
 {
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('markdown_to_html', ['Twig\\Extra\\Markdown\\MarkdownRuntime', 'convert'], ['is_safe' => ['all']]),

--- a/extra/string-extra/StringExtension.php
+++ b/extra/string-extra/StringExtension.php
@@ -32,7 +32,7 @@ final class StringExtension extends AbstractExtension
         $this->slugger = $slugger ?: new AsciiSlugger();
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('u', [$this, 'createUnicodeString']),
@@ -52,10 +52,7 @@ final class StringExtension extends AbstractExtension
         return $this->slugger->slug($string, $separator, $locale);
     }
 
-    /**
-     * @return array|string
-     */
-    public function plural(string $value, string $locale = 'en', bool $all = false)
+    public function plural(string $value, string $locale = 'en', bool $all = false): array|string
     {
         if ($all) {
             return $this->getInflector($locale)->pluralize($value);
@@ -64,10 +61,7 @@ final class StringExtension extends AbstractExtension
         return $this->getInflector($locale)->pluralize($value)[0];
     }
 
-    /**
-     * @return array|string
-     */
-    public function singular(string $value, string $locale = 'en', bool $all = false)
+    public function singular(string $value, string $locale = 'en', bool $all = false): array|string
     {
         if ($all) {
             return $this->getInflector($locale)->singularize($value);

--- a/extra/twig-extra-bundle/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
+++ b/extra/twig-extra-bundle/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
@@ -18,8 +18,7 @@ use Twig\Environment;
 
 class MissingExtensionSuggestorPass implements CompilerPassInterface
 {
-    /** @return void */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->getParameter('kernel.debug')) {
             $twigDefinition = $container->getDefinition('twig');

--- a/extra/twig-extra-bundle/DependencyInjection/TwigExtraExtension.php
+++ b/extra/twig-extra-bundle/DependencyInjection/TwigExtraExtension.php
@@ -23,8 +23,7 @@ use Twig\Extra\TwigExtraBundle\Extensions;
  */
 class TwigExtraExtension extends Extension
 {
-    /** @return void */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
         $configuration = $this->getConfiguration($configs, $container);

--- a/extra/twig-extra-bundle/TwigExtraBundle.php
+++ b/extra/twig-extra-bundle/TwigExtraBundle.php
@@ -17,8 +17,7 @@ use Twig\Extra\TwigExtraBundle\DependencyInjection\Compiler\MissingExtensionSugg
 
 class TwigExtraBundle extends Bundle
 {
-    /** @return void */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Extension/AbstractExtension.php
+++ b/src/Extension/AbstractExtension.php
@@ -13,32 +13,32 @@ namespace Twig\Extension;
 
 abstract class AbstractExtension implements ExtensionInterface
 {
-    public function getTokenParsers()
+    public function getTokenParsers(): array
     {
         return [];
     }
 
-    public function getNodeVisitors()
+    public function getNodeVisitors(): array
     {
         return [];
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [];
     }
 
-    public function getTests()
+    public function getTests(): array
     {
         return [];
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [];
     }
 
-    public function getOperators()
+    public function getOperators(): array
     {
         return [[], []];
     }

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -31,35 +31,35 @@ interface ExtensionInterface
      *
      * @return TokenParserInterface[]
      */
-    public function getTokenParsers();
+    public function getTokenParsers(): array;
 
     /**
      * Returns the node visitor instances to add to the existing list.
      *
      * @return NodeVisitorInterface[]
      */
-    public function getNodeVisitors();
+    public function getNodeVisitors(): array;
 
     /**
      * Returns a list of filters to add to the existing list.
      *
      * @return TwigFilter[]
      */
-    public function getFilters();
+    public function getFilters(): array;
 
     /**
      * Returns a list of tests to add to the existing list.
      *
      * @return TwigTest[]
      */
-    public function getTests();
+    public function getTests(): array;
 
     /**
      * Returns a list of functions to add to the existing list.
      *
      * @return TwigFunction[]
      */
-    public function getFunctions();
+    public function getFunctions(): array;
 
     /**
      * Returns a list of operators to add to the existing list.
@@ -71,5 +71,5 @@ interface ExtensionInterface
      *     array<string, array{precedence: int, class?: class-string<AbstractExpression>, associativity: ExpressionParser::OPERATOR_*}>
      * }
      */
-    public function getOperators();
+    public function getOperators(): array;
 }

--- a/src/Extension/ProfilerExtension.php
+++ b/src/Extension/ProfilerExtension.php
@@ -26,19 +26,13 @@ class ProfilerExtension extends AbstractExtension
         $this->actives[] = $profile;
     }
 
-    /**
-     * @return void
-     */
-    public function enter(Profile $profile)
+    public function enter(Profile $profile): void
     {
         $this->actives[0]->addProfile($profile);
         array_unshift($this->actives, $profile);
     }
 
-    /**
-     * @return void
-     */
-    public function leave(Profile $profile)
+    public function leave(Profile $profile): void
     {
         $profile->leave();
         array_shift($this->actives);

--- a/src/Loader/FilesystemLoader.php
+++ b/src/Loader/FilesystemLoader.php
@@ -139,10 +139,7 @@ class FilesystemLoader implements LoaderInterface
         return $path;
     }
 
-    /**
-     * @return bool
-     */
-    public function exists(string $name)
+    public function exists(string $name): bool
     {
         $name = $this->normalizeName($name);
 
@@ -163,10 +160,7 @@ class FilesystemLoader implements LoaderInterface
         return filemtime($path) < $time;
     }
 
-    /**
-     * @return string|null
-     */
-    protected function findTemplate(string $name, bool $throw = true)
+    protected function findTemplate(string $name, bool $throw = true): ?string
     {
         $name = $this->normalizeName($name);
 

--- a/src/Node/CheckSecurityCallNode.php
+++ b/src/Node/CheckSecurityCallNode.php
@@ -20,7 +20,7 @@ use Twig\Compiler;
 #[YieldReady]
 class CheckSecurityCallNode extends Node
 {
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $compiler
             ->write("\$this->sandbox = \$this->extensions[SandboxExtension::class];\n")

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -56,7 +56,7 @@ class Node implements \Countable, \IteratorAggregate
         $this->tag = $tag;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $attributes = [];
         foreach ($this->attributes as $name => $value) {
@@ -91,10 +91,7 @@ class Node implements \Countable, \IteratorAggregate
         return implode("\n", $repr);
     }
 
-    /**
-     * @return void
-     */
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         foreach ($this->nodes as $node) {
             $compiler->subcompile($node);

--- a/src/TokenParser/TokenParserInterface.php
+++ b/src/TokenParser/TokenParserInterface.php
@@ -31,16 +31,12 @@ interface TokenParserInterface
     /**
      * Parses a token and returns a node.
      *
-     * @return Node
-     *
      * @throws SyntaxError
      */
-    public function parse(Token $token);
+    public function parse(Token $token): Node;
 
     /**
      * Gets the tag name associated with this token parser.
-     *
-     * @return string
      */
-    public function getTag();
+    public function getTag(): string;
 }

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -555,7 +555,7 @@ class EnvironmentTest_Runtime
 
 class EnvironmentTest_LegacyEchoingNode extends Node
 {
-    public function compile($compiler)
+    public function compile($compiler): void
     {
         $compiler
             ->addDebugInfo($this)

--- a/tests/ExpressionParserTest.php
+++ b/tests/ExpressionParserTest.php
@@ -427,7 +427,7 @@ class ExpressionParserTest extends TestCase
     {
         $env = new Environment(new ArrayLoader(['index' => '{{ "a" is foo_foo_bar_bar }}']), ['cache' => false, 'autoescape' => false]);
         $env->addExtension(new class() extends AbstractExtension {
-            public function getTests()
+            public function getTests(): array
             {
                 return [
                     new TwigTest('*_foo_*_bar', function ($foo, $bar, $a) {}),
@@ -442,7 +442,7 @@ class ExpressionParserTest extends TestCase
     {
         $env = new Environment(new ArrayLoader(['index' => '{{ foo_foo_bar_bar("a") }}']), ['cache' => false, 'autoescape' => false]);
         $env->addExtension(new class() extends AbstractExtension {
-            public function getFunctions()
+            public function getFunctions(): array
             {
                 return [
                     new TwigFunction('*_foo_*_bar', function ($foo, $bar, $a) {}),
@@ -457,7 +457,7 @@ class ExpressionParserTest extends TestCase
     {
         $env = new Environment(new ArrayLoader(['index' => '{{ "a"|foo_foo_bar_bar }}']), ['cache' => false, 'autoescape' => false]);
         $env->addExtension(new class() extends AbstractExtension {
-            public function getFilters()
+            public function getFilters(): array
             {
                 return [
                     new TwigFilter('*_foo_*_bar', function ($foo, $bar, $a) {}),


### PR DESCRIPTION
Revert the removal of return types done in #3156 

Should i propagate to `extra` packages in the same PR ? 