### PR TITLE
💡 Node `assert`❔

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -69,6 +69,7 @@ use Twig\Source;
 use Twig\Template;
 use Twig\TemplateWrapper;
 use Twig\TokenParser\ApplyTokenParser;
+use Twig\TokenParser\AssertTokenParser;
 use Twig\TokenParser\BlockTokenParser;
 use Twig\TokenParser\DeprecatedTokenParser;
 use Twig\TokenParser\DoTokenParser;
@@ -187,6 +188,7 @@ final class CoreExtension extends AbstractExtension
             new EmbedTokenParser(),
             new WithTokenParser(),
             new DeprecatedTokenParser(),
+            new AssertTokenParser(),
         ];
     }
 

--- a/src/Node/AssertNode.php
+++ b/src/Node/AssertNode.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Node;
+
+use Twig\Attribute\YieldReady;
+use Twig\Compiler;
+use Twig\Node\Expression\AbstractExpression;
+
+/**
+ * Represents a assert node.
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+#[YieldReady]
+class AssertNode extends Node
+{
+    public function __construct(AbstractExpression $expr, int $lineno, ?string $tag = null)
+    {
+        parent::__construct(['expr' => $expr], [], $lineno, $tag);
+    }
+
+    public function compile(Compiler $compiler): void
+    {
+        $compiler->addDebugInfo($this);
+        // TODO disable in production(?)
+
+        $compiler
+            ->write(' if (!')
+            ->subcompile($this->getNode('expr'))
+            ->raw(") {\n")
+            ->indent()
+            ->write("throw new \RuntimeException('Failed');\n")
+            ->outdent()
+            ->raw("}\n")
+        ;
+    }
+}

--- a/src/Node/AssertNode.php
+++ b/src/Node/AssertNode.php
@@ -38,7 +38,7 @@ class AssertNode extends Node
             ->subcompile($this->getNode('expr'))
             ->raw(") {\n")
             ->indent()
-            ->write("throw new \RuntimeException('Failed');\n")
+            ->write("throw new RuntimeError('Failed');\n")
             ->outdent()
             ->raw("}\n")
         ;

--- a/src/TokenParser/AssertTokenParser.php
+++ b/src/TokenParser/AssertTokenParser.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\TokenParser;
+
+use Twig\Node\AssertNode;
+use Twig\Node\Node;
+use Twig\Token;
+
+/**
+ * Evaluates an expression and triggers an error if the result is false.
+ *
+ * @author Simon André<smn.andre@gmail.com>
+ *
+ * @internal
+ */
+final class AssertTokenParser extends AbstractTokenParser
+{
+    public function parse(Token $token): Node
+    {
+        $expr = $this->parser->getExpressionParser()->parseExpression();
+
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
+
+        return new AssertNode($expr, $token->getLine(), $this->getTag());
+    }
+
+    public function getTag(): string
+    {
+        return 'assert';
+    }
+}

--- a/tests/Fixtures/tags/assert/basic.test
+++ b/tests/Fixtures/tags/assert/basic.test
@@ -1,0 +1,16 @@
+--TEST--
+"assert" creates a condition
+--TEMPLATE--
+{% assert a in ['a', 'b'] %}
+--DATA--
+return ['a' => 'a']
+--EXPECT--
+
+--DATA--
+return ['a' => 'b']
+--EXPECT--
+
+--DATA--
+return ['a' => 'c']
+--EXPECT--
+Twig\Error\Error: Twig\Error\RuntimeError: Failed in "index.twig" at line 2

--- a/tests/Node/AssertTest.php
+++ b/tests/Node/AssertTest.php
@@ -31,7 +31,7 @@ class AssertTest extends NodeTestCase
 
         $expr = new ConstantExpression('foo', 1);
         $node = new AssertNode($expr, 1);
-        $tests[] = [$node, "// line 1\n if (!\"foo\") {\n    throw new \RuntimeException('Failed');\n}"];
+        $tests[] = [$node, "// line 1\n if (!\"foo\") {\n    throw new RuntimeError('Failed');\n}"];
 
         return $tests;
     }

--- a/tests/Node/AssertTest.php
+++ b/tests/Node/AssertTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Twig\Tests\Node;
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Twig\Node\AssertNode;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Test\NodeTestCase;
+
+class AssertTest extends NodeTestCase
+{
+    public function testConstructor()
+    {
+        $expr = new ConstantExpression('foo', 1);
+        $node = new AssertNode($expr, 1);
+
+        $this->assertEquals($expr, $node->getNode('expr'));
+    }
+
+    public function getTests()
+    {
+        $tests = [];
+
+        $expr = new ConstantExpression('foo', 1);
+        $node = new AssertNode($expr, 1);
+        $tests[] = [$node, "// line 1\n if (!\"foo\") {\n    throw new \RuntimeException('Failed');\n}"];
+
+        return $tests;
+    }
+}


### PR DESCRIPTION
Acting as a _spinoff_ to [#4165 Add tag to declare variable types](https://github.com/twigphp/Twig/issues/4165)
(as I don't want to disrupt the main conversation too much 😅)

The idea is to introduce assertions.

I'm opening this to gather feedback and ideas. I'd like to see if there's something interesting here—or not. :)

This could enhance static analysis, define contracts in templates, and serve as a validator during includes/rendering.

```twig
{% assert name string %}
{% assert size in ['sm', 'md', 'lg'] %}
```

Open to any  feedback :)  