### PR TITLE
Trigger deprecations when using "??" and "not" without explicit parentheses when precedence will change in 4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.15.0 (2024-XX-XX)
 
+ * Deprecate using `??` without explicit parentheses
  * Deprecate using `~` with `+` or `-` in an expression without using parentheses to clarify precedence
  * Deprecate not passing `AbstractExpression` args to most constructor arguments for classes extending `AbstractExpression`
  * Fix `power` expressions with a negative number in parenthesis (`(-1) ** 2`)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
 # 3.15.0 (2024-XX-XX)
 
- * Deprecate using `??` without explicit parentheses
- * Deprecate using `~` with `+` or `-` in an expression without using parentheses to clarify precedence
+ * Add support for triggering deprecations for future operator precedence changes
+ * Deprecate using the `not` unary operator in an expression with ``*``, ``/``, ``//``, or ``%`` without using explicit parentheses to clarify precedence
+ * Deprecate using the `??` binary operator without explicit parentheses
+ * Deprecate using the `~` binary operator in an expression with `+` or `-` without using parentheses to clarify precedence
  * Deprecate not passing `AbstractExpression` args to most constructor arguments for classes extending `AbstractExpression`
  * Fix `power` expressions with a negative number in parenthesis (`(-1) ** 2`)
  * Deprecate instantiating `Node` directly. Use `EmptyNode` or `Nodes` instead.

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -315,9 +315,9 @@ Operators
 ---------
 
 * Using ``~`` with ``+`` or ``-`` in an expression without using parentheses to
-  clarify precedence is deprecated as of Twig 3.15 (in Twig 4.0, parentheses
-  won't be needed anymore as ``+`` / ``-`` will have a higher precedence than
-  ``~``).
+  clarify precedence triggers a deprecation as of Twig 3.15 (in Twig 4.0,
+  parentheses won't be needed anymore as ``+`` / ``-`` will have a higher
+  precedence than ``~``).
 
   For example, the following expression will trigger a deprecation in Twig 3.15::
 
