### PR TITLE
Add support for detecting if an expression had explicit parentheses

### DIFF
--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -169,15 +169,10 @@ class ExpressionParser
             return $this->parsePostfixExpression(new $class($expr, $token->getLine()));
         } elseif ($token->test(Token::PUNCTUATION_TYPE, '(')) {
             $this->parser->getStream()->next();
-            $expr = $this->parseExpression();
+            $expr = $this->parseExpression()->setExplicitParentheses();
             $this->parser->getStream()->expect(Token::PUNCTUATION_TYPE, ')', 'An opened parenthesis is not properly closed');
 
-            $expr = $this->parsePostfixExpression($expr);
-            if ($expr instanceof NegUnary) {
-                $expr->wrapInParentheses();
-            }
-
-            return $expr;
+            return $this->parsePostfixExpression($expr);
         }
 
         return $this->parsePrimaryExpression();

--- a/src/Node/Expression/AbstractExpression.php
+++ b/src/Node/Expression/AbstractExpression.php
@@ -25,4 +25,19 @@ abstract class AbstractExpression extends Node
     {
         return $this->hasAttribute('is_generator') && $this->getAttribute('is_generator');
     }
+
+    /**
+     * @return static
+     */
+    public function setExplicitParentheses(): self
+    {
+        $this->setAttribute('with_parentheses', true);
+
+        return $this;
+    }
+
+    public function hasExplicitParentheses(): bool
+    {
+        return $this->hasAttribute('with_parentheses') && $this->getAttribute('with_parentheses');
+    }
 }

--- a/src/Node/Expression/Unary/AbstractUnary.php
+++ b/src/Node/Expression/Unary/AbstractUnary.php
@@ -30,14 +30,14 @@ abstract class AbstractUnary extends AbstractExpression
 
     public function compile(Compiler $compiler): void
     {
-        if ($this->getAttribute('with_parentheses')) {
+        if ($this->hasExplicitParentheses()) {
             $compiler->raw('(');
         } else {
             $compiler->raw(' ');
         }
         $this->operator($compiler);
         $compiler->subcompile($this->getNode('node'));
-        if ($this->getAttribute('with_parentheses')) {
+        if ($this->hasExplicitParentheses()) {
             $compiler->raw(')');
         }
     }


### PR DESCRIPTION
It's going to help with operator precedence changes and their related deprecation notices.
