### PR TITLE
Add support for PHPUnit 11

### DIFF
--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -108,12 +108,24 @@ abstract class IntegrationTestCase extends TestCase
 
     final public static function provideTests(): iterable
     {
-        return self::assembleTests(static::getFixturesDirectory(), false);
+        try {
+            return self::assembleTests(static::getFixturesDirectory(), false);
+        } catch (\BadMethodCallException) {
+            trigger_deprecation('twig/twig', '3.13', 'Not overriding "%s::getFixturesDirectory()" in "%s" is deprecated. This method will be abstract in 4.0.', self::class, static::class);
+            // add a dummy test to avoid a PHPUnit message
+            return [['not', '-', '', [], '', []]];
+        }
     }
 
     final public static function provideLegacyTests(): iterable
     {
-        return self::assembleTests(static::getFixturesDirectory(), true);
+        try {
+            return self::assembleTests(static::getFixturesDirectory(), true);
+        } catch (\BadMethodCallException) {
+            trigger_deprecation('twig/twig', '3.13', 'Not overriding "%s::getFixturesDirectory()" in "%s" is deprecated. This method will be abstract in 4.0.', self::class, static::class);
+            // add a dummy test to avoid a PHPUnit message
+            return [['not', '-', '', [], '', []]];
+        }
     }
 
     /**

--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -11,6 +11,8 @@
 
 namespace Twig\Test;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
 use Twig\Error\Error;
@@ -87,6 +89,7 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * @dataProvider getTests
      */
+    #[DataProvider('provideTests')]
     public function testIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
     {
         $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
@@ -97,9 +100,20 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @group legacy
      */
+    #[DataProvider('provideLegacyTests'), Group('legacy')]
     public function testLegacyIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
     {
         $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
+    }
+
+    final public static function provideTests(): iterable
+    {
+        return self::assembleTests(static::getFixturesDirectory(), false);
+    }
+
+    final public static function provideLegacyTests(): iterable
+    {
+        return self::assembleTests(static::getFixturesDirectory(), true);
     }
 
     /**
@@ -114,6 +128,11 @@ abstract class IntegrationTestCase extends TestCase
             $fixturesDir = $this->getFixturesDir();
         }
 
+        return self::assembleTests($fixturesDir, $legacyTests);
+    }
+
+    private static function assembleTests(string $fixturesDir, bool $legacyTests): array
+    {
         $fixturesDir = realpath($fixturesDir);
         $tests = [];
 

--- a/src/Test/NodeTestCase.php
+++ b/src/Test/NodeTestCase.php
@@ -45,7 +45,7 @@ abstract class NodeTestCase extends TestCase
      * @dataProvider getTests
      * @dataProvider provideTests
      */
-    #[DataProvider('getTests'), DataProvider('provideTests')]
+    #[DataProvider('provideTests')]
     public function testCompile($node, $source, $environment = null, $isPattern = false)
     {
         $this->assertNodeCompilation($source, $node, $environment, $isPattern);


### PR DESCRIPTION
- Related to https://github.com/twigphp/Twig/pull/4313

The test cases `Twig\Test\NodeTestCase` and `Twig\Test\IntegrationTestCase` are currently incompatible with PHPUnit 11.

This pull request adds an option to the user to add support to run the tests with PHPUnit 11, if they implement the `Twig\Test\IntegrationTestCase::getFixturesDirectory()` method. Currently the only solution to the user is to fork `IntegrationTestCase` and `NodeTestCase` test cases, and run them only for PHPUnit 11.

The difference from the previous pull request is that this time, if `getFixturesDirectory()` is not implemented, it does not run the tests and trigger a deprecation, instead of causing an error.