### PR TITLE
[Doc] Provide an alternative for the deprecated spaceless filter

### DIFF
--- a/doc/filters/spaceless.rst
+++ b/doc/filters/spaceless.rst
@@ -3,7 +3,8 @@
 
 .. warning::
 
-    The ``spaceless`` filter is deprecated as of Twig 3.12.
+    The ``spaceless`` filter is deprecated as of Twig 3.12. Instead, use the
+    :ref:`whitespace control features <templates-whitespace-control>`.
 
 Use the ``spaceless`` filter to remove whitespace *between HTML tags*, not
 whitespace within HTML tags or whitespace in plain text:

--- a/doc/filters/spaceless.rst
+++ b/doc/filters/spaceless.rst
@@ -3,8 +3,8 @@
 
 .. warning::
 
-    The ``spaceless`` filter is deprecated as of Twig 3.12. Instead, use the
-    :ref:`whitespace control features <templates-whitespace-control>`.
+    The ``spaceless`` filter is deprecated as of Twig 3.12. While not a full
+    replacement, you can check the :ref:`whitespace control features <templates-whitespace-control>`.
 
 Use the ``spaceless`` filter to remove whitespace *between HTML tags*, not
 whitespace within HTML tags or whitespace in plain text:

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -934,21 +934,6 @@ the modifiers on one side of a tag or on both sides:
         {{~ value }}    </li>
     {# outputs '<li>\nno spaces    </li>' #}
 
-.. tip::
-
-    In addition to the whitespace modifiers, Twig also has a ``spaceless`` filter
-    that removes whitespace **between HTML tags**:
-
-    .. code-block:: html+twig
-
-        {% apply spaceless %}
-            <div>
-                <strong>foo bar</strong>
-            </div>
-        {% endapply %}
-
-        {# output will be <div><strong>foo bar</strong></div> #}
-
 Extensions
 ----------
 


### PR DESCRIPTION
When a feature is deprecated, it's recommended to provide an alternative for it (or mention that there's no alternative).

So, let's mention the whitespace control features in the deprecation message of the `spaceless` filter.