### PR TITLE
Fix Xdebug detection

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
   </testsuites>
   <php>
     <ini name="error_reporting" value="-1" />
-    <ini name="xdebug.overload_var_dump" value="0" />
   </php>
   <listeners>
     <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />

--- a/src/Extension/DebugExtension.php
+++ b/src/Extension/DebugExtension.php
@@ -22,10 +22,8 @@ final class DebugExtension extends AbstractExtension
     {
         // dump is safe if var_dump is overridden by xdebug
         $isDumpOutputHtmlSafe = \extension_loaded('xdebug')
-            // false means that it was not set (and the default is on) or it explicitly enabled
-            && (false === \ini_get('xdebug.overload_var_dump') || \ini_get('xdebug.overload_var_dump'))
-            // false means that it was not set (and the default is on) or it explicitly enabled
-            // xdebug.overload_var_dump produces HTML only when html_errors is also enabled
+            // Xdebug overloads var_dump in develop mode when html_errors is enabled
+            && str_contains(\ini_get('xdebug.mode'), 'develop')
             && (false === \ini_get('html_errors') || \ini_get('html_errors'))
             || 'cli' === \PHP_SAPI
         ;


### PR DESCRIPTION
The ini setting `xdebug.overload_var_dump` has been removed in Xdebug 3. The `var_dump()` method is now always overloaded if the Xdebug runs in develop mode. I've adjusted our detection logic accordingly.

Since our minimum PHP version is 8.0 now, we can stop caring about Xdebug 2 which has never received a PHP 8 compatible release.