### PR TITLE
Remove useless assign in compiled code

### DIFF
--- a/src/Node/IncludeNode.php
+++ b/src/Node/IncludeNode.php
@@ -42,7 +42,6 @@ class IncludeNode extends Node implements NodeOutputInterface
             $template = $compiler->getVarName();
 
             $compiler
-                ->write(\sprintf("$%s = null;\n", $template))
                 ->write("try {\n")
                 ->indent()
                 ->write(\sprintf('$%s = ', $template))

--- a/tests/Node/IncludeTest.php
+++ b/tests/Node/IncludeTest.php
@@ -78,7 +78,6 @@ EOF
         $node = new IncludeNode($expr, $vars, true, true, 1);
         $tests[] = [$node, <<<EOF
 // line 1
-\$__internal_%s = null;
 try {
     \$__internal_%s = \$this->loadTemplate("foo.twig", null, 1);
 } catch (LoaderError \$e) {


### PR DESCRIPTION
It's already unset / initialized on catch. 

Having it this way, is a bit easier for me when analyzing this in TwigStan.