### PR TITLE
Improve formatDate methods phpdoc

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -443,9 +443,9 @@ final class CoreExtension extends AbstractExtension
      *
      *   {{ post.published_at|date("m/d/Y") }}
      *
-     * @param \DateTimeInterface|\DateInterval|string $date     A date
-     * @param string|null                             $format   The target format, null to use the default
-     * @param \DateTimeZone|string|false|null         $timezone The target timezone, null to use the default, false to leave unchanged
+     * @param \DateTimeInterface|\DateInterval|string|int|null $date     A date, a timestamp or null to use the current time
+     * @param string|null                                      $format   The target format, null to use the default
+     * @param \DateTimeZone|string|false|null                  $timezone The target timezone, null to use the default, false to leave unchanged
      */
     public function formatDate($date, $format = null, $timezone = null): string
     {
@@ -466,8 +466,8 @@ final class CoreExtension extends AbstractExtension
      *
      *   {{ post.published_at|date_modify("-1day")|date("m/d/Y") }}
      *
-     * @param \DateTimeInterface|string $date     A date
-     * @param string                    $modifier A modifier string
+     * @param \DateTimeInterface|string|int|null $date     A date, a timestamp or null to use the current time
+     * @param string                             $modifier A modifier string
      *
      * @return \DateTime|\DateTimeImmutable
      *
@@ -506,8 +506,8 @@ final class CoreExtension extends AbstractExtension
      *      {# do something #}
      *    {% endif %}
      *
-     * @param \DateTimeInterface|string|null  $date     A date or null to use the current time
-     * @param \DateTimeZone|string|false|null $timezone The target timezone, null to use the default, false to leave unchanged
+     * @param \DateTimeInterface|string|int|null  $date     A date, a timestamp or null to use the current time
+     * @param \DateTimeZone|string|false|null     $timezone The target timezone, null to use the default, false to leave unchanged
      *
      * @return \DateTime|\DateTimeImmutable
      */


### PR DESCRIPTION
`convertDate`
- Supports null https://github.com/twigphp/Twig/blob/3.x/src/Extension/CoreExtension.php#L539
- Supports timestamp passed as integer https://github.com/twigphp/Twig/blob/3.x/src/Extension/CoreExtension.php#L549

So the phpdoc should not be
`\DateTimeInterface|string|null` but `\DateTimeInterface|string|int|null`

And all the date methods using `convertDate` should also accepts int and null.

This is important since some tools are developing static analysis on twig.