### PR TITLE
Migrate NodeTestCase to static data providers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 # 3.13.0 (2024-XX-XX)
 
  * Add the `types` tag (experimental)
+ * Deprecate the `Twig\Test\NodeTestCase::getTests()` data provider, override `provideTests()` instead.
+ * Mark `Twig\Test\NodeTestCase::getEnvironment()` as final, override `createEnvironment()` instead.
+ * Deprecate `Twig\Test\NodeTestCase::getVariableGetter()`, call `createVariableGetter()` instead.
+ * Deprecate `Twig\Test\NodeTestCase::getAttributeGetter()`, call `createAttributeGetter()` instead.
 
 # 3.12.0 (2024-08-29)
 

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -200,3 +200,19 @@ Sandbox
 * Having the ``extends`` and ``use`` tags allowed by default in a sandbox is
   deprecated as of Twig 3.12. You will need to explicitly allow them if needed
   in 4.0.
+
+Testing Utilities
+-----------------
+
+* Implementing the data provider method ``Twig\Test\NodeTestCase::getTests()``
+  is deprecated as of Twig 3.13. Instead, implement the static data provider
+  ``provideTests()``.
+
+* In order to make their functionality available for static data providers, the
+  helper methods ``getVariableGetter()`` and ``getAttributeGetter()`` on
+  ``Twig\Test\NodeTestCase`` have been deprecated. Call the new methods
+  ``createVariableGetter()`` and ``createAttributeGetter()`` instead.
+
+* The method ``Twig\Test\NodeTestCase::getEnvironment()`` is considered final
+  as of Twig 3.13. If you want to override how the Twig environment is
+  constructed, override ``createEnvironment()`` instead.

--- a/src/Test/NodeTestCase.php
+++ b/src/Test/NodeTestCase.php
@@ -11,6 +11,8 @@
 
 namespace Twig\Test;
 
+use PHPUnit\Framework\Attributes\BeforeClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Twig\Compiler;
 use Twig\Environment;
@@ -24,11 +26,26 @@ abstract class NodeTestCase extends TestCase
      */
     private $currentEnv;
 
-    abstract public function getTests();
+    public function getTests()
+    {
+        return [];
+    }
+
+    /**
+     * @return iterable<array{0: Node, 1: string, 2?: Environment|null, 3?: bool}>
+     */
+    public static function provideTests(): iterable
+    {
+        trigger_deprecation('twig/twig', '3.13', 'Not implementing "%s()" in "%s" is deprecated. This method will be abstract in 4.0.', __METHOD__, static::class);
+
+        return [];
+    }
 
     /**
      * @dataProvider getTests
+     * @dataProvider provideTests
      */
+    #[DataProvider('getTests'), DataProvider('provideTests')]
     public function testCompile($node, $source, $environment = null, $isPattern = false)
     {
         $this->assertNodeCompilation($source, $node, $environment, $isPattern);
@@ -51,24 +68,58 @@ abstract class NodeTestCase extends TestCase
         return new Compiler($environment ?? $this->getEnvironment());
     }
 
+    /**
+     * @final since Twig 3.13
+     */
     protected function getEnvironment()
     {
-        if (!$this->currentEnv) {
-            $this->currentEnv = new Environment(new ArrayLoader());
-        }
-
-        return $this->currentEnv;
+        return $this->currentEnv ??= static::createEnvironment();
     }
 
+    protected static function createEnvironment(): Environment
+    {
+        return new Environment(new ArrayLoader());
+    }
+
+    /**
+     * @deprecated since Twig 3.13, use createVariableGetter() instead.
+     */
     protected function getVariableGetter($name, $line = false)
+    {
+        trigger_deprecation('twig/twig', '3.13', 'Method "%s()" is deprecated, use "createVariableGetter()" instead.', __METHOD__);
+
+        return self::createVariableGetter($name, $line);
+    }
+
+    final protected static function createVariableGetter(string $name, bool $line = false): string
     {
         $line = $line > 0 ? "// line $line\n" : '';
 
         return \sprintf('%s($context["%s"] ?? null)', $line, $name);
     }
 
+    /**
+     * @deprecated since Twig 3.13, use createAttributeGetter() instead.
+     */
     protected function getAttributeGetter()
     {
+        trigger_deprecation('twig/twig', '3.13', 'Method "%s()" is deprecated, use "createAttributeGetter()" instead.', __METHOD__);
+
+        return self::createAttributeGetter();
+    }
+
+    final protected static function createAttributeGetter(): string
+    {
         return 'CoreExtension::getAttribute($this->env, $this->source, ';
+    }
+
+    /** @beforeClass */
+    #[BeforeClass]
+    final public static function checkDataProvider(): void
+    {
+        $r = new \ReflectionMethod(static::class, 'getTests');
+        if ($r->getDeclaringClass()->getName() !== self::class) {
+            trigger_deprecation('twig/twig', '3.13', 'Implementing "%s::getTests()" in "%s" is deprecated, implement "provideTests()" instead.', self::class, static::class);
+        }
     }
 }

