### PR TITLE
Don't wrap `throw` in closure

### DIFF
--- a/src/Node/Expression/NameExpression.php
+++ b/src/Node/Expression/NameExpression.php
@@ -77,11 +77,11 @@ class NameExpression extends AbstractExpression
                 $compiler
                     ->raw(' $context[')
                     ->string($name)
-                    ->raw('] : (function () { throw new RuntimeError(\'Variable ')
+                    ->raw('] : throw new RuntimeError(\'Variable ')
                     ->string($name)
                     ->raw(' does not exist.\', ')
                     ->repr($this->lineno)
-                    ->raw(', $this->source); })()')
+                    ->raw(', $this->source)')
                     ->raw(')')
                 ;
             }

--- a/tests/Node/Expression/NameTest.php
+++ b/tests/Node/Expression/NameTest.php
@@ -34,7 +34,7 @@ class NameTest extends NodeTestCase
         $env = new Environment(new ArrayLoader(), ['strict_variables' => true]);
         $env1 = new Environment(new ArrayLoader(), ['strict_variables' => false]);
 
-        $output = '(isset($context["foo"]) || array_key_exists("foo", $context) ? $context["foo"] : (function () { throw new RuntimeError(\'Variable "foo" does not exist.\', 1, $this->source); })())';
+        $output = '(isset($context["foo"]) || array_key_exists("foo", $context) ? $context["foo"] : throw new RuntimeError(\'Variable "foo" does not exist.\', 1, $this->source))';
 
         return [
             [$node, "// line 1\n".$output, $env],


### PR DESCRIPTION
I believe this was done because in versions of PHP prior to 8, the `throw` keyword was a statement and not an expression. Since Twig now requires PHP 8+, this should no longer be necessary.