### PR TITLE
[RFC] Add PreLexerInterface

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -56,6 +56,8 @@ class Environment
     private $autoReload;
     private $cache;
     private $lexer;
+    /** @var array<PreLexerInterface> */
+    private $preLexers = [];
     private $parser;
     private $compiler;
     /** @var array<string, mixed> */
@@ -488,6 +490,11 @@ class Environment
         throw new LoaderError(\sprintf('Unable to find one of the following templates: "%s".', implode('", "', $names)));
     }
 
+    public function addPreLexer(PreLexerInterface $preLexer): void
+    {
+        $this->preLexers[] = $preLexer;
+    }
+
     public function setLexer(Lexer $lexer)
     {
         $this->lexer = $lexer;
@@ -500,6 +507,10 @@ class Environment
     {
         if (null === $this->lexer) {
             $this->lexer = new Lexer($this);
+        }
+
+        foreach ($this->preLexers as $preLexer) {
+            $source = $preLexer->preLex($source);
         }
 
         return $this->lexer->tokenize($source);

--- a/src/PreLexerInterface.php
+++ b/src/PreLexerInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Twig;
+
+interface PreLexerInterface
+{
+    public function preLex(Source $source): Source;
+}


### PR DESCRIPTION
Inspired by @smnandre https://github.com/twigphp/Twig/issues/3951#issuecomment-1868286974

Currently symfony/ux override the existing Lexer in order to pre-processing the code before the Lexer
https://github.com/symfony/ux/blob/2ded7546dc5f7ef2b85acb33ba6d4871b5376d7e/src/TwigComponent/src/Twig/ComponentLexer.php#L27-L42

One main issue could be that if another library has the same need, you have to chose between both library (since the override can only done once).

One idea could be to introduce a new extension point before the Lexer is called. Something like a PreLexer, then you can have as many PreLexer as you want.

Wording can be improved if accepted and tests might be needed.

Also, I dunno if there are similar use case 
- For PreParser
- For PreCompiler