### PR TITLE
Add conditional return types to `ensureTraversable`

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1280,6 +1280,9 @@ final class CoreExtension extends AbstractExtension
 
     /**
      * @internal
+     * @template TSequence
+     * @param TSequence $seq
+     * @return ($seq is iterable ? TSequence : array{})
      */
     public static function ensureTraversable($seq)
     {


### PR DESCRIPTION
This way, static analyzers can understand what the output of this call will be.