### PR TITLE
Rename AbstractTest to ProfilerTestCase

### DIFF
--- a/tests/Profiler/Dumper/BlackfireTest.php
+++ b/tests/Profiler/Dumper/BlackfireTest.php
@@ -13,7 +13,7 @@ namespace Twig\Tests\Profiler\Dumper;
 
 use Twig\Profiler\Dumper\BlackfireDumper;
 
-class BlackfireTest extends AbstractTest
+class BlackfireTest extends ProfilerTestCase
 {
     public function testDump()
     {

--- a/tests/Profiler/Dumper/HtmlTest.php
+++ b/tests/Profiler/Dumper/HtmlTest.php
@@ -13,7 +13,7 @@ namespace Twig\Tests\Profiler\Dumper;
 
 use Twig\Profiler\Dumper\HtmlDumper;
 
-class HtmlTest extends AbstractTest
+class HtmlTest extends ProfilerTestCase
 {
     public function testDump()
     {

--- a/tests/Profiler/Dumper/ProfilerTestCase.php
+++ b/tests/Profiler/Dumper/ProfilerTestCase.php
@@ -14,7 +14,7 @@ namespace Twig\Tests\Profiler\Dumper;
 use PHPUnit\Framework\TestCase;
 use Twig\Profiler\Profile;
 
-abstract class AbstractTest extends TestCase
+abstract class ProfilerTestCase extends TestCase
 {
     protected function getProfile()
     {

--- a/tests/Profiler/Dumper/TextTest.php
+++ b/tests/Profiler/Dumper/TextTest.php
@@ -13,7 +13,7 @@ namespace Twig\Tests\Profiler\Dumper;
 
 use Twig\Profiler\Dumper\TextDumper;
 
-class TextTest extends AbstractTest
+class TextTest extends ProfilerTestCase
 {
     public function testDump()
     {


### PR DESCRIPTION
PHPUnit 11 doesn't allow abstract test classes to have the suffix "Test". This PR renames a class that violates that rule.