### PR TITLE
Switch to expectUserDeprecationMessage()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/polyfill-php81": "^1.29"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0",
+        "symfony/phpunit-bridge": "^7.2",
         "psr/container": "^1.0|^2.0"
     },
     "autoload": {

--- a/tests/ExpressionParserTest.php
+++ b/tests/ExpressionParserTest.php
@@ -12,7 +12,6 @@ namespace Twig\Tests;
  */
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Twig\Environment;
 use Twig\Error\SyntaxError;
 use Twig\Extension\AbstractExtension;
@@ -29,8 +28,6 @@ use Twig\TwigTest;
 
 class ExpressionParserTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @dataProvider getFailingTestsForAssignment
      */

--- a/tests/Extension/SandboxTest.php
+++ b/tests/Extension/SandboxTest.php
@@ -12,7 +12,6 @@ namespace Twig\Tests\Extension;
  */
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Twig\Environment;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -30,8 +29,6 @@ use Twig\Source;
 
 class SandboxTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     protected static $params;
     protected static $templates;
 

--- a/tests/Node/NodeTest.php
+++ b/tests/Node/NodeTest.php
@@ -12,7 +12,7 @@ namespace Twig\Tests\Node;
  */
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Twig\Node\NameDeprecation;
 use Twig\Node\Node;
 use Twig\TwigFilter;
@@ -21,7 +21,7 @@ use Twig\TwigTest;
 
 class NodeTest extends TestCase
 {
-    use ExpectDeprecationTrait;
+    use ExpectUserDeprecationMessageTrait;
 
     public function testToString()
     {
@@ -83,7 +83,7 @@ EOF
         $node = new Node([], ['foo' => false]);
         $node->deprecateAttribute('foo', new NameDeprecation('foo/bar', '2.0'));
 
-        $this->expectDeprecation('Since foo/bar 2.0: Getting attribute "foo" on a "Twig\Node\Node" class is deprecated.');
+        $this->expectUserDeprecationMessage('Since foo/bar 2.0: Getting attribute "foo" on a "Twig\Node\Node" class is deprecated.');
         $this->assertFalse($node->getAttribute('foo'));
     }
 
@@ -95,7 +95,7 @@ EOF
         $node = new Node([], ['foo' => false]);
         $node->deprecateAttribute('foo', new NameDeprecation('foo/bar', '2.0', 'bar'));
 
-        $this->expectDeprecation('Since foo/bar 2.0: Getting attribute "foo" on a "Twig\Node\Node" class is deprecated, get the "bar" attribute instead.');
+        $this->expectUserDeprecationMessage('Since foo/bar 2.0: Getting attribute "foo" on a "Twig\Node\Node" class is deprecated, get the "bar" attribute instead.');
         $this->assertFalse($node->getAttribute('foo'));
     }
 
@@ -115,7 +115,7 @@ EOF
         $node = new Node(['foo' => $foo = new Node()], []);
         $node->deprecateNode('foo', new NameDeprecation('foo/bar', '2.0'));
 
-        $this->expectDeprecation('Since foo/bar 2.0: Getting node "foo" on a "Twig\Node\Node" class is deprecated.');
+        $this->expectUserDeprecationMessage('Since foo/bar 2.0: Getting node "foo" on a "Twig\Node\Node" class is deprecated.');
         $this->assertSame($foo, $node->getNode('foo'));
     }
 
@@ -127,7 +127,7 @@ EOF
         $node = new Node(['foo' => $foo = new Node()], []);
         $node->deprecateNode('foo', new NameDeprecation('foo/bar', '2.0', 'bar'));
 
-        $this->expectDeprecation('Since foo/bar 2.0: Getting node "foo" on a "Twig\Node\Node" class is deprecated, get the "bar" node instead.');
+        $this->expectUserDeprecationMessage('Since foo/bar 2.0: Getting node "foo" on a "Twig\Node\Node" class is deprecated, get the "bar" node instead.');
         $this->assertSame($foo, $node->getNode('foo'));
     }
 }


### PR DESCRIPTION
This PR leverages symfony/symfony#54593. This will make it easier to switch to a vanilla PHPUnit 11 in the future.