### PR TITLE
Fix wrong format of `Environment::VERSION_ID` constant

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -44,7 +44,7 @@ use Twig\TokenParser\TokenParserInterface;
 class Environment
 {
     public const VERSION = '3.13.0-DEV';
-    public const VERSION_ID = 301300;
+    public const VERSION_ID = 31300;
     public const MAJOR_VERSION = 3;
     public const MINOR_VERSION = 13;
     public const RELEASE_VERSION = 0;

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -50,7 +50,7 @@ class EnvironmentTest extends TestCase
         $this->assertEquals(Environment::MINOR_VERSION, $exploded[1]);
         $this->assertEquals(Environment::RELEASE_VERSION, $exploded[2]);
 
-        $this->assertEquals(Environment::VERSION_ID, \sprintf('%s0%s0%s', $exploded[0], $exploded[1], $exploded[2]));
+        $this->assertEquals(Environment::VERSION_ID, Environment::MAJOR_VERSION * 10000 + Environment::MINOR_VERSION * 100 + Environment::RELEASE_VERSION);
     }
 
     public function testAutoescapeOption()


### PR DESCRIPTION
It seems that format of `Environment::VERSION_ID` constant was (erroneously?) changed with Twig 3.10.0.