### PR TITLE
Add return type `isTraitable`

### DIFF
--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -115,7 +115,7 @@ final class ModuleNode extends Node
         $parent = $this->getNode('parent');
 
         $compiler
-            ->write("protected function doGetParent(array \$context)\n", "{\n")
+            ->write("protected function doGetParent(array \$context): bool|string|Template|TemplateWrapper\n", "{\n")
             ->indent()
             ->addDebugInfo($parent)
             ->write('return ')
@@ -160,7 +160,9 @@ final class ModuleNode extends Node
                 ->write("use Twig\Sandbox\SecurityNotAllowedFilterError;\n")
                 ->write("use Twig\Sandbox\SecurityNotAllowedFunctionError;\n")
                 ->write("use Twig\Source;\n")
-                ->write("use Twig\Template;\n\n")
+                ->write("use Twig\Template;\n")
+                ->write("use Twig\TemplateWrapper;\n")
+                ->write("\n")
             ;
         }
         $compiler
@@ -170,8 +172,11 @@ final class ModuleNode extends Node
             ->raw(" extends Template\n")
             ->write("{\n")
             ->indent()
-            ->write("private \$source;\n")
-            ->write("private \$macros = [];\n\n")
+            ->write("private Source \$source;\n")
+            ->write("/**\n")
+            ->write(" * @var array<string, Template>\n")
+            ->write(" */\n")
+            ->write("private array \$macros = [];\n\n")
         ;
     }
 
@@ -377,7 +382,7 @@ final class ModuleNode extends Node
             ->write("/**\n")
             ->write(" * @codeCoverageIgnore\n")
             ->write(" */\n")
-            ->write("public function getTemplateName()\n", "{\n")
+            ->write("public function getTemplateName(): string\n", "{\n")
             ->indent()
             ->write('return ')
             ->repr($this->getSourceContext()->getName())
@@ -434,7 +439,7 @@ final class ModuleNode extends Node
             ->write("/**\n")
             ->write(" * @codeCoverageIgnore\n")
             ->write(" */\n")
-            ->write("public function isTraitable()\n", "{\n")
+            ->write("public function isTraitable(): bool\n", "{\n")
             ->indent()
             ->write("return false;\n")
             ->outdent()
@@ -448,7 +453,7 @@ final class ModuleNode extends Node
             ->write("/**\n")
             ->write(" * @codeCoverageIgnore\n")
             ->write(" */\n")
-            ->write("public function getDebugInfo()\n", "{\n")
+            ->write("public function getDebugInfo(): array\n", "{\n")
             ->indent()
             ->write(\sprintf("return %s;\n", str_replace("\n", '', var_export(array_reverse($compiler->getDebugInfo(), true), true))))
             ->outdent()
