### PR TITLE
Validate the input of CoreExtension::map()

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1833,6 +1833,10 @@ final class CoreExtension extends AbstractExtension
      */
     public static function map(Environment $env, $array, $arrow)
     {
+        if (!is_iterable($array)) {
+            throw new RuntimeError(\sprintf('The "map" filter expects a sequence/mapping or "Traversable", got "%s".', get_debug_type($array)));
+        }
+
         self::checkArrowInSandbox($env, $arrow, 'map', 'filter');
 
         $r = [];


### PR DESCRIPTION
Fixes https://github.com/twigphp/Twig/pull/4269#discussion_r1742182828

As discovered in #4269, we have a test that checks if the map filter fails if we pass a non-iterable value. However, this test relies on an active error handler that throws on PHP warnings.

This PR adds input validation the the `map()` function like we can already find it in similar functions.