### PR TITLE
Fix template name in error for an unknown dynamic extends called from an include

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -80,23 +80,16 @@ abstract class Template
             return $this->parent;
         }
 
-        try {
-            if (!$parent = $this->doGetParent($context)) {
-                return false;
-            }
+        if (!$parent = $this->doGetParent($context)) {
+            return false;
+        }
 
-            if ($parent instanceof self || $parent instanceof TemplateWrapper) {
-                return $this->parents[$parent->getSourceContext()->getName()] = $parent;
-            }
+        if ($parent instanceof self || $parent instanceof TemplateWrapper) {
+            return $this->parents[$parent->getSourceContext()->getName()] = $parent;
+        }
 
-            if (!isset($this->parents[$parent])) {
-                $this->parents[$parent] = $this->loadTemplate($parent);
-            }
-        } catch (LoaderError $e) {
-            $e->setSourceContext(null);
-            $e->guess();
-
-            throw $e;
+        if (!isset($this->parents[$parent])) {
+            $this->parents[$parent] = $this->loadTemplate($parent);
         }
 
         return $this->parents[$parent];

--- a/tests/Fixtures/tags/inheritance/dynamic_parent_from_include.test
+++ b/tests/Fixtures/tags/inheritance/dynamic_parent_from_include.test
@@ -1,0 +1,14 @@
+--TEST--
+"extends" tag
+--TEMPLATE--
+{{ include('included.twig') }}
+
+--TEMPLATE(included.twig)--
+
+
+
+{% extends dynamic %}
+--DATA--
+return ['dynamic' => 'unknown.twig']
+--EXCEPTION--
+Twig\Error\LoaderError: Template "unknown.twig" is not defined in "included.twig" at line 5.


### PR DESCRIPTION
Closes #3265

The code was introduced in #1529, but removing it nowadays does not break any existing test.

Review ignoring whitespace.