@@ -331,3 +331,20 @@ Operators
     {# or #}
 
     {{ '42' ~ (1 + 41) }} {# this is equivalent to what Twig 4.x will do without the parentheses #}
+
+* Using ``??`` without explicit parentheses to clarify precedence triggers a
+  deprecation as of Twig 3.15 (in Twig 4.0, parentheses won't be needed anymore
+  as ``??`` will have the lowest precedence).
+
+  For example, the following expression will trigger a deprecation in Twig 3.15::
+
+    {{ 'notnull' ?? 'foo' ~ '_bar' }}
+
+  To avoid the deprecation, wrap the ``??`` expressionin parentheses to clarify
+  the precedence::
+
+    {{ ('notnull' ?? 'foo') ~ '_bar' }} {# this is equivalent to what Twig 3.x does without the parentheses #}
+
+    {# or #}
+
+    {{ 'notnull' ?? ('foo' ~ '_bar') }} {# this is equivalent to what Twig 4.x will do without the parentheses #}

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -314,10 +314,9 @@ Node
 Operators
 ---------
 
-* Using ``~`` with ``+`` or ``-`` in an expression without using parentheses to
-  clarify precedence triggers a deprecation as of Twig 3.15 (in Twig 4.0,
-  parentheses won't be needed anymore as ``+`` / ``-`` will have a higher
-  precedence than ``~``).
+* Using ``~`` in an expression with the ``+`` or ``-`` operators without using
+  parentheses to clarify precedence triggers a deprecation as of Twig 3.15 (in
+  Twig 4.0, ``+`` / ``-`` will have a higher precedence than ``~``).
 
   For example, the following expression will trigger a deprecation in Twig 3.15::
 
@@ -333,14 +332,14 @@ Operators
     {{ '42' ~ (1 + 41) }} {# this is equivalent to what Twig 4.x will do without the parentheses #}
 
 * Using ``??`` without explicit parentheses to clarify precedence triggers a
-  deprecation as of Twig 3.15 (in Twig 4.0, parentheses won't be needed anymore
-  as ``??`` will have the lowest precedence).
+  deprecation as of Twig 3.15 (in Twig 4.0, ``??`` will have the lowest
+  precedence).
 
   For example, the following expression will trigger a deprecation in Twig 3.15::
 
     {{ 'notnull' ?? 'foo' ~ '_bar' }}
 
-  To avoid the deprecation, wrap the ``??`` expressionin parentheses to clarify
+  To avoid the deprecation, wrap the ``??`` expression in parentheses to clarify
   the precedence::
 
     {{ ('notnull' ?? 'foo') ~ '_bar' }} {# this is equivalent to what Twig 3.x does without the parentheses #}
@@ -348,3 +347,21 @@ Operators
     {# or #}
 
     {{ 'notnull' ?? ('foo' ~ '_bar') }} {# this is equivalent to what Twig 4.x will do without the parentheses #}
+
+* Using the ``not`` unary operator in an expression with ``*``, ``/``, ``//``,
+  or ``%`` operators without explicit parentheses to clarify precedence
+  triggers a deprecation as of Twig 3.15 (in Twig 4.0, ``not`` will have a
+  higher precedence than ``*``, ``/``, ``//``, and ``%``).
+
+  For example, the following expression will trigger a deprecation in Twig 3.15::
+
+    {{ not 1 * 2 }}
+
+  To avoid the deprecation, wrap the concatenation in parentheses to clarify
+  the precedence::
+
+    {{ (not 1 * 2) }} {# this is equivalent to what Twig 3.x does without the parentheses #}
+
+    {# or #}
+
+    {{ (not 1) * 2 }} {# this is equivalent to what Twig 4.x will do without the parentheses #}

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -66,6 +66,7 @@ use Twig\Node\Expression\Unary\NotUnary;
 use Twig\Node\Expression\Unary\PosUnary;
 use Twig\Node\Node;
 use Twig\NodeVisitor\MacroAutoImportNodeVisitor;
+use Twig\OperatorPrecedenceChange;
 use Twig\Parser;
 use Twig\Source;
 use Twig\Template;
@@ -296,7 +297,7 @@ final class CoreExtension extends AbstractExtension
     {
         return [
             [
-                'not' => ['precedence' => 50, 'class' => NotUnary::class],
+                'not' => ['precedence' => 50, 'precedence_change' => new OperatorPrecedenceChange('twig/twig', '3.15', 70), 'class' => NotUnary::class],
                 '-' => ['precedence' => 500, 'class' => NegUnary::class],
                 '+' => ['precedence' => 500, 'class' => PosUnary::class],
             ],
@@ -323,7 +324,7 @@ final class CoreExtension extends AbstractExtension
                 '..' => ['precedence' => 25, 'class' => RangeBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '+' => ['precedence' => 30, 'class' => AddBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '-' => ['precedence' => 30, 'class' => SubBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
-                '~' => ['precedence' => 40, 'future_precedence' => 27, 'class' => ConcatBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+                '~' => ['precedence' => 40, 'precedence_change' => new OperatorPrecedenceChange('twig/twig', '3.15', 27), 'class' => ConcatBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '*' => ['precedence' => 60, 'class' => MulBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '/' => ['precedence' => 60, 'class' => DivBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '//' => ['precedence' => 60, 'class' => FloorDivBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
@@ -331,7 +332,7 @@ final class CoreExtension extends AbstractExtension
                 'is' => ['precedence' => 100, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 'is not' => ['precedence' => 100, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '**' => ['precedence' => 200, 'class' => PowerBinary::class, 'associativity' => ExpressionParser::OPERATOR_RIGHT],
-                '??' => ['precedence' => 300, 'future_precedence' => 5, 'class' => NullCoalesceExpression::class, 'associativity' => ExpressionParser::OPERATOR_RIGHT],
+                '??' => ['precedence' => 300, 'precedence_change' => new OperatorPrecedenceChange('twig/twig', '3.15', 5), 'class' => NullCoalesceExpression::class, 'associativity' => ExpressionParser::OPERATOR_RIGHT],
             ],
         ];
     }

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -323,8 +323,7 @@ final class CoreExtension extends AbstractExtension
                 '..' => ['precedence' => 25, 'class' => RangeBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '+' => ['precedence' => 30, 'class' => AddBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '-' => ['precedence' => 30, 'class' => SubBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
-                // Precedence of the ~ operator will change to 27 in Twig 4.0
-                '~' => ['precedence' => 40, 'class' => ConcatBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+                '~' => ['precedence' => 40, 'future_precedence' => 27, 'class' => ConcatBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '*' => ['precedence' => 60, 'class' => MulBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '/' => ['precedence' => 60, 'class' => DivBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '//' => ['precedence' => 60, 'class' => FloorDivBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
@@ -332,7 +331,7 @@ final class CoreExtension extends AbstractExtension
                 'is' => ['precedence' => 100, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 'is not' => ['precedence' => 100, 'associativity' => ExpressionParser::OPERATOR_LEFT],
                 '**' => ['precedence' => 200, 'class' => PowerBinary::class, 'associativity' => ExpressionParser::OPERATOR_RIGHT],
-                '??' => ['precedence' => 300, 'class' => NullCoalesceExpression::class, 'associativity' => ExpressionParser::OPERATOR_RIGHT],
+                '??' => ['precedence' => 300, 'future_precedence' => 5, 'class' => NullCoalesceExpression::class, 'associativity' => ExpressionParser::OPERATOR_RIGHT],
             ],
         ];
     }

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -67,8 +67,8 @@ interface ExtensionInterface
      * @return array<array> First array of unary operators, second array of binary operators
      *
      * @psalm-return array{
-     *     array<string, array{precedence: int, class: class-string<AbstractExpression>}>,
-     *     array<string, array{precedence: int, class?: class-string<AbstractExpression>, associativity: ExpressionParser::OPERATOR_*}>
+     *     array<string, array{precedence: int, precedence_change?: OperatorPrecedenceChange, class: class-string<AbstractExpression>}>,
+     *     array<string, array{precedence: int, precedence_change?: OperatorPrecedenceChange, class?: class-string<AbstractExpression>, associativity: ExpressionParser::OPERATOR_*}>
      * }
      */
     public function getOperators();

--- a/src/OperatorPrecedenceChange.php
+++ b/src/OperatorPrecedenceChange.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig;
+
+/**
+ * Represents a precedence change for an operator.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class OperatorPrecedenceChange
+{
+    public function __construct(
+        private string $package,
+        private string $version,
+        private int $newPrecedence,
+    ) {
+    }
+
+    public function getPackage(): string
+    {
+        return $this->package;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function getNewPrecedence(): string
+    {
+        return $this->newPrecedence;
+    }
+}

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -598,7 +598,7 @@ class EnvironmentTest_Extension extends AbstractExtension implements GlobalsInte
     {
         return [
             ['foo_unary' => []],
-            ['foo_binary' => []],
+            ['foo_binary' => ['precedence' => 0]],
         ];
     }
 

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -597,7 +597,7 @@ class EnvironmentTest_Extension extends AbstractExtension implements GlobalsInte
     public function getOperators(): array
     {
         return [
-            ['foo_unary' => []],
+            ['foo_unary' => ['precedence' => 0]],
             ['foo_binary' => ['precedence' => 0]],
         ];
     }

--- a/tests/Fixtures/operators/contat_vs_add_sub.legacy.test
+++ b/tests/Fixtures/operators/contat_vs_add_sub.legacy.test
@@ -1,8 +1,8 @@
 --TEST--
 +/- will have a higher precedence over ~ in Twig 4.0
 --DEPRECATION--
-Since twig/twig 3.15: As "+" / "-" will have a higher precedence than "~" in Twig 4.0, please add parentheses to keep the current behavior in "index.twig" at line 2.
-Since twig/twig 3.15: As "+" / "-" will have a higher precedence than "~" in Twig 4.0, please add parentheses to keep the current behavior in "index.twig" at line 3.
+Since twig/twig 3.15: Add explicit parentheses around the "~" operator to avoid behavior change in Twig 4.0 as its precedence will change in "index.twig" at line 2.
+Since twig/twig 3.15: Add explicit parentheses around the "~" operator to avoid behavior change in Twig 4.0 as its precedence will change in "index.twig" at line 3.
 --TEMPLATE--
 {{ '42' ~ 1 + 41 }}
 {{ '42' ~ 43 - 1 }}

--- a/tests/Fixtures/operators/contat_vs_add_sub.legacy.test
+++ b/tests/Fixtures/operators/contat_vs_add_sub.legacy.test
@@ -1,8 +1,8 @@
 --TEST--
 +/- will have a higher precedence over ~ in Twig 4.0
 --DEPRECATION--
-Since twig/twig 3.15: Add explicit parentheses around the "~" operator to avoid behavior change in Twig 4.0 as its precedence will change in "index.twig" at line 2.
-Since twig/twig 3.15: Add explicit parentheses around the "~" operator to avoid behavior change in Twig 4.0 as its precedence will change in "index.twig" at line 3.
+Since twig/twig 3.15: Add explicit parentheses around the "~" binary operator to avoid behavior change in the next major version as its precedence will change in "index.twig" at line 2.
+Since twig/twig 3.15: Add explicit parentheses around the "~" binary operator to avoid behavior change in the next major version as its precedence will change in "index.twig" at line 3.
 --TEMPLATE--
 {{ '42' ~ 1 + 41 }}
 {{ '42' ~ 43 - 1 }}

--- a/tests/Fixtures/operators/not_precedence.legacy.test
+++ b/tests/Fixtures/operators/not_precedence.legacy.test
@@ -1,0 +1,9 @@
+--TEST--
+*, /, //, and % will have a higher precedence over not in Twig 4.0
+--DEPRECATION--
+Since twig/twig 3.15: Add explicit parentheses around the "not" unary operator to avoid behavior change in the next major version as its precedence will change in "index.twig" at line 2.
+--TEMPLATE--
+{{ not 1 * 2 }}
+--DATA--
+return []
+--EXPECT--

--- a/tests/Fixtures/operators/not_precedence.test
+++ b/tests/Fixtures/operators/not_precedence.test
@@ -1,0 +1,9 @@
+--TEST--
+*, /, //, and % will have a higher precedence over not in Twig 4.0
+--TEMPLATE--
+{{ (not 1) * 2 }}
+{{ (not 1 * 2) }}
+--DATA--
+return []
+--EXPECT--
+0

--- a/tests/Fixtures/tests/null_coalesce.legacy.test
+++ b/tests/Fixtures/tests/null_coalesce.legacy.test
@@ -1,0 +1,16 @@
+--TEST--
+Twig supports the ?? operator
+--DEPRECATION--
+Since twig/twig 3.15: Add explicit parentheses around the "??" operator to avoid behavior change in Twig 4.0 as its precedence will change in "index.twig" at line 4.
+Since twig/twig 3.15: Add explicit parentheses around the "??" operator to avoid behavior change in Twig 4.0 as its precedence will change in "index.twig" at line 5.
+--TEMPLATE--
+{{ nope ?? nada ?? 'OK' -}} {# no deprecation as the operators have the same precedence #}
+
+{{ 1 + nope ?? nada ?? 2 }}
+{{ 1 + nope ?? 3 + nada ?? 2 }}
+--DATA--
+return []
+--EXPECT--
+OK
+3
+6

--- a/tests/Fixtures/tests/null_coalesce.legacy.test
+++ b/tests/Fixtures/tests/null_coalesce.legacy.test
@@ -1,8 +1,8 @@
 --TEST--
 Twig supports the ?? operator
 --DEPRECATION--
-Since twig/twig 3.15: Add explicit parentheses around the "??" operator to avoid behavior change in Twig 4.0 as its precedence will change in "index.twig" at line 4.
-Since twig/twig 3.15: Add explicit parentheses around the "??" operator to avoid behavior change in Twig 4.0 as its precedence will change in "index.twig" at line 5.
+Since twig/twig 3.15: Add explicit parentheses around the "??" binary operator to avoid behavior change in the next major version as its precedence will change in "index.twig" at line 4.
+Since twig/twig 3.15: Add explicit parentheses around the "??" binary operator to avoid behavior change in the next major version as its precedence will change in "index.twig" at line 5.
 --TEMPLATE--
 {{ nope ?? nada ?? 'OK' -}} {# no deprecation as the operators have the same precedence #}
 

--- a/tests/Fixtures/tests/null_coalesce.test
+++ b/tests/Fixtures/tests/null_coalesce.test
@@ -10,9 +10,9 @@ Twig supports the ?? operator
 {{ foo.bar.baz.missing ?? 'OK' }}
 {{ foo['bar'] ?? 'KO' }}
 {{ foo['missing'] ?? 'OK' }}
-{{ nope ?? nada ?? 'OK' }}
-{{ 1 + nope ?? nada ?? 2 }}
-{{ 1 + nope ?? 3 + nada ?? 2 }}
+{{ nope ?? (nada ?? 'OK') }}
+{{ 1 + (nope ?? (nada ?? 2)) }}
+{{ 1 + (nope ?? 3) + (nada ?? 2) }}
 --DATA--
 return ['bar' => 'OK', 'foo' => ['bar' => 'OK']]
 --EXPECT--


### PR DESCRIPTION
Closes #3387
Closes #3642

