### PR TITLE
[Doc] html_cva

### DIFF
--- a/doc/functions/html_cva.rst
+++ b/doc/functions/html_cva.rst
@@ -146,7 +146,7 @@ If no variants match, you can define a default set of classes to apply:
                 lg: 'rounded-lg',
             }
         },
-        defaultVariants={
+        defaultVariant={
             rounded: 'md',
         }
     ) %}


### PR DESCRIPTION
Juste rename defaultVariant without "s".