### PR TITLE
Allow Twig callable arguments to use camel or snake names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 # 3.15.0 (2024-XX-XX)
 
+ * Allow Twig callable argument names to be free-form (snake-case or camelCase) independently of the PHP callable signature
+   They were automatically converted to snake-cased before
  * Deprecate the `attribute` function; use the `.` notation and wrap the name with parenthesis instead
  * Add support for argument unpackaging
  * Add JSON support for the file extension escaping strategy

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -286,3 +286,6 @@ Functions/Filters/Tests
       $twig->addFunction(new TwigFunction('upper', 'upper', [
           'deprecation_info' => new DeprecatedCallableInfo('twig/twig', '3.12'),
       ]));
+
+* For variadic arguments, use snake-case for the argument name to ease the
+  transition to 4.0.

--- a/src/Util/CallableArgumentsExtractor.php
+++ b/src/Util/CallableArgumentsExtractor.php
@@ -40,22 +40,25 @@ final class CallableArgumentsExtractor
     public function extractArguments(Node $arguments): array
     {
         $extractedArguments = [];
+        $extractedArgumentNameMap = [];
         $named = false;
         foreach ($arguments as $name => $node) {
             if (!\is_int($name)) {
                 $named = true;
-                $name = $this->normalizeName($name);
             } elseif ($named) {
                 throw new SyntaxError(\sprintf('Positional arguments cannot be used after named arguments for %s "%s".', $this->twigCallable->getType(), $this->twigCallable->getName()), $this->node->getTemplateLine(), $this->node->getSourceContext());
             }
 
-            $extractedArguments[$name] = $node;
+            $extractedArguments[$normalizedName = $this->normalizeName($name)] = $node;
+            $extractedArgumentNameMap[$normalizedName] = $name;
         }
 
         if (!$named && !$this->twigCallable->isVariadic()) {
             $min = $this->twigCallable->getMinimalNumberOfRequiredArguments();
             if (\count($extractedArguments) < $this->rc->getReflector()->getNumberOfRequiredParameters() - $min) {
-                throw new SyntaxError(\sprintf('Value for argument "%s" is required for %s "%s".', $this->rc->getReflector()->getParameters()[$min + \count($extractedArguments)]->getName(), $this->twigCallable->getType(), $this->twigCallable->getName()), $this->node->getTemplateLine(), $this->node->getSourceContext());
+                $argName = $this->toSnakeCase($this->rc->getReflector()->getParameters()[$min + \count($extractedArguments)]->getName());
+
+                throw new SyntaxError(\sprintf('Value for argument "%s" is required for %s "%s".', $argName, $this->twigCallable->getType(), $this->twigCallable->getName()), $this->node->getTemplateLine(), $this->node->getSourceContext());
             }
 
             return $extractedArguments;
@@ -76,7 +79,7 @@ final class CallableArgumentsExtractor
         $optionalArguments = [];
         $pos = 0;
         foreach ($callableParameters as $callableParameter) {
-            $callableParameterName = $this->normalizeName($callableParameter->name);
+            $callableParameterName = $callableParameter->name;
             if (\PHP_VERSION_ID >= 80000 && 'range' === $callable) {
                 if ('start' === $callableParameterName) {
                     $callableParameterName = 'low';
@@ -86,8 +89,9 @@ final class CallableArgumentsExtractor
             }
 
             $callableParameterNames[] = $callableParameterName;
+            $normalizedCallableParameterName = $this->normalizeName($callableParameterName);
 
-            if (\array_key_exists($callableParameterName, $extractedArguments)) {
+            if (\array_key_exists($normalizedCallableParameterName, $extractedArguments)) {
                 if (\array_key_exists($pos, $extractedArguments)) {
                     throw new SyntaxError(\sprintf('Argument "%s" is defined twice for %s "%s".', $callableParameterName, $this->twigCallable->getType(), $this->twigCallable->getName()), $this->node->getTemplateLine(), $this->node->getSourceContext());
                 }
@@ -95,13 +99,13 @@ final class CallableArgumentsExtractor
                 if (\count($missingArguments)) {
                     throw new SyntaxError(\sprintf(
                         'Argument "%s" could not be assigned for %s "%s(%s)" because it is mapped to an internal PHP function which cannot determine default value for optional argument%s "%s".',
-                        $callableParameterName, $this->twigCallable->getType(), $this->twigCallable->getName(), implode(', ', $callableParameterNames), \count($missingArguments) > 1 ? 's' : '', implode('", "', $missingArguments)
+                        $callableParameterName, $this->twigCallable->getType(), $this->twigCallable->getName(), implode(', ', array_map([$this, 'toSnakeCase'], $callableParameterNames)), \count($missingArguments) > 1 ? 's' : '', implode('", "', $missingArguments)
                     ), $this->node->getTemplateLine(), $this->node->getSourceContext());
                 }
 
                 $arguments = array_merge($arguments, $optionalArguments);
-                $arguments[] = $extractedArguments[$callableParameterName];
-                unset($extractedArguments[$callableParameterName]);
+                $arguments[] = $extractedArguments[$normalizedCallableParameterName];
+                unset($extractedArguments[$normalizedCallableParameterName]);
                 $optionalArguments = [];
             } elseif (\array_key_exists($pos, $extractedArguments)) {
                 $arguments = array_merge($arguments, $optionalArguments);
@@ -118,7 +122,7 @@ final class CallableArgumentsExtractor
 
                 $missingArguments[] = $callableParameterName;
             } else {
-                throw new SyntaxError(\sprintf('Value for argument "%s" is required for %s "%s".', $callableParameterName, $this->twigCallable->getType(), $this->twigCallable->getName()), $this->node->getTemplateLine(), $this->node->getSourceContext());
+                throw new SyntaxError(\sprintf('Value for argument "%s" is required for %s "%s".', $this->toSnakeCase($callableParameterName), $this->twigCallable->getType(), $this->twigCallable->getName()), $this->node->getTemplateLine(), $this->node->getSourceContext());
             }
         }
 
@@ -128,7 +132,13 @@ final class CallableArgumentsExtractor
                 if (\is_int($key)) {
                     $arbitraryArguments->addElement($value);
                 } else {
-                    $arbitraryArguments->addElement($value, new ConstantExpression($key, $this->node->getTemplateLine()));
+                    $originalKey = $extractedArgumentNameMap[$key];
+                    if ($originalKey !== $this->toSnakeCase($originalKey)) {
+                        trigger_deprecation('twig/twig', '3.15', \sprintf('Using "snake_case" for variadic arguments is required for a smooth upgrade with Twig 4.0; rename "%s" to "%s" in "%s" at line %d.', $originalKey, $this->toSnakeCase($originalKey), $this->node->getSourceContext()->getName(), $this->node->getTemplateLine()));
+                    }
+                    $arbitraryArguments->addElement($value, new ConstantExpression($this->toSnakeCase($originalKey), $this->node->getTemplateLine()));
+                    // I Twig 4.0, don't convert the key:
+                    // $arbitraryArguments->addElement($value, new ConstantExpression($originalKey, $this->node->getTemplateLine()));
                 }
                 unset($extractedArguments[$key]);
             }
@@ -151,7 +161,7 @@ final class CallableArgumentsExtractor
             throw new SyntaxError(
                 \sprintf(
                     'Unknown argument%s "%s" for %s "%s(%s)".',
-                    \count($extractedArguments) > 1 ? 's' : '', implode('", "', array_keys($extractedArguments)), $this->twigCallable->getType(), $this->twigCallable->getName(), implode(', ', $callableParameterNames)
+                    \count($extractedArguments) > 1 ? 's' : '', implode('", "', array_keys($extractedArguments)), $this->twigCallable->getType(), $this->twigCallable->getName(), implode(', ', array_map([$this, 'toSnakeCase'], $callableParameterNames))
                 ),
                 $unknownArgument ? $unknownArgument->getTemplateLine() : $this->node->getTemplateLine(),
                 $unknownArgument ? $unknownArgument->getSourceContext() : $this->node->getSourceContext()
@@ -163,7 +173,12 @@ final class CallableArgumentsExtractor
 
     private function normalizeName(string $name): string
     {
-        return strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], ['\\1_\\2', '\\1_\\2'], $name));
+        return strtolower(str_replace('_', '', $name));
+    }
+
+    private function toSnakeCase(string $name): string
+    {
+        return strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z0-9])([A-Z])/'], '\1_\2', $name));
     }
 
     private function getCallableParameters(): array


### PR DESCRIPTION
Closes #3475

Twig callables (functions/filters/tests) now accept snake and camel argument names independently of the name of the underlying PHP callable parameter names.