--- a/tests/Node/AutoEscapeTest.php
+++ b/tests/Node/AutoEscapeTest.php
@@ -27,7 +27,7 @@ class AutoEscapeTest extends NodeTestCase
         $this->assertTrue($node->getAttribute('value'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $body = new Node([new TextNode('foo', 1)]);
         $node = new AutoEscapeNode(true, $body, 1);

--- a/tests/Node/BlockReferenceTest.php
+++ b/tests/Node/BlockReferenceTest.php
@@ -23,7 +23,7 @@ class BlockReferenceTest extends NodeTestCase
         $this->assertEquals('foo', $node->getAttribute('name'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         return [
             [new BlockReferenceNode('foo', 1), <<<'EOF'

--- a/tests/Node/BlockTest.php
+++ b/tests/Node/BlockTest.php
@@ -28,7 +28,7 @@ class BlockTest extends NodeTestCase
         $this->assertEquals('foo', $node->getAttribute('name'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
         $tests[] = [new BlockNode('foo', new TextNode('foo', 1), 1), <<<EOF

--- a/tests/Node/DeprecatedTest.php
+++ b/tests/Node/DeprecatedTest.php
@@ -11,6 +11,7 @@ namespace Twig\Tests\Node;
  * file that was distributed with this source code.
  */
 
+use Twig\Compiler;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\Node\DeprecatedNode;
@@ -32,7 +33,7 @@ class DeprecatedTest extends NodeTestCase
         $this->assertEquals($expr, $node->getNode('expr'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
 
@@ -75,7 +76,7 @@ EOF
         $node->setNode('package', new ConstantExpression('twig/twig', 1));
         $node->setNode('version', new ConstantExpression('1.1', 1));
 
-        $compiler = $this->getCompiler($environment);
+        $compiler = new Compiler($environment);
         $varName = $compiler->getVarName();
 
         $tests[] = [$node, <<<EOF

--- a/tests/Node/DoTest.php
+++ b/tests/Node/DoTest.php
@@ -25,7 +25,7 @@ class DoTest extends NodeTestCase
         $this->assertEquals($expr, $node->getNode('expr'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
 

--- a/tests/Node/Expression/ArrayTest.php
+++ b/tests/Node/Expression/ArrayTest.php
@@ -25,7 +25,7 @@ class ArrayTest extends NodeTestCase
         $this->assertEquals($foo, $node->getNode('1'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $elements = [
             new ConstantExpression('foo', 1),

--- a/tests/Node/Expression/AssignNameTest.php
+++ b/tests/Node/Expression/AssignNameTest.php
@@ -23,7 +23,7 @@ class AssignNameTest extends NodeTestCase
         $this->assertEquals('foo', $node->getAttribute('name'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $node = new AssignNameExpression('foo', 1);
 

--- a/tests/Node/Expression/Binary/AddTest.php
+++ b/tests/Node/Expression/Binary/AddTest.php
@@ -27,7 +27,7 @@ class AddTest extends NodeTestCase
         $this->assertEquals($right, $node->getNode('right'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $left = new ConstantExpression(1, 1);
         $right = new ConstantExpression(2, 1);

--- a/tests/Node/Expression/Binary/AndTest.php
+++ b/tests/Node/Expression/Binary/AndTest.php
@@ -27,7 +27,7 @@ class AndTest extends NodeTestCase
         $this->assertEquals($right, $node->getNode('right'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $left = new ConstantExpression(1, 1);
         $right = new ConstantExpression(2, 1);

--- a/tests/Node/Expression/Binary/ConcatTest.php
+++ b/tests/Node/Expression/Binary/ConcatTest.php
@@ -27,7 +27,7 @@ class ConcatTest extends NodeTestCase
         $this->assertEquals($right, $node->getNode('right'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $left = new ConstantExpression(1, 1);
         $right = new ConstantExpression(2, 1);

--- a/tests/Node/Expression/Binary/DivTest.php
+++ b/tests/Node/Expression/Binary/DivTest.php
@@ -27,7 +27,7 @@ class DivTest extends NodeTestCase
         $this->assertEquals($right, $node->getNode('right'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $left = new ConstantExpression(1, 1);
         $right = new ConstantExpression(2, 1);

--- a/tests/Node/Expression/Binary/FloorDivTest.php
+++ b/tests/Node/Expression/Binary/FloorDivTest.php
@@ -27,7 +27,7 @@ class FloorDivTest extends NodeTestCase
         $this->assertEquals($right, $node->getNode('right'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $left = new ConstantExpression(1, 1);
         $right = new ConstantExpression(2, 1);

--- a/tests/Node/Expression/Binary/ModTest.php
+++ b/tests/Node/Expression/Binary/ModTest.php
@@ -27,7 +27,7 @@ class ModTest extends NodeTestCase
         $this->assertEquals($right, $node->getNode('right'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $left = new ConstantExpression(1, 1);
         $right = new ConstantExpression(2, 1);

--- a/tests/Node/Expression/Binary/MulTest.php
+++ b/tests/Node/Expression/Binary/MulTest.php
@@ -27,7 +27,7 @@ class MulTest extends NodeTestCase
         $this->assertEquals($right, $node->getNode('right'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $left = new ConstantExpression(1, 1);
         $right = new ConstantExpression(2, 1);

--- a/tests/Node/Expression/Binary/OrTest.php
+++ b/tests/Node/Expression/Binary/OrTest.php
@@ -27,7 +27,7 @@ class OrTest extends NodeTestCase
         $this->assertEquals($right, $node->getNode('right'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $left = new ConstantExpression(1, 1);
         $right = new ConstantExpression(2, 1);

--- a/tests/Node/Expression/Binary/SubTest.php
+++ b/tests/Node/Expression/Binary/SubTest.php
@@ -27,7 +27,7 @@ class SubTest extends NodeTestCase
         $this->assertEquals($right, $node->getNode('right'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $left = new ConstantExpression(1, 1);
         $right = new ConstantExpression(2, 1);

--- a/tests/Node/Expression/ConditionalTest.php
+++ b/tests/Node/Expression/ConditionalTest.php
@@ -29,7 +29,7 @@ class ConditionalTest extends NodeTestCase
         $this->assertEquals($expr3, $node->getNode('expr3'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
 

--- a/tests/Node/Expression/ConstantTest.php
+++ b/tests/Node/Expression/ConstantTest.php
@@ -23,7 +23,7 @@ class ConstantTest extends NodeTestCase
         $this->assertEquals('foo', $node->getAttribute('value'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
 

--- a/tests/Node/Expression/Filter/RawTest.php
+++ b/tests/Node/Expression/Filter/RawTest.php
@@ -28,7 +28,7 @@ class RawTest extends NodeTestCase
         $this->assertCount(0, $filter->getNode('arguments'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $node = new RawFilter(new ConstantExpression('foo', 12));
 

--- a/tests/Node/Expression/FilterTest.php
+++ b/tests/Node/Expression/FilterTest.php
@@ -23,8 +23,6 @@ use Twig\TwigFilter;
 
 class FilterTest extends NodeTestCase
 {
-    private $extension = null;
-
     public function testConstructor()
     {
         $expr = new ConstantExpression('foo', 1);
@@ -37,26 +35,21 @@ class FilterTest extends NodeTestCase
         $this->assertEquals($args, $node->getNode('arguments'));
     }
 
-    protected function tearDown(): void
+    public static function provideTests(): iterable
     {
-        $this->extension = null;
-    }
-
-    public function getTests()
-    {
-        $environment = $this->getEnvironment();
+        $environment = static::createEnvironment();
 
         $tests = [];
 
         $expr = new ConstantExpression('foo', 1);
-        $node = $this->createFilter($environment, $expr, 'upper');
-        $node = $this->createFilter($environment, $node, 'number_format', [new ConstantExpression(2, 1), new ConstantExpression('.', 1), new ConstantExpression(',', 1)]);
+        $node = self::createFilter($environment, $expr, 'upper');
+        $node = self::createFilter($environment, $node, 'number_format', [new ConstantExpression(2, 1), new ConstantExpression('.', 1), new ConstantExpression(',', 1)]);
 
         $tests[] = [$node, '$this->extensions[\'Twig\Extension\CoreExtension\']->formatNumber(Twig\Extension\CoreExtension::upper($this->env->getCharset(), "foo"), 2, ".", ",")'];
 
         // named arguments
         $date = new ConstantExpression(0, 1);
-        $node = $this->createFilter($environment, $date, 'date', [
+        $node = self::createFilter($environment, $date, 'date', [
             'timezone' => new ConstantExpression('America/Chicago', 1),
             'format' => new ConstantExpression('d/m/Y H:i:s P', 1),
         ]);
@@ -64,55 +57,55 @@ class FilterTest extends NodeTestCase
 
         // skip an optional argument
         $date = new ConstantExpression(0, 1);
-        $node = $this->createFilter($environment, $date, 'date', [
+        $node = self::createFilter($environment, $date, 'date', [
             'timezone' => new ConstantExpression('America/Chicago', 1),
         ]);
         $tests[] = [$node, '$this->extensions[\'Twig\Extension\CoreExtension\']->formatDate(0, null, "America/Chicago")'];
 
         // underscores vs camelCase for named arguments
         $string = new ConstantExpression('abc', 1);
-        $node = $this->createFilter($environment, $string, 'reverse', [
+        $node = self::createFilter($environment, $string, 'reverse', [
             'preserve_keys' => new ConstantExpression(true, 1),
         ]);
         $tests[] = [$node, 'Twig\Extension\CoreExtension::reverse($this->env->getCharset(), "abc", true)'];
-        $node = $this->createFilter($environment, $string, 'reverse', [
+        $node = self::createFilter($environment, $string, 'reverse', [
             'preserveKeys' => new ConstantExpression(true, 1),
         ]);
         $tests[] = [$node, 'Twig\Extension\CoreExtension::reverse($this->env->getCharset(), "abc", true)'];
 
         // filter as an anonymous function
-        $node = $this->createFilter($environment, new ConstantExpression('foo', 1), 'anonymous');
+        $node = self::createFilter($environment, new ConstantExpression('foo', 1), 'anonymous');
         $tests[] = [$node, '$this->env->getFilter(\'anonymous\')->getCallable()("foo")'];
 
         // needs environment
-        $node = $this->createFilter($environment, $string, 'bar');
+        $node = self::createFilter($environment, $string, 'bar');
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_filter_dummy($this->env, "abc")', $environment];
 
-        $node = $this->createFilter($environment, $string, 'bar_closure');
+        $node = self::createFilter($environment, $string, 'bar_closure');
         $tests[] = [$node, twig_tests_filter_dummy::class.'($this->env, "abc")', $environment];
 
-        $node = $this->createFilter($environment, $string, 'bar', [new ConstantExpression('bar', 1)]);
+        $node = self::createFilter($environment, $string, 'bar', [new ConstantExpression('bar', 1)]);
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_filter_dummy($this->env, "abc", "bar")', $environment];
 
         // arbitrary named arguments
-        $node = $this->createFilter($environment, $string, 'barbar');
+        $node = self::createFilter($environment, $string, 'barbar');
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_filter_barbar($context, "abc")', $environment];
 
-        $node = $this->createFilter($environment, $string, 'barbar', ['foo' => new ConstantExpression('bar', 1)]);
+        $node = self::createFilter($environment, $string, 'barbar', ['foo' => new ConstantExpression('bar', 1)]);
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_filter_barbar($context, "abc", null, null, ["foo" => "bar"])', $environment];
 
-        $node = $this->createFilter($environment, $string, 'barbar', ['arg2' => new ConstantExpression('bar', 1)]);
+        $node = self::createFilter($environment, $string, 'barbar', ['arg2' => new ConstantExpression('bar', 1)]);
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_filter_barbar($context, "abc", null, "bar")', $environment];
 
         if (\PHP_VERSION_ID >= 80111) {
-            $node = $this->createFilter($environment, $string, 'first_class_callable_static');
+            $node = self::createFilter($environment, $string, 'first_class_callable_static');
             $tests[] = [$node, 'Twig\Tests\Node\Expression\FilterTestExtension::staticMethod("abc")', $environment];
 
-            $node = $this->createFilter($environment, $string, 'first_class_callable_object');
+            $node = self::createFilter($environment, $string, 'first_class_callable_object');
             $tests[] = [$node, '$this->extensions[\'Twig\Tests\Node\Expression\FilterTestExtension\']->objectMethod("abc")', $environment];
         }
 
-        $node = $this->createFilter($environment, $string, 'barbar', [
+        $node = self::createFilter($environment, $string, 'barbar', [
             new ConstantExpression('1', 1),
             new ConstantExpression('2', 1),
             new ConstantExpression('3', 1),
@@ -121,13 +114,13 @@ class FilterTest extends NodeTestCase
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_filter_barbar($context, "abc", "1", "2", ["3", "foo" => "bar"])', $environment];
 
         // from extension
-        $node = $this->createFilter($environment, $string, 'foo');
-        $tests[] = [$node, \sprintf('$this->extensions[\'%s\']->foo("abc")', \get_class($this->getExtension())), $environment];
+        $node = self::createFilter($environment, $string, 'foo');
+        $tests[] = [$node, \sprintf('$this->extensions[\'%s\']->foo("abc")', \get_class(self::createExtension())), $environment];
 
-        $node = $this->createFilter($environment, $string, 'foobar');
+        $node = self::createFilter($environment, $string, 'foobar');
         $tests[] = [$node, '$this->env->getFilter(\'foobar\')->getCallable()("abc")', $environment];
 
-        $node = $this->createFilter($environment, $string, 'magic_static');
+        $node = self::createFilter($environment, $string, 'magic_static');
         $tests[] = [$node, 'Twig\Tests\Node\Expression\ChildMagicCallStub::magicStaticCall("abc")', $environment];
 
         return $tests;
@@ -161,12 +154,12 @@ class FilterTest extends NodeTestCase
         $compiler->compile($node);
     }
 
-    protected function createFilter(Environment $env, $node, $name, array $arguments = [])
+    private static function createFilter(Environment $env, $node, $name, array $arguments = []): FilterExpression
     {
         return new FilterExpression($node, $env->getFilter($name), new Node($arguments), 1);
     }
 
-    protected function getEnvironment()
+    protected static function createEnvironment(): Environment
     {
         $env = new Environment(new ArrayLoader());
         $env->addFilter(new TwigFilter('anonymous', function () {}));
@@ -177,18 +170,14 @@ class FilterTest extends NodeTestCase
         if (\PHP_VERSION_ID >= 80111) {
             $env->addExtension(new FilterTestExtension());
         }
-        $env->addExtension($this->getExtension());
+        $env->addExtension(self::createExtension());
 
         return $env;
     }
 
-    private function getExtension()
+    private static function createExtension(): AbstractExtension
     {
-        if ($this->extension) {
-            return $this->extension;
-        }
-
-        return $this->extension = new class() extends AbstractExtension {
+        return new class extends AbstractExtension {
             public function getFilters(): array
             {
                 return [

--- a/tests/Node/Expression/FunctionTest.php
+++ b/tests/Node/Expression/FunctionTest.php
@@ -31,57 +31,57 @@ class FunctionTest extends NodeTestCase
         $this->assertEquals($args, $node->getNode('arguments'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
-        $environment = $this->getEnvironment();
+        $environment = static::createEnvironment();
 
         $tests = [];
 
-        $node = $this->createFunction($environment, 'foo');
+        $node = self::createFunction($environment, 'foo');
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_dummy()', $environment];
 
-        $node = $this->createFunction($environment, 'foo_closure');
+        $node = self::createFunction($environment, 'foo_closure');
         $tests[] = [$node, twig_tests_function_dummy::class.'()', $environment];
 
-        $node = $this->createFunction($environment, 'foo', [new ConstantExpression('bar', 1), new ConstantExpression('foobar', 1)]);
+        $node = self::createFunction($environment, 'foo', [new ConstantExpression('bar', 1), new ConstantExpression('foobar', 1)]);
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_dummy("bar", "foobar")', $environment];
 
-        $node = $this->createFunction($environment, 'bar');
+        $node = self::createFunction($environment, 'bar');
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_dummy($this->env)', $environment];
 
-        $node = $this->createFunction($environment, 'bar', [new ConstantExpression('bar', 1)]);
+        $node = self::createFunction($environment, 'bar', [new ConstantExpression('bar', 1)]);
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_dummy($this->env, "bar")', $environment];
 
-        $node = $this->createFunction($environment, 'foofoo');
+        $node = self::createFunction($environment, 'foofoo');
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_dummy($context)', $environment];
 
-        $node = $this->createFunction($environment, 'foofoo', [new ConstantExpression('bar', 1)]);
+        $node = self::createFunction($environment, 'foofoo', [new ConstantExpression('bar', 1)]);
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_dummy($context, "bar")', $environment];
 
-        $node = $this->createFunction($environment, 'foobar');
+        $node = self::createFunction($environment, 'foobar');
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_dummy($this->env, $context)', $environment];
 
-        $node = $this->createFunction($environment, 'foobar', [new ConstantExpression('bar', 1)]);
+        $node = self::createFunction($environment, 'foobar', [new ConstantExpression('bar', 1)]);
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_dummy($this->env, $context, "bar")', $environment];
 
         // named arguments
-        $node = $this->createFunction($environment, 'date', [
+        $node = self::createFunction($environment, 'date', [
             'timezone' => new ConstantExpression('America/Chicago', 1),
             'date' => new ConstantExpression(0, 1),
         ]);
         $tests[] = [$node, '$this->extensions[\'Twig\Extension\CoreExtension\']->convertDate(0, "America/Chicago")'];
 
         // arbitrary named arguments
-        $node = $this->createFunction($environment, 'barbar');
+        $node = self::createFunction($environment, 'barbar');
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_barbar()', $environment];
 
-        $node = $this->createFunction($environment, 'barbar', ['foo' => new ConstantExpression('bar', 1)]);
+        $node = self::createFunction($environment, 'barbar', ['foo' => new ConstantExpression('bar', 1)]);
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_barbar(null, null, ["foo" => "bar"])', $environment];
 
-        $node = $this->createFunction($environment, 'barbar', ['arg2' => new ConstantExpression('bar', 1)]);
+        $node = self::createFunction($environment, 'barbar', ['arg2' => new ConstantExpression('bar', 1)]);
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_barbar(null, "bar")', $environment];
 
-        $node = $this->createFunction($environment, 'barbar', [
+        $node = self::createFunction($environment, 'barbar', [
             new ConstantExpression('1', 1),
             new ConstantExpression('2', 1),
             new ConstantExpression('3', 1),
@@ -90,18 +90,18 @@ class FunctionTest extends NodeTestCase
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_function_barbar("1", "2", ["3", "foo" => "bar"])', $environment];
 
         // function as an anonymous function
-        $node = $this->createFunction($environment, 'anonymous', [new ConstantExpression('foo', 1)]);
+        $node = self::createFunction($environment, 'anonymous', [new ConstantExpression('foo', 1)]);
         $tests[] = [$node, '$this->env->getFunction(\'anonymous\')->getCallable()("foo")'];
 
         return $tests;
     }
 
-    protected function createFunction(Environment $env, $name, array $arguments = [])
+    private static function createFunction(Environment $env, $name, array $arguments = []): FunctionExpression
     {
         return new FunctionExpression($env->getFunction($name), new Node($arguments), 1);
     }
 
-    protected function getEnvironment()
+    protected static function createEnvironment(): Environment
     {
         $env = new Environment(new ArrayLoader());
         $env->addFunction(new TwigFunction('anonymous', function () {}));

--- a/tests/Node/Expression/GetAttrTest.php
+++ b/tests/Node/Expression/GetAttrTest.php
@@ -35,7 +35,7 @@ class GetAttrTest extends NodeTestCase
         $this->assertEquals(Template::ARRAY_CALL, $node->getAttribute('type'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
 
@@ -43,7 +43,7 @@ class GetAttrTest extends NodeTestCase
         $attr = new ConstantExpression('bar', 1);
         $args = new ArrayExpression([], 1);
         $node = new GetAttrExpression($expr, $attr, $args, Template::ANY_CALL, 1);
-        $tests[] = [$node, \sprintf('%s%s, "bar", [], "any", false, false, false, 1)', $this->getAttributeGetter(), $this->getVariableGetter('foo', 1))];
+        $tests[] = [$node, \sprintf('%s%s, "bar", [], "any", false, false, false, 1)', self::createAttributeGetter(), self::createVariableGetter('foo', 1))];
 
         $node = new GetAttrExpression($expr, $attr, $args, Template::ARRAY_CALL, 1);
         $tests[] = [$node, '(($__internal_%s = // line 1'."\n".
@@ -53,7 +53,7 @@ class GetAttrTest extends NodeTestCase
         $args->addElement(new NameExpression('foo', 1));
         $args->addElement(new ConstantExpression('bar', 1));
         $node = new GetAttrExpression($expr, $attr, $args, Template::METHOD_CALL, 1);
-        $tests[] = [$node, \sprintf('%s%s, "bar", [%s, "bar"], "method", false, false, false, 1)', $this->getAttributeGetter(), $this->getVariableGetter('foo', 1), $this->getVariableGetter('foo'))];
+        $tests[] = [$node, \sprintf('%s%s, "bar", [%s, "bar"], "method", false, false, false, 1)', self::createAttributeGetter(), self::createVariableGetter('foo', 1), self::createVariableGetter('foo'))];
 
         return $tests;
     }

--- a/tests/Node/Expression/NameTest.php
+++ b/tests/Node/Expression/NameTest.php
@@ -25,7 +25,7 @@ class NameTest extends NodeTestCase
         $this->assertEquals('foo', $node->getAttribute('name'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $node = new NameExpression('foo', 1);
         $self = new NameExpression('_self', 1);
@@ -38,7 +38,7 @@ class NameTest extends NodeTestCase
 
         return [
             [$node, "// line 1\n".$output, $env],
-            [$node, $this->getVariableGetter('foo', 1), $env1],
+            [$node, self::createVariableGetter('foo', 1), $env1],
             [$self, "// line 1\n\$this->getTemplateName()"],
             [$context, "// line 1\n\$context"],
         ];

--- a/tests/Node/Expression/NullCoalesceTest.php
+++ b/tests/Node/Expression/NullCoalesceTest.php
@@ -18,7 +18,7 @@ use Twig\Test\NodeTestCase;
 
 class NullCoalesceTest extends NodeTestCase
 {
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $left = new NameExpression('foo', 1);
         $right = new ConstantExpression(2, 1);

--- a/tests/Node/Expression/ParentTest.php
+++ b/tests/Node/Expression/ParentTest.php
@@ -23,7 +23,7 @@ class ParentTest extends NodeTestCase
         $this->assertEquals('foo', $node->getAttribute('name'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
         $tests[] = [new ParentExpression('foo', 1), '$this->renderParentBlock("foo", $context, $blocks)'];

--- a/tests/Node/Expression/TestTest.php
+++ b/tests/Node/Expression/TestTest.php
@@ -34,32 +34,32 @@ class TestTest extends NodeTestCase
         $this->assertEquals($name, $node->getAttribute('name'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
-        $environment = $this->getEnvironment();
+        $environment = static::createEnvironment();
 
         $tests = [];
 
         $expr = new ConstantExpression('foo', 1);
-        $node = new NullTest($expr, $this->getEnvironment()->getTest('null'), new Node([]), 1);
+        $node = new NullTest($expr, $environment->getTest('null'), new Node([]), 1);
         $tests[] = [$node, '(null === "foo")'];
 
         // test as an anonymous function
-        $node = $this->createTest($environment, new ConstantExpression('foo', 1), 'anonymous', [new ConstantExpression('foo', 1)]);
+        $node = self::createTest($environment, new ConstantExpression('foo', 1), 'anonymous', [new ConstantExpression('foo', 1)]);
         $tests[] = [$node, '$this->env->getTest(\'anonymous\')->getCallable()("foo", "foo")'];
 
         // arbitrary named arguments
         $string = new ConstantExpression('abc', 1);
-        $node = $this->createTest($environment, $string, 'barbar');
+        $node = self::createTest($environment, $string, 'barbar');
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_test_barbar("abc")', $environment];
 
-        $node = $this->createTest($environment, $string, 'barbar', ['foo' => new ConstantExpression('bar', 1)]);
+        $node = self::createTest($environment, $string, 'barbar', ['foo' => new ConstantExpression('bar', 1)]);
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_test_barbar("abc", null, null, ["foo" => "bar"])', $environment];
 
-        $node = $this->createTest($environment, $string, 'barbar', ['arg2' => new ConstantExpression('bar', 1)]);
+        $node = self::createTest($environment, $string, 'barbar', ['arg2' => new ConstantExpression('bar', 1)]);
         $tests[] = [$node, 'Twig\Tests\Node\Expression\twig_tests_test_barbar("abc", null, "bar")', $environment];
 
-        $node = $this->createTest($environment, $string, 'barbar', [
+        $node = self::createTest($environment, $string, 'barbar', [
             new ConstantExpression('1', 1),
             new ConstantExpression('2', 1),
             new ConstantExpression('3', 1),
@@ -70,12 +70,12 @@ class TestTest extends NodeTestCase
         return $tests;
     }
 
-    protected function createTest(Environment $env, $node, $name, array $arguments = [])
+    private static function createTest(Environment $env, $node, $name, array $arguments = []): TestExpression
     {
         return new TestExpression($node, $env->getTest($name), new Node($arguments), 1);
     }
 
-    protected function getEnvironment()
+    protected static function createEnvironment(): Environment
     {
         $env = new Environment(new ArrayLoader());
         $env->addTest(new TwigTest('anonymous', function () {}));

--- a/tests/Node/Expression/Unary/NegTest.php
+++ b/tests/Node/Expression/Unary/NegTest.php
@@ -25,7 +25,7 @@ class NegTest extends NodeTestCase
         $this->assertEquals($expr, $node->getNode('node'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $node = new ConstantExpression(1, 1);
         $node = new NegUnary($node, 1);

--- a/tests/Node/Expression/Unary/NotTest.php
+++ b/tests/Node/Expression/Unary/NotTest.php
@@ -25,7 +25,7 @@ class NotTest extends NodeTestCase
         $this->assertEquals($expr, $node->getNode('node'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $node = new ConstantExpression(1, 1);
         $node = new NotUnary($node, 1);

--- a/tests/Node/Expression/Unary/PosTest.php
+++ b/tests/Node/Expression/Unary/PosTest.php
@@ -25,7 +25,7 @@ class PosTest extends NodeTestCase
         $this->assertEquals($expr, $node->getNode('node'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $node = new ConstantExpression(1, 1);
         $node = new PosUnary($node, 1);

--- a/tests/Node/ForTest.php
+++ b/tests/Node/ForTest.php
@@ -42,7 +42,7 @@ class ForTest extends NodeTestCase
         $this->assertEquals($else, $node->getNode('else'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
 
@@ -54,12 +54,16 @@ class ForTest extends NodeTestCase
         $node = new ForNode($keyTarget, $valueTarget, $seq, null, $body, $else, 1);
         $node->setAttribute('with_loop', false);
 
+        $itemsGetter = self::createVariableGetter('items');
+        $fooGetter = self::createVariableGetter('foo');
+        $valuesGetter = self::createVariableGetter('values');
+
         $tests[] = [$node, <<<EOF
 // line 1
 \$context['_parent'] = \$context;
-\$context['_seq'] = CoreExtension::ensureTraversable({$this->getVariableGetter('items')});
+\$context['_seq'] = CoreExtension::ensureTraversable($itemsGetter);
 foreach (\$context['_seq'] as \$context["key"] => \$context["item"]) {
-    yield {$this->getVariableGetter('foo')};
+    yield $fooGetter;
 }
 \$_parent = \$context['_parent'];
 unset(\$context['_seq'], \$context['key'], \$context['item'], \$context['_parent']);
@@ -78,7 +82,7 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$context['_parent'] = \$context;
-\$context['_seq'] = CoreExtension::ensureTraversable({$this->getVariableGetter('values')});
+\$context['_seq'] = CoreExtension::ensureTraversable($valuesGetter);
 \$context['loop'] = [
   'parent' => \$context['_parent'],
   'index0' => 0,
@@ -93,7 +97,7 @@ if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_
     \$context['loop']['last'] = 1 === \$length;
 }
 foreach (\$context['_seq'] as \$context["k"] => \$context["v"]) {
-    yield {$this->getVariableGetter('foo')};
+    yield $fooGetter;
     ++\$context['loop']['index0'];
     ++\$context['loop']['index'];
     \$context['loop']['first'] = false;
@@ -120,7 +124,7 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$context['_parent'] = \$context;
-\$context['_seq'] = CoreExtension::ensureTraversable({$this->getVariableGetter('values')});
+\$context['_seq'] = CoreExtension::ensureTraversable($valuesGetter);
 \$context['loop'] = [
   'parent' => \$context['_parent'],
   'index0' => 0,
@@ -135,7 +139,7 @@ if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_
     \$context['loop']['last'] = 1 === \$length;
 }
 foreach (\$context['_seq'] as \$context["k"] => \$context["v"]) {
-    yield {$this->getVariableGetter('foo')};
+    yield $fooGetter;
     ++\$context['loop']['index0'];
     ++\$context['loop']['index'];
     \$context['loop']['first'] = false;
@@ -162,7 +166,7 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$context['_parent'] = \$context;
-\$context['_seq'] = CoreExtension::ensureTraversable({$this->getVariableGetter('values')});
+\$context['_seq'] = CoreExtension::ensureTraversable($valuesGetter);
 \$context['_iterated'] = false;
 \$context['loop'] = [
   'parent' => \$context['_parent'],
@@ -178,7 +182,7 @@ if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_
     \$context['loop']['last'] = 1 === \$length;
 }
 foreach (\$context['_seq'] as \$context["k"] => \$context["v"]) {
-    yield {$this->getVariableGetter('foo')};
+    yield $fooGetter;
     \$context['_iterated'] = true;
     ++\$context['loop']['index0'];
     ++\$context['loop']['index'];
@@ -190,7 +194,7 @@ foreach (\$context['_seq'] as \$context["k"] => \$context["v"]) {
     }
 }
 if (!\$context['_iterated']) {
-    yield {$this->getVariableGetter('foo')};
+    yield $fooGetter;
 }
 \$_parent = \$context['_parent'];
 unset(\$context['_seq'], \$context['k'], \$context['v'], \$context['_parent'], \$context['_iterated'], \$context['loop']);

--- a/tests/Node/IfTest.php
+++ b/tests/Node/IfTest.php
@@ -37,7 +37,7 @@ class IfTest extends NodeTestCase
         $this->assertEquals($else, $node->getNode('else'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
 
@@ -48,10 +48,13 @@ class IfTest extends NodeTestCase
         $else = null;
         $node = new IfNode($t, $else, 1);
 
+        $fooGetter = self::createVariableGetter('foo');
+        $barGetter = self::createVariableGetter('bar');
+
         $tests[] = [$node, <<<EOF
 // line 1
 if (true) {
-    yield {$this->getVariableGetter('foo')};
+    yield $fooGetter;
 }
 EOF
         ];
@@ -68,9 +71,9 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 if (true) {
-    yield {$this->getVariableGetter('foo')};
+    yield $fooGetter;
 } elseif (false) {
-    yield {$this->getVariableGetter('bar')};
+    yield $barGetter;
 }
 EOF
         ];
@@ -85,9 +88,9 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 if (true) {
-    yield {$this->getVariableGetter('foo')};
+    yield $fooGetter;
 } else {
-    yield {$this->getVariableGetter('bar')};
+    yield $barGetter;
 }
 EOF
         ];

--- a/tests/Node/ImportTest.php
+++ b/tests/Node/ImportTest.php
@@ -28,7 +28,7 @@ class ImportTest extends NodeTestCase
         $this->assertEquals($var, $node->getNode('var'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
 

--- a/tests/Node/IncludeTest.php
+++ b/tests/Node/IncludeTest.php
@@ -34,7 +34,7 @@ class IncludeTest extends NodeTestCase
         $this->assertTrue($node->getAttribute('only'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
 

--- a/tests/Node/MacroTest.php
+++ b/tests/Node/MacroTest.php
@@ -34,7 +34,7 @@ class MacroTest extends NodeTestCase
         $this->assertEquals('foo', $node->getAttribute('name'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $arguments = new Node([
             'foo' => new ConstantExpression(null, 1),

--- a/tests/Node/ModuleTest.php
+++ b/tests/Node/ModuleTest.php
@@ -23,8 +23,6 @@ use Twig\Node\Node;
 use Twig\Node\SetNode;
 use Twig\Node\TextNode;
 use Twig\Source;
-use Twig\Template;
-use Twig\TemplateWrapper;
 use Twig\Test\NodeTestCase;
 
 class ModuleTest extends NodeTestCase
@@ -46,7 +44,7 @@ class ModuleTest extends NodeTestCase
         $this->assertEquals($source->getName(), $node->getTemplateName());
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $twig = new Environment(new ArrayLoader(['foo.twig' => '{{ foo }}']));
 

--- a/tests/Node/PrintTest.php
+++ b/tests/Node/PrintTest.php
@@ -28,7 +28,7 @@ class PrintTest extends NodeTestCase
         $this->assertEquals($expr, $node->getNode('expr'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
         $tests[] = [new PrintNode(new ConstantExpression('foo', 1), 1), "// line 1\nyield \"foo\";"];

--- a/tests/Node/SandboxTest.php
+++ b/tests/Node/SandboxTest.php
@@ -25,7 +25,7 @@ class SandboxTest extends NodeTestCase
         $this->assertEquals($body, $node->getNode('body'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
 

--- a/tests/Node/SetTest.php
+++ b/tests/Node/SetTest.php
@@ -35,7 +35,7 @@ class SetTest extends NodeTestCase
         $this->assertFalse($node->getAttribute('capture'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
 
@@ -52,27 +52,25 @@ EOF
         $values = new Node([new PrintNode(new ConstantExpression('foo', 1), 1)], [], 1);
         $node = new SetNode(true, $names, $values, 1);
 
-        if ($this->getEnvironment()->useYield()) {
-            $tests[] = [$node, <<<EOF
+        $tests[] = [$node, <<<EOF
 // line 1
 \$context["foo"] = ('' === \$tmp = implode('', iterator_to_array((function () use (&\$context, \$macros, \$blocks) {
     yield "foo";
     return; yield '';
 })(), false))) ? '' : new Markup(\$tmp, \$this->env->getCharset());
 EOF
-                , new Environment(new ArrayLoader()),
-            ];
-        } else {
-            $tests[] = [$node, <<<'EOF'
+            , new Environment(new ArrayLoader(), ['use_yield' => true]),
+        ];
+
+        $tests[] = [$node, <<<'EOF'
 // line 1
 $context["foo"] = ('' === $tmp = \Twig\Extension\CoreExtension::captureOutput((function () use (&$context, $macros, $blocks) {
     yield "foo";
     return; yield '';
 })())) ? '' : new Markup($tmp, $this->env->getCharset());
 EOF
-                , new Environment(new ArrayLoader()),
-            ];
-        }
+            , new Environment(new ArrayLoader(), ['use_yield' => false]),
+        ];
 
         $names = new Node([new AssignNameExpression('foo', 1)], [], 1);
         $values = new TextNode('foo', 1);

--- a/tests/Node/TextTest.php
+++ b/tests/Node/TextTest.php
@@ -23,7 +23,7 @@ class TextTest extends NodeTestCase
         $this->assertEquals('foo', $node->getAttribute('data'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         $tests = [];
         $tests[] = [new TextNode('foo', 1), "// line 1\nyield \"foo\";"];

--- a/tests/Node/TypesTest.php
+++ b/tests/Node/TypesTest.php
@@ -7,7 +7,7 @@ use Twig\Test\NodeTestCase;
 
 class TypesTest extends NodeTestCase
 {
-    private function getValidMapping(): array
+    private static function getValidMapping(): array
     {
         // {foo: 'string', bar?: 'int'}
         return [
@@ -18,26 +18,26 @@ class TypesTest extends NodeTestCase
             'bar' => [
                 'type' => 'int',
                 'optional' => true,
-            ]
+            ],
         ];
     }
 
     public function testConstructor()
     {
-        $types = $this->getValidMapping();
+        $types = self::getValidMapping();
         $node = new TypesNode($types, 1);
 
         $this->assertEquals($types, $node->getAttribute('mapping'));
     }
 
-    public function getTests()
+    public static function provideTests(): iterable
     {
         return [
             // 1st test: Node shouldn't compile at all
             [
-                new TypesNode($this->getValidMapping(), 1),
-                ''
-            ]
+                new TypesNode(self::getValidMapping(), 1),
+                '',
+            ],
         ];
     }
 }


### PR DESCRIPTION
PHPUnit 11 requires data providers to be static. This PR prepares our abstract `NodeTestCase` by deprecating the non-static `getTests()` and adding a static `provideTests()` as a replacement. I've also added PHPUnit attributes which newer PHPUnit releases prefer over PHPDoc annotations.