### PR TITLE
Fix compatibility with PHPUnit 11

### DIFF
--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -11,6 +11,8 @@
 
 namespace Twig\Test;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
 use Twig\Error\Error;
@@ -87,6 +89,7 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * @dataProvider getTests
      */
+    #[DataProvider('provideTests')]
     public function testIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
     {
         $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
@@ -97,9 +100,20 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @group legacy
      */
+    #[DataProvider('provideLegacyTests'), Group('legacy')]
     public function testLegacyIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
     {
         $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
+    }
+
+    final public static function provideTests(): iterable
+    {
+        return self::assembleTests(static::getFixturesDirectory(), false);
+    }
+
+    final public static function provideLegacyTests(): iterable
+    {
+        return self::assembleTests(static::getFixturesDirectory(), true);
     }
 
     /**
@@ -114,6 +128,11 @@ abstract class IntegrationTestCase extends TestCase
             $fixturesDir = $this->getFixturesDir();
         }
 
+        return self::assembleTests($fixturesDir, $legacyTests);
+    }
+
+    private static function assembleTests(string $fixturesDir, bool $legacyTests): array
+    {
         $fixturesDir = realpath($fixturesDir);
         $tests = [];
 

--- a/src/Test/NodeTestCase.php
+++ b/src/Test/NodeTestCase.php
@@ -45,7 +45,7 @@ abstract class NodeTestCase extends TestCase
      * @dataProvider getTests
      * @dataProvider provideTests
      */
-    #[DataProvider('getTests'), DataProvider('provideTests')]
+    #[DataProvider('provideTests')]
     public function testCompile($node, $source, $environment = null, $isPattern = false)
     {
         $this->assertNodeCompilation($source, $node, $environment, $isPattern);


### PR DESCRIPTION
When `PHPUnit\Framework\Attributes\DataProvider` attribute is found, PHPUnit ignores the `@dataProvider` annotation. This behavior can be used to fix compatibility with PHPUnit 11.

- Adds static data providers for `Twig\Test\IntegrationTestCase`. Running PHPUnit 10+ will require `Twig\Test\IntegrationTestCase::getFixturesDirectory()` to be implemented.
- Removes the `Twig\Test\NodeTestCase::getTests()` data provider from the `DataProvider` attribute. This way it doesn't get called with PHPUnit 10+ causing the tests to fail.

Related to:
- https://github.com/twigphp/Twig/pull/4269
- https://github.com/twigphp/Twig/pull/4265
- https://github.com/twigphp/Twig/pull/4266