### PR TITLE
Add template cache hot reload

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.15.0 (2024-XX-XX)
 
+ * Add template cache hot reload
  * Allow Twig callable argument names to be free-form (snake-case or camelCase) independently of the PHP callable signature
    They were automatically converted to snake-cased before
  * Deprecate the `attribute` function; use the `.` notation and wrap the name with parenthesis instead

--- a/src/Cache/ChainCache.php
+++ b/src/Cache/ChainCache.php
@@ -19,7 +19,7 @@ namespace Twig\Cache;
  *
  * @author Quentin Devos <quentin@devos.pm>
  */
-final class ChainCache implements CacheInterface
+final class ChainCache implements CacheInterface, RemovableCacheInterface
 {
     /**
      * @param iterable<CacheInterface> $caches The ordered list of caches used to store and fetch cached items
@@ -67,6 +67,15 @@ final class ChainCache implements CacheInterface
         }
 
         return 0;
+    }
+
+    public function remove(string $name, string $cls): void
+    {
+        foreach ($this->caches as $cache) {
+            if ($cache instanceof RemovableCacheInterface) {
+                $cache->remove($name, $cls);
+            }
+        }
     }
 
     /**

--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -16,7 +16,7 @@ namespace Twig\Cache;
  *
  * @author Andrew Tch <andrew@noop.lv>
  */
-class FilesystemCache implements CacheInterface
+class FilesystemCache implements CacheInterface, RemovableCacheInterface
 {
     public const FORCE_BYTECODE_INVALIDATION = 1;
 
@@ -74,6 +74,14 @@ class FilesystemCache implements CacheInterface
         }
 
         throw new \RuntimeException(\sprintf('Failed to write cache file "%s".', $key));
+    }
+
+    public function remove(string $name, string $cls): void
+    {
+        $key = $this->generateKey($name, $cls);
+        if (!@unlink($key) && file_exists($key)) {
+            throw new \RuntimeException(\sprintf('Failed to delete cache file "%s".', $key));
+        }
     }
 
     public function getTimestamp(string $key): int

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -16,7 +16,7 @@ namespace Twig\Cache;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class NullCache implements CacheInterface
+final class NullCache implements CacheInterface, RemovableCacheInterface
 {
     public function generateKey(string $name, string $className): string
     {
@@ -34,5 +34,9 @@ final class NullCache implements CacheInterface
     public function getTimestamp(string $key): int
     {
         return 0;
+    }
+
+    public function remove(string $name, string $cls): void
+    {
     }
 }

--- a/src/Cache/RemovableCacheInterface.php
+++ b/src/Cache/RemovableCacheInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Cache;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface RemovableCacheInterface
+{
+    public function remove(string $name, string $cls): void;
+}

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -14,6 +14,7 @@ namespace Twig;
 use Twig\Cache\CacheInterface;
 use Twig\Cache\FilesystemCache;
 use Twig\Cache\NullCache;
+use Twig\Cache\RemovableCacheInterface;
 use Twig\Error\Error;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
@@ -231,6 +232,15 @@ class Environment
     public function isStrictVariables()
     {
         return $this->strictVariables;
+    }
+
+    public function removeCache(string $name): void
+    {
+        if ($this->cache instanceof RemovableCacheInterface) {
+            $this->cache->remove($name, $this->getTemplateClass($name));
+        } else {
+            throw new \LogicException(\sprintf('The "%s" cache class does not support removing template cache as it does not implement the "RemovableCacheInterface" interface.', \get_class($this->cache)));
+        }
     }
 
     /**

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -22,6 +22,7 @@ use Twig\Extension\AbstractExtension;
 use Twig\Extension\ExtensionInterface;
 use Twig\Extension\GlobalsInterface;
 use Twig\Loader\ArrayLoader;
+use Twig\Loader\FilesystemLoader;
 use Twig\Loader\LoaderInterface;
 use Twig\Node\Node;
 use Twig\NodeVisitor\NodeVisitorInterface;
@@ -496,6 +497,53 @@ EOF
         $twig->resetGlobals();
         $g3 = $twig->getGlobals();
         $this->assertNotSame($g3['global_ext'], $g2['global_ext']);
+    }
+
+    public function testHotCache()
+    {
+        $dir = sys_get_temp_dir().'/twig-hot-cache-test';
+        if (is_dir($dir)) {
+            FilesystemHelper::removeDir($dir);
+        }
+        mkdir($dir);
+        file_put_contents($dir.'/index.twig', 'x');
+        try {
+            $twig = new Environment(new FilesystemLoader($dir), [
+                'debug' => false,
+                'auto_reload' => false,
+                'cache' => $dir.'/cache',
+            ]);
+
+            // prime the cache
+            $this->assertSame('x', $twig->load('index.twig')->render([]));
+
+            // update the template
+            file_put_contents($dir.'/index.twig', 'y');
+
+            // re-render, should use the cached version
+            $this->assertSame('x', $twig->load('index.twig')->render([]));
+
+            // clear the cache
+            $twig->removeCache('index.twig');
+
+            // re-render, should use the updated template
+            $this->assertSame('y', $twig->load('index.twig')->render([]));
+
+            // the new template should not be cached
+            $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir.'/cache', \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
+            $count = 0;
+            foreach ($iterator as $fileInfo) {
+                if (!$fileInfo->isDir()) {
+                    ++$count;
+                }
+            }
+            $this->assertSame(0, $count);
+
+            // re-render, should use the updated template
+            $this->assertSame('y', $twig->load('index.twig')->render([]));
+        } finally {
+            FilesystemHelper::removeDir($dir);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #3880

This PR achieves 2 things in the minimum amount of code (in 2 commits):

* It adds a new `RemovableCacheInterface` that allows cache to be removed.
* It adds a memory cache to allow updating existing templates in the same process (think FrakenPHP for instance) without polluting the permanent cache.
