### PR TITLE
Use a more precise return type in AbstractTwigCallable

### DIFF
--- a/src/AbstractTwigCallable.php
+++ b/src/AbstractTwigCallable.php
@@ -104,6 +104,9 @@ abstract class AbstractTwigCallable implements TwigCallableInterface
         return $this->options['needs_context'];
     }
 
+    /**
+     * @return static
+     */
     public function withDynamicArguments(string $name, string $dynamicName, array $arguments): self
     {
         $new = clone $this;


### PR DESCRIPTION
This method is not expected to change the type of callable.

As using it is the only way to configure arguments for a Twig callable (there is no constructor argument for them), it avoids getting static analysis errors in `Extension::getFunctions()` when using it.