@@ -459,7 +464,7 @@ final class ModuleNode extends Node
     protected function compileGetSourceContext(Compiler $compiler)
     {
         $compiler
-            ->write("public function getSourceContext()\n", "{\n")
+            ->write("public function getSourceContext(): Source\n", "{\n")
             ->indent()
             ->write('return new Source(')
             ->string($compiler->getEnvironment()->isDebug() ? $this->getSourceContext()->getCode() : '')

--- a/src/Template.php
+++ b/src/Template.php
@@ -52,24 +52,20 @@ abstract class Template
 
     /**
      * Returns the template name.
-     *
-     * @return string The template name
      */
-    abstract public function getTemplateName();
+    abstract public function getTemplateName(): string;
 
     /**
      * Returns debug information about the template.
      *
-     * @return array Debug information
+     * @return array<int, int> Debug information
      */
-    abstract public function getDebugInfo();
+    abstract public function getDebugInfo(): array;
 
     /**
      * Returns information about the original template source code.
-     *
-     * @return Source
      */
-    abstract public function getSourceContext();
+    abstract public function getSourceContext(): Source;
 
     /**
      * Returns the parent template.
@@ -107,12 +103,12 @@ abstract class Template
         return $this->parents[$parent];
     }
 
-    protected function doGetParent(array $context)
+    protected function doGetParent(array $context): bool|string|self|TemplateWrapper
     {
         return false;
     }
 
-    public function isTraitable()
+    public function isTraitable(): bool
     {
         return true;
     }

--- a/tests/Node/ModuleTest.php
+++ b/tests/Node/ModuleTest.php
@@ -23,6 +23,8 @@ use Twig\Node\Node;
 use Twig\Node\SetNode;
 use Twig\Node\TextNode;
 use Twig\Source;
+use Twig\Template;
+use Twig\TemplateWrapper;
 use Twig\Test\NodeTestCase;
 
 class ModuleTest extends NodeTestCase
@@ -73,12 +75,16 @@ use Twig\Sandbox\SecurityNotAllowedFilterError;
 use Twig\Sandbox\SecurityNotAllowedFunctionError;
 use Twig\Source;
 use Twig\Template;
+use Twig\TemplateWrapper;
 
 /* foo.twig */
 class __TwigTemplate_%x extends Template
 {
-    private \$source;
-    private \$macros = [];
+    private Source \$source;
+    /**
+     * @var array<string, Template>
+     */
+    private array \$macros = [];
 
     public function __construct(Environment \$env)
     {
@@ -103,7 +109,7 @@ class __TwigTemplate_%x extends Template
     /**
      * @codeCoverageIgnore
      */
-    public function getTemplateName()
+    public function getTemplateName(): string
     {
         return "foo.twig";
     }
@@ -111,12 +117,12 @@ class __TwigTemplate_%x extends Template
     /**
      * @codeCoverageIgnore
      */
-    public function getDebugInfo()
+    public function getDebugInfo(): array
     {
-        return array (  38 => 1,);
+        return array (  42 => 1,);
     }
 
-    public function getSourceContext()
+    public function getSourceContext(): Source
     {
         return new Source("", "foo.twig", "");
     }
@@ -145,12 +151,16 @@ use Twig\Sandbox\SecurityNotAllowedFilterError;
 use Twig\Sandbox\SecurityNotAllowedFunctionError;
 use Twig\Source;
 use Twig\Template;
+use Twig\TemplateWrapper;
 
 /* foo.twig */
 class __TwigTemplate_%x extends Template
 {
-    private \$source;
-    private \$macros = [];
+    private Source \$source;
+    /**
+     * @var array<string, Template>
+     */
+    private array \$macros = [];
 
     public function __construct(Environment \$env)
     {
@@ -162,7 +172,7 @@ class __TwigTemplate_%x extends Template
         ];
     }
 
-    protected function doGetParent(array \$context)
+    protected function doGetParent(array \$context): bool|string|Template|TemplateWrapper
     {
         // line 1
         return "layout.twig";
@@ -181,7 +191,7 @@ class __TwigTemplate_%x extends Template
     /**
      * @codeCoverageIgnore
      */
-    public function getTemplateName()
+    public function getTemplateName(): string
     {
         return "foo.twig";
     }
@@ -189,7 +199,7 @@ class __TwigTemplate_%x extends Template
     /**
      * @codeCoverageIgnore
      */
-    public function isTraitable()
+    public function isTraitable(): bool
     {
         return false;
     }
@@ -197,12 +207,12 @@ class __TwigTemplate_%x extends Template
     /**
      * @codeCoverageIgnore
      */
-    public function getDebugInfo()
+    public function getDebugInfo(): array
     {
-        return array (  44 => 1,  42 => 2,  35 => 1,);
+        return array (  48 => 1,  46 => 2,  39 => 1,);
     }
 
-    public function getSourceContext()
+    public function getSourceContext(): Source
     {
         return new Source("", "foo.twig", "");
     }
@@ -236,12 +246,16 @@ use Twig\Sandbox\SecurityNotAllowedFilterError;
 use Twig\Sandbox\SecurityNotAllowedFunctionError;
 use Twig\Source;
 use Twig\Template;
+use Twig\TemplateWrapper;
 
 /* foo.twig */
 class __TwigTemplate_%x extends Template
 {
-    private \$source;
-    private \$macros = [];
+    private Source \$source;
+    /**
+     * @var array<string, Template>
+     */
+    private array \$macros = [];
 
     public function __construct(Environment \$env)
     {
@@ -253,7 +267,7 @@ class __TwigTemplate_%x extends Template
         ];
     }
 
-    protected function doGetParent(array \$context)
+    protected function doGetParent(array \$context): bool|string|Template|TemplateWrapper
     {
         // line 2
         return \$this->loadTemplate(((true) ? ("foo") : ("foo")), "foo.twig", 2);
@@ -271,7 +285,7 @@ class __TwigTemplate_%x extends Template
     /**
      * @codeCoverageIgnore
      */
-    public function getTemplateName()
+    public function getTemplateName(): string
     {
         return "foo.twig";
     }
@@ -279,7 +293,7 @@ class __TwigTemplate_%x extends Template
     /**
      * @codeCoverageIgnore
      */
-    public function isTraitable()
+    public function isTraitable(): bool
     {
         return false;
     }
@@ -287,12 +301,12 @@ class __TwigTemplate_%x extends Template
     /**
      * @codeCoverageIgnore
      */
-    public function getDebugInfo()
+    public function getDebugInfo(): array
     {
-        return array (  44 => 2,  42 => 4,  35 => 2,);
+        return array (  48 => 2,  46 => 4,  39 => 2,);
     }
 
-    public function getSourceContext()
+    public function getSourceContext(): Source
     {
         return new Source("{{ foo }}", "foo.twig", "");
     }

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -21,6 +21,7 @@ use Twig\Sandbox\SecurityError;
 use Twig\Sandbox\SecurityPolicy;
 use Twig\Source;
 use Twig\Template;
+use Twig\TemplateWrapper;
 
 class TemplateTest extends TestCase
 {
@@ -443,22 +444,22 @@ class TemplateForTest extends Template
         return true;
     }
 
-    public function getTemplateName()
+    public function getTemplateName(): string
     {
         return $this->name;
     }
 
-    public function getDebugInfo()
+    public function getDebugInfo() : array
     {
         return [];
     }
 
-    public function getSourceContext()
+    public function getSourceContext() : Source
     {
         return new Source('', $this->getTemplateName());
     }
 
-    protected function doGetParent(array $context)
+    protected function doGetParent(array $context): bool|string|Template|TemplateWrapper
     {
         return false;
     }


### PR DESCRIPTION
I'd like to do this for more methods that are exposed in the compiled code. This will ease static analysis as there are less errors that are coming from Twig. 

This is just a first small PR to see if this is acceptable 😊 
