### PR TITLE
Allow running CI on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: "CI"
 on:
     pull_request:
     push:
-        branches:
-            - '3.x'
 
 env:
     SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE: 1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,9 +3,6 @@ name: "Documentation"
 on:
     pull_request:
     push:
-        branches:
-            - '2.x'
-            - '3.x'
 
 permissions:
   contents: read


### PR DESCRIPTION
This allows contributors to verify if the CI passes on their forks before opening a PR.