### PR TITLE
Fix isset in ForLoopNode

### DIFF
--- a/src/Node/ForLoopNode.php
+++ b/src/Node/ForLoopNode.php
@@ -38,7 +38,7 @@ class ForLoopNode extends Node
                 ->write("++\$context['loop']['index0'];\n")
                 ->write("++\$context['loop']['index'];\n")
                 ->write("\$context['loop']['first'] = false;\n")
-                ->write("if (isset(\$context['loop']['length'])) {\n")
+                ->write("if (isset(\$context['loop']['revindex0'], \$context['loop']['revindex'])) {\n")
                 ->indent()
                 ->write("--\$context['loop']['revindex0'];\n")
                 ->write("--\$context['loop']['revindex'];\n")

--- a/tests/Node/ForTest.php
+++ b/tests/Node/ForTest.php
@@ -101,7 +101,7 @@ foreach (\$context['_seq'] as \$context["k"] => \$context["v"]) {
     ++\$context['loop']['index0'];
     ++\$context['loop']['index'];
     \$context['loop']['first'] = false;
-    if (isset(\$context['loop']['length'])) {
+    if (isset(\$context['loop']['revindex0'], \$context['loop']['revindex'])) {
         --\$context['loop']['revindex0'];
         --\$context['loop']['revindex'];
         \$context['loop']['last'] = 0 === \$context['loop']['revindex0'];
@@ -143,7 +143,7 @@ foreach (\$context['_seq'] as \$context["k"] => \$context["v"]) {
     ++\$context['loop']['index0'];
     ++\$context['loop']['index'];
     \$context['loop']['first'] = false;
-    if (isset(\$context['loop']['length'])) {
+    if (isset(\$context['loop']['revindex0'], \$context['loop']['revindex'])) {
         --\$context['loop']['revindex0'];
         --\$context['loop']['revindex'];
         \$context['loop']['last'] = 0 === \$context['loop']['revindex0'];
@@ -187,7 +187,7 @@ foreach (\$context['_seq'] as \$context["k"] => \$context["v"]) {
     ++\$context['loop']['index0'];
     ++\$context['loop']['index'];
     \$context['loop']['first'] = false;
-    if (isset(\$context['loop']['length'])) {
+    if (isset(\$context['loop']['revindex0'], \$context['loop']['revindex'])) {
         --\$context['loop']['revindex0'];
         --\$context['loop']['revindex'];
         \$context['loop']['last'] = 0 === \$context['loop']['revindex0'];


### PR DESCRIPTION
Even though the code works perfectly fine, PHPStan doesn't understand it.

> Offset 'revindex0' does not exist on array{parent: array{index0: int<1, max>, index: int<2, max>, first: false, revindex0?: int, revindex?: int, length: int<0, max>, last?: bool}.
> Offset 'revindex' does not exist on array{parent: array{index0: int<1, max>, index: int<2, max>, first: false, revindex0: int, revindex?: int, length: int<0, max>, last?: bool}.

Since we want to work with `revindex` and `revindex0`, we can better check for their existence, instead of `length`.

/cc @stof @fabpot 