### PR TITLE
Add fixture filename as key

### DIFF
--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -146,7 +146,7 @@ abstract class IntegrationTestCase extends TestCase
                 throw new \InvalidArgumentException(\sprintf('Test "%s" is not valid.', str_replace($fixturesDir.'/', '', $file)));
             }
 
-            $tests[] = [str_replace($fixturesDir.'/', '', $file), $message, $condition, $templates, $exception, $outputs, $deprecation];
+            $tests[str_replace($fixturesDir.'/', '', $file)] = [str_replace($fixturesDir.'/', '', $file), $message, $condition, $templates, $exception, $outputs, $deprecation];
         }
 
         if ($legacyTests && !$tests) {


### PR DESCRIPTION
This way, it's easier to see which test failed and what the file was.

In PHPStorm this is visualized very nice.
![Screenshot 2024-09-26 at 14 19 49@2x](https://github.com/user-attachments/assets/1fe87364-c014-4cff-9b90-b9db0368efc8)
