### PR TITLE
Only unset loop when with_loop

### DIFF
--- a/src/Node/ForNode.php
+++ b/src/Node/ForNode.php
@@ -101,7 +101,11 @@ class ForNode extends Node
         $compiler->write("\$_parent = \$context['_parent'];\n");
 
         // remove some "private" loop variables (needed for nested loops)
-        $compiler->write('unset($context[\'_seq\'], $context[\'_iterated\'], $context[\''.$this->getNode('key_target')->getAttribute('name').'\'], $context[\''.$this->getNode('value_target')->getAttribute('name').'\'], $context[\'_parent\'], $context[\'loop\']);'."\n");
+        $compiler->write('unset($context[\'_seq\'], $context[\'_iterated\'], $context[\''.$this->getNode('key_target')->getAttribute('name').'\'], $context[\''.$this->getNode('value_target')->getAttribute('name').'\'], $context[\'_parent\']');
+        if ($this->getAttribute('with_loop')) {
+            $compiler->raw(', $context[\'loop\']');
+        }
+        $compiler->raw(");\n");
 
         // keep the values set in the inner context for variables defined in the outer context
         $compiler->write("\$context = array_intersect_key(\$context, \$_parent) + \$_parent;\n");

--- a/tests/Node/ForTest.php
+++ b/tests/Node/ForTest.php
@@ -62,7 +62,7 @@ foreach (\$context['_seq'] as \$context["key"] => \$context["item"]) {
     yield {$this->getVariableGetter('foo')};
 }
 \$_parent = \$context['_parent'];
-unset(\$context['_seq'], \$context['_iterated'], \$context['key'], \$context['item'], \$context['_parent'], \$context['loop']);
+unset(\$context['_seq'], \$context['_iterated'], \$context['key'], \$context['item'], \$context['_parent']);
 \$context = array_intersect_key(\$context, \$_parent) + \$_parent;
 EOF
         ];


### PR DESCRIPTION
Even though PHP does not complain, PHPStan does.
> Cannot unset offset 'loop' on array{ ... the context values ... }

Since this is compiled code, we can easily produce a bit more valid code in the eyes of PHPStan.