### PR TITLE
Make data providers static

### DIFF
--- a/extra/markdown-extra/Tests/FunctionalTest.php
+++ b/extra/markdown-extra/Tests/FunctionalTest.php
@@ -57,7 +57,7 @@ EOF
         }
     }
 
-    public function getMarkdownTests()
+    public static function getMarkdownTests()
     {
         return [
             [<<<EOF

--- a/tests/Cache/FilesystemTest.php
+++ b/tests/Cache/FilesystemTest.php
@@ -171,7 +171,7 @@ class FilesystemTest extends TestCase
         $this->assertMatchesRegularExpression($expected, $cache->generateKey('_test_', static::class));
     }
 
-    public function provideDirectories()
+    public static function provideDirectories()
     {
         $pattern = '#a/b/[a-zA-Z0-9]+/[a-zA-Z0-9]+.php$#';
 

--- a/tests/CustomExtensionTest.php
+++ b/tests/CustomExtensionTest.php
@@ -31,7 +31,7 @@ class CustomExtensionTest extends TestCase
         $env->getUnaryOperators();
     }
 
-    public function provideInvalidExtensions()
+    public static function provideInvalidExtensions()
     {
         return [
             [new InvalidOperatorExtension([1, 2, 3]), '"Twig\Tests\InvalidOperatorExtension::getOperators()" must return an array of 2 elements, got 3.'],

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -234,7 +234,7 @@ EOHTML
         }
     }
 
-    public function getErroredTemplates()
+    public static function getErroredTemplates()
     {
         return [
             // error occurs in a template

--- a/tests/ExpressionParserTest.php
+++ b/tests/ExpressionParserTest.php
@@ -48,7 +48,7 @@ class ExpressionParserTest extends TestCase
         $parser->parse($env->tokenize(new Source($template, 'index')));
     }
 
-    public function getFailingTestsForAssignment()
+    public static function getFailingTestsForAssignment()
     {
         return [
             ['{% set false = "foo" %}'],
@@ -91,7 +91,7 @@ class ExpressionParserTest extends TestCase
         $parser->parse($env->tokenize(new Source($template, 'index')));
     }
 
-    public function getFailingTestsForSequence()
+    public static function getFailingTestsForSequence()
     {
         return [
             ['{{ [1, "a": "b"] }}'],
@@ -100,7 +100,7 @@ class ExpressionParserTest extends TestCase
         ];
     }
 
-    public function getTestsForSequence()
+    public static function getTestsForSequence()
     {
         return [
             // simple sequence
@@ -190,7 +190,7 @@ class ExpressionParserTest extends TestCase
                     new ConstantExpression(2, 1),
 
                     new ConstantExpression(2, 1),
-                    $this->createNameExpression('foo', ['spread' => true]),
+                    self::createNameExpression('foo', ['spread' => true]),
                 ], 1)],
 
             // mapping with spread operator
@@ -203,7 +203,7 @@ class ExpressionParserTest extends TestCase
                     new ConstantExpression('c', 1),
 
                     new ConstantExpression(0, 1),
-                    $this->createNameExpression('otherLetters', ['spread' => true]),
+                    self::createNameExpression('otherLetters', ['spread' => true]),
                 ], 1)],
         ];
     }
@@ -232,7 +232,7 @@ class ExpressionParserTest extends TestCase
         $this->assertEquals($expected, $parser->parse($stream)->getNode('body')->getNode('0')->getNode('expr'));
     }
 
