### PR TITLE
Add more precise types for the registration of safe classes

### DIFF
--- a/src/Runtime/EscaperRuntime.php
+++ b/src/Runtime/EscaperRuntime.php
@@ -52,6 +52,9 @@ final class EscaperRuntime implements RuntimeExtensionInterface
         return $this->escapers;
     }
 
+    /**
+     * @param array<class-string<\Stringable>, string[]> $safeClasses
+     */
     public function setSafeClasses(array $safeClasses = [])
     {
         $this->safeClasses = [];
@@ -61,6 +64,10 @@ final class EscaperRuntime implements RuntimeExtensionInterface
         }
     }
 
+    /**
+     * @param class-string<\Stringable> $class
+     * @param string[]                  $strategies
+     */
     public function addSafeClass(string $class, array $strategies)
     {
         $class = ltrim($class, '\\');


### PR DESCRIPTION
Safe classes only impact the auto-escaping of the string casting of instance of those classes.
By defining that this method only expects names of stringable classes, it allows static analysis tools to report non-working configurations (for instance for people thinking this would impact the auto-escaping for values returned by getters of a safe class, as in https://github.com/twigphp/Twig/issues/4113 for instance).

The method technically support prefixing the class name with a `\`. Static analyzers would reject such string when checking for `class-string`. However, I think this is fine. Projects wanting to use a SA tool are probably already using the `::class` constant anyway to refer to class names (and otherwise, removing the leading `\` in their string literal is easy)