### PR TITLE
Deprecate OptimizerNodeVisitor::OPTIMIZE_TEXT_NODES

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.12.0 (2024-XX-XX)
 
+ * Deprecate `OptimizerNodeVisitor::OPTIMIZE_TEXT_NODES`
  * Fix performance regression when `use_yield` is `false` (which is the default)
  * Improve compatibility when `use_yield` is `false` (as extensions still using `echo` will work as is)
  * Accept colons (`:`) in addition to equals (`=`) to separate argument names and values in named arguments
@@ -18,6 +19,7 @@
 
 # 3.11.0 (2024-08-08)
 
+ * Deprecate `OptimizerNodeVisitor::OPTIMIZE_RAW_FILTER`
  * Add `Twig\Cache\ChainCache` and `Twig\Cache\ReadOnlyFilesystemCache`
  * Add the possibility to deprecate attributes and nodes on `Node`
  * Add the possibility to add a package and a version to the `deprecated` tag

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -141,6 +141,11 @@ Node Visitors
 * The ``Twig\NodeVisitor\AbstractNodeVisitor`` class is deprecated, implement the
   ``Twig\NodeVisitor\NodeVisitorInterface`` interface instead.
 
+* The ``Twig\NodeVisitor\OptimizerNodeVisitor::OPTIMIZE_RAW_FILTER`` and the
+  ``Twig\NodeVisitor\OptimizerNodeVisitor::OPTIMIZE_TEXT_NODES`` options are
+  deprecated as of Twig 3.12 and will be removed in Twig 4.0; they don't do
+  anything anymore.
+
 Parser
 ------
 

--- a/src/NodeVisitor/OptimizerNodeVisitor.php
+++ b/src/NodeVisitor/OptimizerNodeVisitor.php
@@ -62,6 +62,10 @@ final class OptimizerNodeVisitor implements NodeVisitorInterface
             trigger_deprecation('twig/twig', '3.11', 'The "Twig\NodeVisitor\OptimizerNodeVisitor::OPTIMIZE_RAW_FILTER" option is deprecated and does nothing.');
         }
 
+        if (-1 !== $optimizers && self::OPTIMIZE_TEXT_NODES === (self::OPTIMIZE_TEXT_NODES & $optimizers)) {
+            trigger_deprecation('twig/twig', '3.12', 'The "Twig\NodeVisitor\OptimizerNodeVisitor::OPTIMIZE_TEXT_NODES" option is deprecated and does nothing.');
+        }
+
         $this->optimizers = $optimizers;
     }
 
@@ -81,42 +85,6 @@ final class OptimizerNodeVisitor implements NodeVisitorInterface
         }
 
         $node = $this->optimizePrintNode($node);
-
-        if (self::OPTIMIZE_TEXT_NODES === (self::OPTIMIZE_TEXT_NODES & $this->optimizers)) {
-            $node = $this->mergeTextNodeCalls($node);
-        }
-
-        return $node;
-    }
-
-    private function mergeTextNodeCalls(Node $node): Node
-    {
-        $text = '';
-        $names = [];
-        foreach ($node as $k => $n) {
-            if (!$n instanceof TextNode) {
-                return $node;
-            }
-
-            $text .= $n->getAttribute('data');
-            $names[] = $k;
-        }
-
-        if (!$text) {
-            return $node;
-        }
-
-        if (Node::class === \get_class($node)) {
-            return new TextNode($text, $node->getTemplateLine());
-        }
-
-        foreach ($names as $i => $name) {
-            if (0 === $i) {
-                $node->setNode($name, new TextNode($text, $node->getTemplateLine()));
-            } else {
-                $node->removeNode($name);
-            }
-        }
 
         return $node;
     }

--- a/tests/NodeVisitor/OptimizerTest.php
+++ b/tests/NodeVisitor/OptimizerTest.php
@@ -27,10 +27,8 @@ class OptimizerTest extends TestCase
     public function testConstructor()
     {
         $this->expectNotToPerformAssertions();
-        new OptimizerNodeVisitor(
-            OptimizerNodeVisitor::OPTIMIZE_FOR
-            | OptimizerNodeVisitor::OPTIMIZE_TEXT_NODES
-        );
+
+        new OptimizerNodeVisitor(OptimizerNodeVisitor::OPTIMIZE_FOR);
     }
 
     public function testRenderBlockOptimizer()


### PR DESCRIPTION
Refs #4146

While trying to debug #4146, I realized that this optimization is not possible as we don't know how nodes are going to be used.

See the script provided in #4146 to reproduce the problem.

@brandonkelly Can you confirm that this fixes your problem? Maybe there is also an issue with yield vs echo, but the script provided in the issue runs fine for me after this PR.