-    public function getTestsForString()
+    public static function getTestsForString()
     {
         return [
             [
@@ -321,7 +321,7 @@ class ExpressionParserTest extends TestCase
         $parser->parse($env->tokenize(new Source($template, 'index')));
     }
 
-    public function getMacroDefinitionDoesNotSupportNonConstantDefaultValues()
+    public static function getMacroDefinitionDoesNotSupportNonConstantDefaultValues()
     {
         return [
             ['{% macro foo(name = "a #{foo} a") %}{% endmacro %}'],
@@ -344,7 +344,7 @@ class ExpressionParserTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    public function getMacroDefinitionSupportsConstantDefaultValues()
+    public static function getMacroDefinitionSupportsConstantDefaultValues()
     {
         return [
             ['{% macro foo(name = "aa") %}{% endmacro %}'],
@@ -584,7 +584,7 @@ class ExpressionParserTest extends TestCase
         $this->doesNotPerformAssertions();
     }
 
-    private function createNameExpression(string $name, array $attributes)
+    private static function createNameExpression(string $name, array $attributes): NameExpression
     {
         $expression = new NameExpression($name, 1);
         foreach ($attributes as $key => $value) {

--- a/tests/Extension/CoreTest.php
+++ b/tests/Extension/CoreTest.php
@@ -67,7 +67,7 @@ class CoreTest extends TestCase
         }
     }
 
-    public function getRandomFunctionTestData()
+    public static function getRandomFunctionTestData()
     {
         return [
             'array' => [
@@ -165,7 +165,7 @@ class CoreTest extends TestCase
         $this->assertSame($expected, CoreExtension::first('UTF-8', $input));
     }
 
-    public function provideTwigFirstCases()
+    public static function provideTwigFirstCases()
     {
         $i = [1 => 'a', 2 => 'b', 3 => 'c'];
 
@@ -186,7 +186,7 @@ class CoreTest extends TestCase
         $this->assertSame($expected, CoreExtension::last('UTF-8', $input));
     }
 
-    public function provideTwigLastCases()
+    public static function provideTwigLastCases()
     {
         $i = [1 => 'a', 2 => 'b', 3 => 'c'];
 
@@ -207,7 +207,7 @@ class CoreTest extends TestCase
         $this->assertSame($expected, CoreExtension::keys($input));
     }
 
-    public function provideArrayKeyCases()
+    public static function provideArrayKeyCases()
     {
         $array = ['a' => 'a1', 'b' => 'b1', 'c' => 'c1'];
         $keys = array_keys($array);
@@ -230,7 +230,7 @@ class CoreTest extends TestCase
         $this->assertSame($expected, CoreExtension::inFilter($value, $compare));
     }
 
-    public function provideInFilterCases()
+    public static function provideInFilterCases()
     {
         $array = [1, 2, 'a' => 3, 5, 6, 7];
         $keys = array_keys($array);
@@ -258,7 +258,7 @@ class CoreTest extends TestCase
         $this->assertSame($expected, CoreExtension::slice('UTF-8', $input, $start, $length, $preserveKeys));
     }
 
-    public function provideSliceFilterCases()
+    public static function provideSliceFilterCases()
     {
         $i = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4];
         $keys = array_keys($i);
@@ -296,7 +296,7 @@ class CoreTest extends TestCase
         $this->assertSame(1, CoreExtension::compare('foo', \NAN));
     }
 
-    public function provideCompareCases()
+    public static function provideCompareCases()
     {
         return [
             [0, 'a', 'a'],

--- a/tests/Extension/EscaperTest.php
+++ b/tests/Extension/EscaperTest.php
@@ -32,7 +32,7 @@ class EscaperTest extends TestCase
         $this->assertSame($expected, $twig->getRuntime(EscaperRuntime::class)->escape($string, $strategy, 'ISO-8859-1'));
     }
 
-    public function provideCustomEscaperCases()
+    public static function provideCustomEscaperCases()
     {
         return [
             ['foo**ISO-8859-1**UTF-8', 'foo', 'foo'],

--- a/tests/Extension/SandboxTest.php
+++ b/tests/Extension/SandboxTest.php
@@ -79,7 +79,7 @@ class SandboxTest extends TestCase
         $twig->createTemplate($template, 'index')->render([]);
     }
 
-    public function getSandboxedForCoreTagsTests()
+    public static function getSandboxedForCoreTagsTests()
     {
         yield ['apply', '{% apply upper %}foo{% endapply %}'];
         yield ['autoescape', '{% autoescape %}foo{% endautoescape %}'];
@@ -116,7 +116,7 @@ class SandboxTest extends TestCase
         $twig->createTemplate($template, 'index')->render([]);
     }
 
-    public function getSandboxedForExtendsAndUseTagsTests()
+    public static function getSandboxedForExtendsAndUseTagsTests()
     {
         yield ['extends', '{% extends "1_empty" %}'];
         yield ['use', '{% use "1_empty" %}'];
@@ -253,7 +253,7 @@ class SandboxTest extends TestCase
         }
     }
 
-    public function getSandboxUnallowedToStringTests()
+    public static function getSandboxUnallowedToStringTests()
     {
         return [
             'simple' => ['{{ obj }}'],
@@ -281,7 +281,7 @@ class SandboxTest extends TestCase
         $this->assertEquals($output, $twig->load('index')->render(self::$params));
     }
 
-    public function getSandboxAllowedToStringTests()
+    public static function getSandboxAllowedToStringTests()
     {
         return [
             'constant_test' => ['{{ obj is constant("PHP_INT_MAX") }}', ''],

--- a/tests/FileExtensionEscapingStrategyTest.php
+++ b/tests/FileExtensionEscapingStrategyTest.php
@@ -24,7 +24,7 @@ class FileExtensionEscapingStrategyTest extends TestCase
         $this->assertSame($strategy, FileExtensionEscapingStrategy::guess($filename));
     }
 
-    public function getGuessData()
+    public static function getGuessData()
     {
         return [
             // default

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -193,7 +193,7 @@ class LexerTest extends TestCase
         $this->assertSame($expected, $token->getValue());
     }
 
-    public function getStringWithEscapedDelimiter()
+    public static function getStringWithEscapedDelimiter()
     {
         yield '{{ \'\x6\' }} => \x6' => [
             '{{ \'\x6\' }}',
@@ -247,7 +247,7 @@ class LexerTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    public function getStringWithEscapedDelimiterProducingDeprecation()
+    public static function getStringWithEscapedDelimiterProducingDeprecation()
     {
         yield '{{ \'App\Test\' }} => AppTest' => [
             '{{ \'App\\Test\' }}',
@@ -465,7 +465,7 @@ bar
         }
     }
 
-    public function getTemplateForErrorsAtTheEndOfTheStream()
+    public static function getTemplateForErrorsAtTheEndOfTheStream()
     {
         yield ['{{ ='];
         yield ['{{ ..'];
@@ -493,7 +493,7 @@ bar
         $this->addToAssertionCount(1);
     }
 
-    public function getTemplateForStrings()
+    public static function getTemplateForStrings()
     {
         yield ['日本では、春になると桜の花が咲きます。多くの人々は、公園や川の近くに集まり、お花見を楽しみます。桜の花びらが風に舞い、まるで雪のように見える瞬間は、とても美しいです。'];
         yield ['في العالم العربي، يُعتبر الخط العربي أحد أجمل أشكال الفن. يُستخدم الخط في تزيين المساجد والكتب والمخطوطات القديمة. يتميز الخط العربي بجماله وتناسقه، ويُعتبر رمزًا للثقافة الإسلامية.'];

--- a/tests/Loader/FilesystemTest.php
+++ b/tests/Loader/FilesystemTest.php
@@ -42,7 +42,7 @@ class FilesystemTest extends TestCase
         }
     }
 
-    public function getSecurityTests()
+    public static function getSecurityTests()
     {
         return [
             ["AutoloaderTest\0.php"],
@@ -105,7 +105,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals("named path (final)\n", $loader->getSourceContext('@named/index.html')->getCode());
     }
 
-    public function getBasePaths()
+    public static function getBasePaths()
     {
         return [
             [
@@ -197,7 +197,7 @@ class FilesystemTest extends TestCase
         $this->assertSame('block from theme 2', $template->renderBlock('b2', []));
     }
 
-    public function getArrayInheritanceTests()
+    public static function getArrayInheritanceTests()
     {
         return [
             'valid array inheritance' => ['array_inheritance_valid_parent.html.twig'],

--- a/tests/NodeVisitor/OptimizerTest.php
+++ b/tests/NodeVisitor/OptimizerTest.php
@@ -92,7 +92,7 @@ class OptimizerTest extends TestCase
         }
     }
 
-    public function getTestsForForLoopOptimizer()
+    public static function getTestsForForLoopOptimizer()
     {
         return [
             ['{% for i in foo %}{% endfor %}', ['i' => false]],

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -69,7 +69,7 @@ class ParserTest extends TestCase
         $this->assertEquals($expected, $m->invoke($parser, $input));
     }
 
-    public function getFilterBodyNodesData()
+    public static function getFilterBodyNodesData()
     {
         return [
             [
@@ -102,7 +102,7 @@ class ParserTest extends TestCase
         $m->invoke($parser, $input);
     }
 
-    public function getFilterBodyNodesDataThrowsException()
+    public static function getFilterBodyNodesDataThrowsException()
     {
         return [
             [new TextNode('foo', 1)],
@@ -122,7 +122,7 @@ class ParserTest extends TestCase
         $this->assertNull($m->invoke($parser, new TextNode(\chr(0xEF).\chr(0xBB).\chr(0xBF).$emptyNode, 1)));
     }
 
-    public function getFilterBodyNodesWithBOMData()
+    public static function getFilterBodyNodesWithBOMData()
     {
         return [
             [' '],

--- a/tests/Runtime/EscaperRuntimeTest.php
+++ b/tests/Runtime/EscaperRuntimeTest.php
@@ -357,7 +357,7 @@ class EscaperRuntimeTest extends TestCase
         $this->assertSame($expected, $escaper->escape($string, $strategy, $charset));
     }
 
-    public function provideCustomEscaperCases()
+    public static function provideCustomEscaperCases()
     {
         return [
             ['foo**ISO-8859-1', 'foo', 'foo', 'ISO-8859-1'],
@@ -378,7 +378,7 @@ class EscaperRuntimeTest extends TestCase
         $this->assertSame($escapedJs, $escaper->escape($obj, 'js', null, true));
     }
 
-    public function provideObjectsForEscaping()
+    public static function provideObjectsForEscaping()
     {
         return [
             ['&lt;br /&gt;', '<br />', ['\Twig\Tests\Runtime\Extension_TestClass' => ['js']]],

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -61,7 +61,7 @@ class TemplateTest extends TestCase
         }
     }
 
-    public function getAttributeExceptions()
+    public static function getAttributeExceptions()
     {
         return [
             ['{{ string["a"] }}', 'Impossible to access a key ("a") on a string variable ("foo") in "%s" at line 1.'],
@@ -113,7 +113,7 @@ class TemplateTest extends TestCase
         }
     }
 
-    public function getGetAttributeWithSandbox()
+    public static function getGetAttributeWithSandbox()
     {
         return [
             [new TemplatePropertyObject(), 'defined', false],
@@ -132,7 +132,7 @@ class TemplateTest extends TestCase
         $this->assertSame('', $twig->render('index'));
     }
 
-    public function getRenderTemplateWithoutOutputData()
+    public static function getRenderTemplateWithoutOutputData()
     {
         return [
             [''],
@@ -265,7 +265,7 @@ class TemplateTest extends TestCase
         $this->assertNull(CoreExtension::getAttribute($twig, $template->getSourceContext(), $object, 'foo'));
     }
 
-    public function getGetAttributeTests()
+    public static function getGetAttributeTests()
     {
         $array = [
             'defined' => 'defined',

--- a/tests/TokenParser/TypesTokenParserTest.php
+++ b/tests/TokenParser/TypesTokenParserTest.php
@@ -22,7 +22,7 @@ class TypesTokenParserTest extends TestCase
         self::assertEquals($expected, $typesNode->getAttribute('mapping'));
     }
 
-    public function getMappingTests(): array
+    public static function getMappingTests(): array
     {
         return [
             // empty mapping


### PR DESCRIPTION
Data providers must be static in PHPUnit 11. This PR fixes all the low hanging fruit.