### PR TITLE
Add test about Environment version constants.

### DIFF
--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -38,6 +38,21 @@ class EnvironmentTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
+    public function testVersionConstants()
+    {
+        $version = Environment::VERSION;
+        $exploded = explode('-', $version);
+        $this->assertEquals(Environment::EXTRA_VERSION, $exploded[1] ?? '');
+
+        $version = $exploded[0];
+        $exploded = explode('.', $version);
+        $this->assertEquals(Environment::MAJOR_VERSION, $exploded[0]);
+        $this->assertEquals(Environment::MINOR_VERSION, $exploded[1]);
+        $this->assertEquals(Environment::RELEASE_VERSION, $exploded[2]);
+
+        $this->assertEquals(Environment::VERSION_ID, \sprintf('%s0%s0%s', $exploded[0], $exploded[1], $exploded[2]));
+    }
+
     public function testAutoescapeOption()
     {
         $loader = new ArrayLoader([


### PR DESCRIPTION
Hi @fabpot 

The Environment Version constants seems to be manually updated.
https://github.com/twigphp/Twig/blob/fe36e084b4e208c44e30886053c8594bb99bd78f/src/Environment.php#L46-L51

A mistake was made on the 3.11 version, the MAJOR_VERSION was set to 4 instead of 3
https://github.com/twigphp/Twig/blob/e80fb8ebba85c7341a97a9ebf825d7fd4b77708d/src/Environment.php#L48

It was fixed in another version, but I think it could be useful to have some test about the consistency of all those constants.
Such test would have fail for the 3.11 version and avoid the mistake.