### PR TITLE
Simplify compiled `for` loop code

### DIFF
--- a/src/Node/ForNode.php
+++ b/src/Node/ForNode.php
@@ -43,25 +43,24 @@ class ForNode extends Node
     {
         $iteratorVar = $compiler->getVarName();
         $functionVar = $compiler->getVarName();
-        $parentVar = $compiler->getVarName();
 
         $compiler
             ->addDebugInfo($this)
             ->write("\$$iteratorVar = new \Twig\Runtime\LoopIterator(")
             ->subcompile($this->getNode('seq'))
             ->raw(");\n")
-            ->write("\$$functionVar = function (\$$iteratorVar, &\$context, \$blocks, \$$functionVar, \$depth) {\n")
+            ->write("\$$functionVar = function (\$iterator, &\$context, \$blocks, \$recurseFunc, \$depth) {\n")
             ->indent()
             ->write("\$macros = \$this->macros;\n")
-            ->write("\$$parentVar = \$context;\n")
+            ->write("\$parent = \$context;\n")
         ;
 
         if ($this->getAttribute('with_loop')) {
-            $compiler->write("\$context['loop'] = new \Twig\Runtime\LoopContext(\$$iteratorVar, \$$parentVar, \$blocks, \$$functionVar, \$depth);\n");
+            $compiler->write("\$context['loop'] = new \Twig\Runtime\LoopContext(\$iterator, \$parent, \$blocks, \$recurseFunc, \$depth);\n");
         }
 
         $compiler
-            ->write("foreach (\$$iteratorVar as ")
+            ->write("foreach (\$iterator as ")
             ->subcompile($this->getNode('key_target'))
             ->raw(' => ')
             ->subcompile($this->getNode('value_target'))
@@ -74,7 +73,7 @@ class ForNode extends Node
 
         if ($this->hasNode('else')) {
             $compiler
-                ->write("if (0 === \${$iteratorVar}->getIndex0()) {\n")
+                ->write("if (0 === \$iterator->getIndex0()) {\n")
                 ->indent()
                 ->subcompile($this->getNode('else'))
                 ->outdent()
@@ -90,7 +89,7 @@ class ForNode extends Node
         $compiler->raw(");\n");
 
         // keep the values set in the inner context for variables defined in the outer context
-        $compiler->write("\$context = array_intersect_key(\$context, \$$parentVar) + \$$parentVar;\n");
+        $compiler->write("\$context = array_intersect_key(\$context, \$parent) + \$parent;\n");
 
         $compiler
             ->write("yield from [];\n")

--- a/src/Node/ForNode.php
+++ b/src/Node/ForNode.php
@@ -50,7 +50,7 @@ class ForNode extends Node
             ->write("\$$iteratorVar = new \Twig\Runtime\LoopIterator(")
             ->subcompile($this->getNode('seq'))
             ->raw(");\n")
-            ->write("\$$functionVar = function (\$$iteratorVar, &\$context, \$blocks, &\$$functionVar, \$depth) {\n")
+            ->write("\$$functionVar = function (\$$iteratorVar, &\$context, \$blocks, \$$functionVar, \$depth) {\n")
             ->indent()
             ->write("\$macros = \$this->macros;\n")
             ->write("\$$parentVar = \$context;\n")

--- a/tests/Node/ForTest.php
+++ b/tests/Node/ForTest.php
@@ -68,14 +68,14 @@ class ForTest extends NodeTestCase
         $tests[] = [$node, <<<EOF
 // line 1
 \$__internal_compile_0 = new \Twig\Runtime\LoopIterator({$itemsGetter});
-\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, \$__internal_compile_1, \$depth) {
+\$__internal_compile_1 = function (\$iterator, &\$context, \$blocks, \$recurseFunc, \$depth) {
     \$macros = \$this->macros;
-    \$__internal_compile_2 = \$context;
-    foreach (\$__internal_compile_0 as \$context["key"] => \$context["item"]) {
+    \$parent = \$context;
+    foreach (\$iterator as \$context["key"] => \$context["item"]) {
         yield {$fooGetter};
     }
     unset(\$context['key'], \$context['item']);
-    \$context = array_intersect_key(\$context, \$__internal_compile_2) + \$__internal_compile_2;
+    \$context = array_intersect_key(\$context, \$parent) + \$parent;
     yield from [];
 };
 yield from \$__internal_compile_1(\$__internal_compile_0, \$context, \$blocks, \$__internal_compile_1, 0);
@@ -93,15 +93,15 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$__internal_compile_0 = new \Twig\Runtime\LoopIterator({$valuesGetter});
-\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, \$__internal_compile_1, \$depth) {
+\$__internal_compile_1 = function (\$iterator, &\$context, \$blocks, \$recurseFunc, \$depth) {
     \$macros = \$this->macros;
-    \$__internal_compile_2 = \$context;
-    \$context['loop'] = new \Twig\Runtime\LoopContext(\$__internal_compile_0, \$__internal_compile_2, \$blocks, \$__internal_compile_1, \$depth);
-    foreach (\$__internal_compile_0 as \$context["k"] => \$context["v"]) {
+    \$parent = \$context;
+    \$context['loop'] = new \Twig\Runtime\LoopContext(\$iterator, \$parent, \$blocks, \$recurseFunc, \$depth);
+    foreach (\$iterator as \$context["k"] => \$context["v"]) {
         yield {$fooGetter};
     }
     unset(\$context['k'], \$context['v'], \$context['loop']);
-    \$context = array_intersect_key(\$context, \$__internal_compile_2) + \$__internal_compile_2;
+    \$context = array_intersect_key(\$context, \$parent) + \$parent;
     yield from [];
 };
 yield from \$__internal_compile_1(\$__internal_compile_0, \$context, \$blocks, \$__internal_compile_1, 0);
@@ -119,15 +119,15 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$__internal_compile_0 = new \Twig\Runtime\LoopIterator({$valuesGetter});
-\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, \$__internal_compile_1, \$depth) {
+\$__internal_compile_1 = function (\$iterator, &\$context, \$blocks, \$recurseFunc, \$depth) {
     \$macros = \$this->macros;
-    \$__internal_compile_2 = \$context;
-    \$context['loop'] = new \Twig\Runtime\LoopContext(\$__internal_compile_0, \$__internal_compile_2, \$blocks, \$__internal_compile_1, \$depth);
-    foreach (\$__internal_compile_0 as \$context["k"] => \$context["v"]) {
+    \$parent = \$context;
+    \$context['loop'] = new \Twig\Runtime\LoopContext(\$iterator, \$parent, \$blocks, \$recurseFunc, \$depth);
+    foreach (\$iterator as \$context["k"] => \$context["v"]) {
         yield {$fooGetter};
     }
     unset(\$context['k'], \$context['v'], \$context['loop']);
-    \$context = array_intersect_key(\$context, \$__internal_compile_2) + \$__internal_compile_2;
+    \$context = array_intersect_key(\$context, \$parent) + \$parent;
     yield from [];
 };
 yield from \$__internal_compile_1(\$__internal_compile_0, \$context, \$blocks, \$__internal_compile_1, 0);
@@ -146,20 +146,20 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$__internal_compile_0 = new \Twig\Runtime\LoopIterator({$valuesGetter});
-\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, \$__internal_compile_1, \$depth) {
+\$__internal_compile_1 = function (\$iterator, &\$context, \$blocks, \$recurseFunc, \$depth) {
     \$macros = \$this->macros;
-    \$__internal_compile_2 = \$context;
-    \$context['loop'] = new \Twig\Runtime\LoopContext(\$__internal_compile_0, \$__internal_compile_2, \$blocks, \$__internal_compile_1, \$depth);
-    foreach (\$__internal_compile_0 as \$context["k"] => \$context["v"]) {
+    \$parent = \$context;
+    \$context['loop'] = new \Twig\Runtime\LoopContext(\$iterator, \$parent, \$blocks, \$recurseFunc, \$depth);
+    foreach (\$iterator as \$context["k"] => \$context["v"]) {
         if (true) {
             yield {$fooGetter};
         }
     }
-    if (0 === \$__internal_compile_0->getIndex0()) {
+    if (0 === \$iterator->getIndex0()) {
         yield {$fooGetter};
     }
     unset(\$context['k'], \$context['v'], \$context['loop']);
-    \$context = array_intersect_key(\$context, \$__internal_compile_2) + \$__internal_compile_2;
+    \$context = array_intersect_key(\$context, \$parent) + \$parent;
     yield from [];
 };
 yield from \$__internal_compile_1(\$__internal_compile_0, \$context, \$blocks, \$__internal_compile_1, 0);
@@ -173,15 +173,15 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$__internal_compile_0 = new \Twig\Runtime\LoopIterator({$itemsGetter});
-\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, \$__internal_compile_1, \$depth) {
+\$__internal_compile_1 = function (\$iterator, &\$context, \$blocks, \$recurseFunc, \$depth) {
     \$macros = \$this->macros;
-    \$__internal_compile_2 = \$context;
-    \$context['loop'] = new \Twig\Runtime\LoopContext(\$__internal_compile_0, \$__internal_compile_2, \$blocks, \$__internal_compile_1, \$depth);
-    foreach (\$__internal_compile_0 as \$context["_key"] => \$context["item"]) {
+    \$parent = \$context;
+    \$context['loop'] = new \Twig\Runtime\LoopContext(\$iterator, \$parent, \$blocks, \$recurseFunc, \$depth);
+    foreach (\$iterator as \$context["_key"] => \$context["item"]) {
         yield from CoreExtension::getAttribute(\$this->env, \$this->source, \$context["loop"], "__invoke", arguments: [CoreExtension::getAttribute(\$this->env, \$this->source, \$context["item"], "children", arguments: [], lineno: 1)], type: "method", lineno: 1);
     }
     unset(\$context['_key'], \$context['item'], \$context['loop']);
-    \$context = array_intersect_key(\$context, \$__internal_compile_2) + \$__internal_compile_2;
+    \$context = array_intersect_key(\$context, \$parent) + \$parent;
     yield from [];
 };
 yield from \$__internal_compile_1(\$__internal_compile_0, \$context, \$blocks, \$__internal_compile_1, 0);

--- a/tests/Node/ForTest.php
+++ b/tests/Node/ForTest.php
@@ -68,7 +68,7 @@ class ForTest extends NodeTestCase
         $tests[] = [$node, <<<EOF
 // line 1
 \$__internal_compile_0 = new \Twig\Runtime\LoopIterator({$itemsGetter});
-\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, &\$__internal_compile_1, \$depth) {
+\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, \$__internal_compile_1, \$depth) {
     \$macros = \$this->macros;
     \$__internal_compile_2 = \$context;
     foreach (\$__internal_compile_0 as \$context["key"] => \$context["item"]) {
@@ -93,7 +93,7 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$__internal_compile_0 = new \Twig\Runtime\LoopIterator({$valuesGetter});
-\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, &\$__internal_compile_1, \$depth) {
+\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, \$__internal_compile_1, \$depth) {
     \$macros = \$this->macros;
     \$__internal_compile_2 = \$context;
     \$context['loop'] = new \Twig\Runtime\LoopContext(\$__internal_compile_0, \$__internal_compile_2, \$blocks, \$__internal_compile_1, \$depth);
@@ -119,7 +119,7 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$__internal_compile_0 = new \Twig\Runtime\LoopIterator({$valuesGetter});
-\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, &\$__internal_compile_1, \$depth) {
+\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, \$__internal_compile_1, \$depth) {
     \$macros = \$this->macros;
     \$__internal_compile_2 = \$context;
     \$context['loop'] = new \Twig\Runtime\LoopContext(\$__internal_compile_0, \$__internal_compile_2, \$blocks, \$__internal_compile_1, \$depth);
@@ -146,7 +146,7 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$__internal_compile_0 = new \Twig\Runtime\LoopIterator({$valuesGetter});
-\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, &\$__internal_compile_1, \$depth) {
+\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, \$__internal_compile_1, \$depth) {
     \$macros = \$this->macros;
     \$__internal_compile_2 = \$context;
     \$context['loop'] = new \Twig\Runtime\LoopContext(\$__internal_compile_0, \$__internal_compile_2, \$blocks, \$__internal_compile_1, \$depth);
@@ -173,7 +173,7 @@ EOF
         $tests[] = [$node, <<<EOF
 // line 1
 \$__internal_compile_0 = new \Twig\Runtime\LoopIterator({$itemsGetter});
-\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, &\$__internal_compile_1, \$depth) {
+\$__internal_compile_1 = function (\$__internal_compile_0, &\$context, \$blocks, \$__internal_compile_1, \$depth) {
     \$macros = \$this->macros;
     \$__internal_compile_2 = \$context;
     \$context['loop'] = new \Twig\Runtime\LoopContext(\$__internal_compile_0, \$__internal_compile_2, \$blocks, \$__internal_compile_1, \$depth);


### PR DESCRIPTION
**Do not pass closure as reference**
It's not needed.

**Do not use same var names in loop function** 
These variables are passed in when the loop function is invoked when yielding.
Giving them the same internal var names complicates things for no good reason.