### PR TITLE
Unify error messages when a filter expects a mapping/sequence

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -366,7 +366,7 @@ final class CoreExtension extends AbstractExtension
         }
 
         if (!$count = \count($values)) {
-            throw new RuntimeError('The "cycle" function does not work on empty sequences.');
+            throw new RuntimeError('The "cycle" function expects a non-empty sequence.');
         }
 
         return $values[$position % $count];
@@ -436,7 +436,7 @@ final class CoreExtension extends AbstractExtension
         $values = self::toArray($values);
 
         if (0 === \count($values)) {
-            throw new RuntimeError('The "random" function cannot pick from an empty sequence/mapping.');
+            throw new RuntimeError('The "random" function cannot pick from an empty sequence or mapping.');
         }
 
         return $values[array_rand($values, 1)];
@@ -573,7 +573,7 @@ final class CoreExtension extends AbstractExtension
     public static function replace($str, $from): string
     {
         if (!is_iterable($from)) {
-            throw new RuntimeError(\sprintf('The "replace" filter expects a sequence/mapping or "Traversable" as replace values, got "%s".', get_debug_type($from)));
+            throw new RuntimeError(\sprintf('The "replace" filter expects a sequence or a mapping, got "%s".', get_debug_type($from)));
         }
 
         return strtr($str ?? '', self::toArray($from));
@@ -670,7 +670,7 @@ final class CoreExtension extends AbstractExtension
 
         foreach ($arrays as $argNumber => $array) {
             if (!is_iterable($array)) {
-                throw new RuntimeError(\sprintf('The "merge" filter only works with sequences/mappings or "Traversable", got "%s" for argument %d.', get_debug_type($array), $argNumber + 1));
+                throw new RuntimeError(\sprintf('The "merge" filter expects a sequence or a mapping, got "%s" for argument %d.', get_debug_type($array), $argNumber + 1));
             }
 
             $result = array_merge($result, self::toArray($array));
@@ -977,7 +977,7 @@ final class CoreExtension extends AbstractExtension
         if ($array instanceof \Traversable) {
             $array = iterator_to_array($array);
         } elseif (!\is_array($array)) {
-            throw new RuntimeError(\sprintf('The "sort" filter only works with sequences/mappings or "Traversable", got "%s".', get_debug_type($array)));
+            throw new RuntimeError(\sprintf('The "sort" filter expects a sequence or a mapping, got "%s".', get_debug_type($array)));
         }
 
         if (null !== $arrow) {
@@ -1577,7 +1577,7 @@ final class CoreExtension extends AbstractExtension
     public static function batch($items, $size, $fill = null, $preserveKeys = true): array
     {
         if (!is_iterable($items)) {
-            throw new RuntimeError(\sprintf('The "batch" filter expects a sequence/mapping or "Traversable", got "%s".', get_debug_type($items)));
+            throw new RuntimeError(\sprintf('The "batch" filter expects a sequence or a mapping, got "%s".', get_debug_type($items)));
         }
 
         $size = (int) ceil($size);
@@ -1824,7 +1824,7 @@ final class CoreExtension extends AbstractExtension
     public static function column($array, $name, $index = null): array
     {
         if (!is_iterable($array)) {
-            throw new RuntimeError(\sprintf('The "column" filter only works with sequences/mappings or "Traversable", got "%s" as first argument.', get_debug_type($array)));
+            throw new RuntimeError(\sprintf('The "column" filter expects a sequence or a mapping, got "%s".', get_debug_type($array)));
         }
 
         if ($array instanceof \Traversable) {
@@ -1859,7 +1859,7 @@ final class CoreExtension extends AbstractExtension
     public static function find(Environment $env, $array, $arrow)
     {
         if (!is_iterable($array)) {
-            throw new RuntimeError(\sprintf('The "find" filter expects a sequence/mapping or "Traversable", got "%s".', get_debug_type($array)));
+            throw new RuntimeError(\sprintf('The "find" filter expects a sequence or a mapping, got "%s".', get_debug_type($array)));
         }
 
         self::checkArrowInSandbox($env, $arrow, 'find', 'filter');
@@ -1879,7 +1879,7 @@ final class CoreExtension extends AbstractExtension
     public static function map(Environment $env, $array, $arrow)
     {
         if (!is_iterable($array)) {
-            throw new RuntimeError(\sprintf('The "map" filter expects a sequence/mapping or "Traversable", got "%s".', get_debug_type($array)));
+            throw new RuntimeError(\sprintf('The "map" filter expects a sequence or a mapping, got "%s".', get_debug_type($array)));
         }
 
         self::checkArrowInSandbox($env, $arrow, 'map', 'filter');
@@ -1898,7 +1898,7 @@ final class CoreExtension extends AbstractExtension
     public static function reduce(Environment $env, $array, $arrow, $initial = null)
     {
         if (!is_iterable($array)) {
-            throw new RuntimeError(\sprintf('The "reduce" filter only works with sequences/mappings or "Traversable", got "%s" as first argument.', get_debug_type($array)));
+            throw new RuntimeError(\sprintf('The "reduce" filter expects a sequence or a mapping, got "%s".', get_debug_type($array)));
         }
 
         self::checkArrowInSandbox($env, $arrow, 'reduce', 'filter');
@@ -1917,7 +1917,7 @@ final class CoreExtension extends AbstractExtension
     public static function arraySome(Environment $env, $array, $arrow)
     {
         if (!is_iterable($array)) {
-            throw new RuntimeError(\sprintf('The "has some" filter only works with sequences/mappings or "Traversable", got "%s" as first argument.', get_debug_type($array)));
+            throw new RuntimeError(\sprintf('The "has some" test expects a sequence or a mapping, got "%s".', get_debug_type($array)));
         }
 
         self::checkArrowInSandbox($env, $arrow, 'has some', 'operator');
@@ -1937,7 +1937,7 @@ final class CoreExtension extends AbstractExtension
     public static function arrayEvery(Environment $env, $array, $arrow)
     {
         if (!is_iterable($array)) {
-            throw new RuntimeError(\sprintf('The "has every" filter only works with sequences/mappings or "Traversable", got "%s" as first argument.', get_debug_type($array)));
+            throw new RuntimeError(\sprintf('The "has every" test expects a sequence or a mapping, got "%s".', get_debug_type($array)));
         }
 
         self::checkArrowInSandbox($env, $arrow, 'has every', 'operator');

--- a/tests/Fixtures/exceptions/exception_in_extension_extends.test
+++ b/tests/Fixtures/exceptions/exception_in_extension_extends.test
@@ -9,4 +9,4 @@ Exception thrown from a child for an extension error
 --DATA--
 return []
 --EXCEPTION--
-Twig\Error\RuntimeError: The "random" function cannot pick from an empty sequence/mapping in "base.twig" at line 4.
+Twig\Error\RuntimeError: The "random" function cannot pick from an empty sequence or mapping in "base.twig" at line 4.

--- a/tests/Fixtures/exceptions/exception_in_extension_include.test
+++ b/tests/Fixtures/exceptions/exception_in_extension_include.test
@@ -9,4 +9,4 @@ Exception thrown from an include for an extension error
 --DATA--
 return []
 --EXCEPTION--
-Twig\Error\RuntimeError: The "random" function cannot pick from an empty sequence/mapping in "content.twig" at line 4.
+Twig\Error\RuntimeError: The "random" function cannot pick from an empty sequence or mapping in "content.twig" at line 4.

--- a/tests/Fixtures/filters/replace_invalid_arg.test
+++ b/tests/Fixtures/filters/replace_invalid_arg.test
@@ -5,4 +5,4 @@ Exception for invalid argument type in replace call
 --DATA--
 return ['stdClass' => new \stdClass()]
 --EXCEPTION--
-Twig\Error\RuntimeError: The "replace" filter expects a sequence/mapping or "Traversable" as replace values, got "stdClass" in "index.twig" at line 2.
+Twig\Error\RuntimeError: The "replace" filter expects a sequence or a mapping, got "stdClass" in "index.twig" at line 2.

--- a/tests/Fixtures/functions/cycle_empty_mapping.test
+++ b/tests/Fixtures/functions/cycle_empty_mapping.test
@@ -5,4 +5,4 @@
 --DATA--
 return []
 --EXCEPTION--
-Twig\Error\RuntimeError: The "cycle" function does not work on empty sequences in "index.twig" at line 2.
+Twig\Error\RuntimeError: The "cycle" function expects a non-empty sequence in "index.twig" at line 2.

--- a/tests/Fixtures/functions/cycle_empty_sequence.test
+++ b/tests/Fixtures/functions/cycle_empty_sequence.test
@@ -5,4 +5,4 @@
 --DATA--
 return []
 --EXCEPTION--
-Twig\Error\RuntimeError: The "cycle" function does not work on empty sequences in "index.twig" at line 2.
+Twig\Error\RuntimeError: The "cycle" function expects a non-empty sequence in "index.twig" at line 2.


### PR DESCRIPTION
Besides unifying the error messages, I've also removed the mention of `\Traversable` as this does not help and is an implementation detail (mapping and sequence are Twig terms, Traversable is not).

Or maybe we should introduce the notion of a "iterable"?
