### PR TITLE
Fix method visibility

### DIFF
--- a/src/Test/NodeTestCase.php
+++ b/src/Test/NodeTestCase.php
@@ -53,7 +53,7 @@ abstract class NodeTestCase extends TestCase
         return new Compiler($environment ?? $this->getEnvironment());
     }
 
-    final private function getEnvironment()
+    final protected function getEnvironment(): Environment
     {
         return $this->currentEnv ??= static::createEnvironment();
     }


### PR DESCRIPTION
The method's visibility was accidentally changed to private in 6f885353f3eba94decad73d31aeaf674046a45ed. Since it's a utility function for child classes, it should remain protected.