### PR TITLE
fix intl-extra tests

### DIFF
--- a/extra/intl-extra/Tests/Fixtures/currency_names.test
+++ b/extra/intl-extra/Tests/Fixtures/currency_names.test
@@ -10,7 +10,7 @@
 return [];
 --EXPECT--
 0
-292
-292
+293
+293
 US Dollar
 dollar des États-Unis


### PR DESCRIPTION
The Caribbean guilder was added in symfony/symfony#58183.