### PR TITLE
Fix iterable return type

### DIFF
--- a/src/Node/BlockNode.php
+++ b/src/Node/BlockNode.php
@@ -33,7 +33,7 @@ class BlockNode extends Node
         $compiler
             ->addDebugInfo($this)
             ->write("/**\n")
-            ->write(" * @return iterable<string>\n")
+            ->write(" * @return iterable<null|scalar|\Stringable>\n")
             ->write(" */\n")
             ->write(\sprintf("public function block_%s(array \$context, array \$blocks = []): iterable\n", $this->getAttribute('name')), "{\n")
             ->indent()

--- a/src/Template.php
+++ b/src/Template.php
@@ -382,7 +382,7 @@ abstract class Template
     }
 
     /**
-     * @return iterable<string>
+     * @return iterable<null|scalar|\Stringable>
      */
     public function yield(array $context, array $blocks = []): iterable
     {
@@ -412,7 +412,7 @@ abstract class Template
     }
 
     /**
-     * @return iterable<string>
+     * @return iterable<null|scalar|\Stringable>
      */
     public function yieldBlock($name, array $context, array $blocks = [], $useBlocks = true, ?self $templateContext = null): iterable
     {
@@ -472,7 +472,7 @@ abstract class Template
      * @param array  $context The context
      * @param array  $blocks  The current set of blocks
      *
-     * @return iterable<string>
+     * @return iterable<null|scalar|\Stringable>
      */
     public function yieldParentBlock($name, array $context, array $blocks = []): iterable
     {
@@ -491,7 +491,7 @@ abstract class Template
      * @param array $context An array of parameters to pass to the template
      * @param array $blocks  An array of blocks to pass to the template
      *
-     * @return iterable<string>
+     * @return iterable<null|scalar|\Stringable>
      */
     abstract protected function doDisplay(array $context, array $blocks = []): iterable;
 }

--- a/tests/Node/BlockTest.php
+++ b/tests/Node/BlockTest.php
@@ -34,7 +34,7 @@ class BlockTest extends NodeTestCase
         $tests[] = [new BlockNode('foo', new TextNode('foo', 1), 1), <<<EOF
 // line 1
 /**
- * @return iterable<string>
+ * @return iterable<null|scalar|\Stringable>
  */
 public function block_foo(array \$context, array \$blocks = []): iterable
 {


### PR DESCRIPTION
Currently, the PHPDoc states that a string should be returned, but that's not correct.

It can be anything that is echo-able.

That means any scalar, Stringable and even null.

/cc @stof @fabpot 