### PR TITLE
Prepare IntegrationTestCase for static data providers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
  * Mark `Twig\Test\NodeTestCase::getEnvironment()` as final, override `createEnvironment()` instead.
  * Deprecate `Twig\Test\NodeTestCase::getVariableGetter()`, call `createVariableGetter()` instead.
  * Deprecate `Twig\Test\NodeTestCase::getAttributeGetter()`, call `createAttributeGetter()` instead.
+ * Deprecate not overriding `Twig\Test\IntegrationTestCase::getFixturesDirectory()`, this method will be abstract in 4.0
+ * Marked `Twig\Test\IntegrationTestCase::getTests()` and `getLegacyTests()` as final
 
 # 3.12.0 (2024-08-29)
 

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -216,3 +216,10 @@ Testing Utilities
 * The method ``Twig\Test\NodeTestCase::getEnvironment()`` is considered final
   as of Twig 3.13. If you want to override how the Twig environment is
   constructed, override ``createEnvironment()`` instead.
+
+* The method ``getFixturesDir()`` on ``Twig\Test\IntegrationTestCase`` is
+  deprecated, implement the new static method ``getFixturesDirectory()``
+  instead, which will be abstract in 4.0.
+
+* The data providers ``getTests()`` and ``getLegacyTests()`` on
+  ``Twig\Test\IntegrationTestCase`` are considered final als of Twig 3.13.

--- a/extra/cache-extra/Tests/IntegrationTest.php
+++ b/extra/cache-extra/Tests/IntegrationTest.php
@@ -38,7 +38,7 @@ class IntegrationTest extends IntegrationTestCase
         ];
     }
 
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__.'/Fixtures/';
     }

--- a/extra/cache-extra/composer.json
+++ b/extra/cache-extra/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=8.0.2",
         "symfony/cache": "^5.4|^6.4|^7.0",
-        "twig/twig": "^3.12|^4.0"
+        "twig/twig": "^3.13|^4.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^6.4|^7.0"

--- a/extra/cssinliner-extra/Tests/IntegrationTest.php
+++ b/extra/cssinliner-extra/Tests/IntegrationTest.php
@@ -23,7 +23,7 @@ class IntegrationTest extends IntegrationTestCase
         ];
     }
 
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__.'/Fixtures/';
     }

--- a/extra/cssinliner-extra/composer.json
+++ b/extra/cssinliner-extra/composer.json
@@ -18,7 +18,7 @@
         "php": ">=8.0.2",
         "symfony/deprecation-contracts": "^2.5|^3",
         "tijsverkoyen/css-to-inline-styles": "^2.0",
-        "twig/twig": "^3.0|^4.0"
+        "twig/twig": "^3.13|^4.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^6.4|^7.0"

--- a/extra/html-extra/Tests/IntegrationTest.php
+++ b/extra/html-extra/Tests/IntegrationTest.php
@@ -23,7 +23,7 @@ class IntegrationTest extends IntegrationTestCase
         ];
     }
 
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__.'/Fixtures/';
     }

--- a/extra/html-extra/composer.json
+++ b/extra/html-extra/composer.json
@@ -18,7 +18,7 @@
         "php": ">=8.0.2",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/mime": "^5.4|^6.4|^7.0",
-        "twig/twig": "^3.0|^4.0"
+        "twig/twig": "^3.13|^4.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^6.4|^7.0"

--- a/extra/inky-extra/Tests/IntegrationTest.php
+++ b/extra/inky-extra/Tests/IntegrationTest.php
@@ -23,7 +23,7 @@ class IntegrationTest extends IntegrationTestCase
         ];
     }
 
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__.'/Fixtures/';
     }

--- a/extra/inky-extra/composer.json
+++ b/extra/inky-extra/composer.json
@@ -18,7 +18,7 @@
         "php": ">=8.0.2",
         "symfony/deprecation-contracts": "^2.5|^3",
         "lorenzo/pinky": "^1.0.5",
-        "twig/twig": "^3.0|^4.0"
+        "twig/twig": "^3.13|^4.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^6.4|^7.0"

