### PR TITLE
Make FilesystemLoader::findTemplate public

### DIFF
--- a/src/Loader/FilesystemLoader.php
+++ b/src/Loader/FilesystemLoader.php
@@ -166,7 +166,7 @@ class FilesystemLoader implements LoaderInterface
     /**
      * @return string|null
      */
-    protected function findTemplate(string $name, bool $throw = true)
+    public function findTemplate(string $name, bool $throw = true)
     {
         $name = $this->normalizeName($name);
 


### PR DESCRIPTION
For [TwigStan](https://github.com/twigstan/twigstan), I want to be able to find a template by the namespaced path. 

Currently, the only way to do this is to use getSourceContext() but this also loads the template into memory.

/cc @fabpot 