### PR TITLE
Remove useless Closure::bind in for loop

### DIFF
--- a/src/Node/ForNode.php
+++ b/src/Node/ForNode.php
@@ -96,7 +96,6 @@ class ForNode extends Node
             ->write("return; yield;\n")
             ->outdent()
             ->write("};\n")
-            ->write("\Closure::bind(\$$functionVar, \$this, self::class);\n")
             ->write("yield from \$$functionVar(\$$iteratorVar, \$context, \$blocks, \$$functionVar, 0);\n")
         ;
     }

--- a/tests/Node/ForTest.php
+++ b/tests/Node/ForTest.php
@@ -78,7 +78,6 @@ class ForTest extends NodeTestCase
     \$context = array_intersect_key(\$context, \$__internal_compile_2) + \$__internal_compile_2;
     return; yield;
 };
-\Closure::bind(\$__internal_compile_1, \$this, self::class);
 yield from \$__internal_compile_1(\$__internal_compile_0, \$context, \$blocks, \$__internal_compile_1, 0);
 EOF
         ];
@@ -105,7 +104,6 @@ EOF
     \$context = array_intersect_key(\$context, \$__internal_compile_2) + \$__internal_compile_2;
     return; yield;
 };
-\Closure::bind(\$__internal_compile_1, \$this, self::class);
 yield from \$__internal_compile_1(\$__internal_compile_0, \$context, \$blocks, \$__internal_compile_1, 0);
 EOF
         ];
@@ -132,7 +130,6 @@ EOF
     \$context = array_intersect_key(\$context, \$__internal_compile_2) + \$__internal_compile_2;
     return; yield;
 };
-\Closure::bind(\$__internal_compile_1, \$this, self::class);
 yield from \$__internal_compile_1(\$__internal_compile_0, \$context, \$blocks, \$__internal_compile_1, 0);
 EOF
         ];
@@ -165,7 +162,6 @@ EOF
     \$context = array_intersect_key(\$context, \$__internal_compile_2) + \$__internal_compile_2;
     return; yield;
 };
-\Closure::bind(\$__internal_compile_1, \$this, self::class);
 yield from \$__internal_compile_1(\$__internal_compile_0, \$context, \$blocks, \$__internal_compile_1, 0);
 EOF
         ];
@@ -188,7 +184,6 @@ EOF
     \$context = array_intersect_key(\$context, \$__internal_compile_2) + \$__internal_compile_2;
     return; yield;
 };
-\Closure::bind(\$__internal_compile_1, \$this, self::class);
 yield from \$__internal_compile_1(\$__internal_compile_0, \$context, \$blocks, \$__internal_compile_1, 0);
 EOF
             , $env];


### PR DESCRIPTION
This has no effect. The returned value is not used.

https://www.php.net/manual/en/closure.bind.php