--- a/extra/intl-extra/Tests/IntegrationTest.php
+++ b/extra/intl-extra/Tests/IntegrationTest.php
@@ -23,7 +23,7 @@ class IntegrationTest extends IntegrationTestCase
         ];
     }
 
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__.'/Fixtures/';
     }

--- a/extra/intl-extra/composer.json
+++ b/extra/intl-extra/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=8.0.2",
-        "twig/twig": "^3.10|^4.0",
+        "twig/twig": "^3.13|^4.0",
         "symfony/intl": "^5.4|^6.4|^7.0"
     },
     "require-dev": {

--- a/extra/markdown-extra/Tests/IntegrationTest.php
+++ b/extra/markdown-extra/Tests/IntegrationTest.php
@@ -23,7 +23,7 @@ class IntegrationTest extends IntegrationTestCase
         ];
     }
 
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__.'/Fixtures/';
     }

--- a/extra/markdown-extra/composer.json
+++ b/extra/markdown-extra/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=8.0.2",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "twig/twig": "^3.0|^4.0"
+        "twig/twig": "^3.13|^4.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^6.4|^7.0",

--- a/extra/string-extra/Tests/IntegrationTest.php
+++ b/extra/string-extra/Tests/IntegrationTest.php
@@ -23,7 +23,7 @@ class IntegrationTest extends IntegrationTestCase
         ];
     }
 
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__.'/Fixtures/';
     }

--- a/extra/string-extra/composer.json
+++ b/extra/string-extra/composer.json
@@ -18,7 +18,7 @@
         "php": ">=8.0.2",
         "symfony/string": "^5.4|^6.4|^7.0",
         "symfony/translation-contracts": "^1.1|^2|^3",
-        "twig/twig": "^3.0|^4.0"
+        "twig/twig": "^3.13|^4.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^6.4|^7.0"

--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -30,9 +30,18 @@ use Twig\TwigTest;
 abstract class IntegrationTestCase extends TestCase
 {
     /**
+     * @deprecated since Twig 3.13, use getFixturesDirectory() instead.
      * @return string
      */
-    abstract protected function getFixturesDir();
+    protected function getFixturesDir()
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+
+    protected static function getFixturesDirectory(): string
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
 
     /**
      * @return RuntimeLoaderInterface[]
@@ -92,9 +101,19 @@ abstract class IntegrationTestCase extends TestCase
         $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
     }
 
+    /**
+     * @final since Twig 3.13
+     */
     public function getTests($name, $legacyTests = false)
     {
-        $fixturesDir = realpath($this->getFixturesDir());
+        try {
+            $fixturesDir = static::getFixturesDirectory();
+        } catch (\BadMethodCallException) {
+            trigger_deprecation('twig/twig', '3.13', 'Not overriding "%s::getFixturesDirectory()" in "%s" is deprecated. This method will be abstract in 4.0.', self::class, static::class);
+            $fixturesDir = $this->getFixturesDir();
+        }
+
+        $fixturesDir = realpath($fixturesDir);
         $tests = [];
 
         foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($fixturesDir), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
@@ -137,6 +156,9 @@ abstract class IntegrationTestCase extends TestCase
         return $tests;
     }
 
+    /**
+     * @final since Twig 3.13
+     */
     public function getLegacyTests()
     {
         return $this->getTests('testLegacyIntegration', true);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -48,7 +48,7 @@ class IntegrationTest extends IntegrationTestCase
         ];
     }
 
-    public function getFixturesDir()
+    protected static function getFixturesDirectory(): string
     {
         return __DIR__.'/Fixtures/';
     }


### PR DESCRIPTION
Data providers need to be static in PHPUnit 11. Because of this, I'd like to declare the two methods we use as data providers in `IntegrationTestCase` as static in 4.0. This PR prepares that change:

* The non-static `getFixturesDir()` method is replaced with a static `getFixturesDirectory()`.
* Both methods `getTests()` and `getLegacyTests()` are marked as final, so we can declare them static in the next major.

This however means that we're delaying PHPUnit 11 compatibility of integration tests to Twig 4.0. If that's too late for us, we could deprecate the whole `IntegrationTestCase` in favor of a compatible replacement. That's a bigger change, but I would work on it if you think it's worth it.