### PR TITLE
Replace `var_` with `print_` in Lexer / Token ?

### DIFF
--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -32,8 +32,8 @@ The lexer tokenizes a template source code into a token stream (each token is
 an instance of ``\Twig\Token``, and the stream is an instance of
 ``\Twig\TokenStream``). The default lexer recognizes 15 different token types:
 
-* ``\Twig\Token::BLOCK_START_TYPE``, ``\Twig\Token::BLOCK_END_TYPE``: Delimiters for blocks (``{% %}``)
-* ``\Twig\Token::VAR_START_TYPE``, ``\Twig\Token::VAR_END_TYPE``: Delimiters for variables (``{{ }}``)
+* ``\Twig\Token::BLOCK_START_TYPE``, ``\Twig\Token::BLOCK_END_TYPE``: Delimiters for blocks statements (``{% %}``)
+* ``\Twig\Token::PRINT_START_TYPE``, ``\Twig\Token::PRINT_END_TYPE``: Delimiters for print statements (``{{ }}``)
 * ``\Twig\Token::TEXT_TYPE``: A text outside an expression;
 * ``\Twig\Token::NAME_TYPE``: A name in an expression;
 * ``\Twig\Token::NUMBER_TYPE``: A number in an expression;
@@ -60,9 +60,9 @@ Here is the output for the ``Hello {{ name }}`` template:
 .. code-block:: text
 
     TEXT_TYPE(Hello )
-    VAR_START_TYPE()
+    PRINT_START_TYPE()
     NAME_TYPE(name)
-    VAR_END_TYPE()
+    PRINT_END_TYPE()
     EOF_TYPE()
 
 .. note::

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -32,7 +32,7 @@ The lexer tokenizes a template source code into a token stream (each token is
 an instance of ``\Twig\Token``, and the stream is an instance of
 ``\Twig\TokenStream``). The default lexer recognizes 15 different token types:
 
-* ``\Twig\Token::BLOCK_START_TYPE``, ``\Twig\Token::BLOCK_END_TYPE``: Delimiters for blocks statements (``{% %}``)
+* ``\Twig\Token::BLOCK_START_TYPE``, ``\Twig\Token::BLOCK_END_TYPE``: Delimiters for block statements (``{% %}``)
 * ``\Twig\Token::PRINT_START_TYPE``, ``\Twig\Token::PRINT_END_TYPE``: Delimiters for print statements (``{{ }}``)
 * ``\Twig\Token::TEXT_TYPE``: A text outside an expression;
 * ``\Twig\Token::NAME_TYPE``: A name in an expression;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -127,10 +127,10 @@ class Parser
                     $rv[] = new TextNode($token->getValue(), $token->getLine());
                     break;
 
-                case Token::VAR_START_TYPE:
+                case Token::PRINT_START_TYPE:
                     $token = $this->stream->next();
                     $expr = $this->expressionParser->parseExpression();
-                    $this->stream->expect(Token::VAR_END_TYPE);
+                    $this->stream->expect(Token::PRINT_END_TYPE);
                     $rv[] = new PrintNode($expr, $token->getLine());
                     break;
 

--- a/src/Token.php
+++ b/src/Token.php
@@ -20,9 +20,9 @@ final class Token
     public const EOF_TYPE = -1;
     public const TEXT_TYPE = 0;
     public const BLOCK_START_TYPE = 1;
-    public const VAR_START_TYPE = 2;
+    public const PRINT_START_TYPE = 2;
     public const BLOCK_END_TYPE = 3;
-    public const VAR_END_TYPE = 4;
+    public const PRINT_END_TYPE = 4;
     public const NAME_TYPE = 5;
     public const NUMBER_TYPE = 6;
     public const STRING_TYPE = 7;
@@ -32,6 +32,16 @@ final class Token
     public const INTERPOLATION_END_TYPE = 11;
     public const ARROW_TYPE = 12;
     public const SPREAD_TYPE = 13;
+
+    /**
+     * @deprecated since Twig 3.XX, use PRINT_START_TYPE instead. The VAR_START_TYPE constant will be removed in Twig 4.0.
+     */
+    public const VAR_START_TYPE = self::PRINT_START_TYPE;
+
+    /**
+     * @deprecated since Twig 3.XX, use PRINT_END_TYPE instead. The VAR_END_TYPE constant will be removed in Twig 4.0.
+     */
+    public const VAR_END_TYPE = self::PRINT_END_TYPE;
 
     public function __construct(
         private int $type,
@@ -100,11 +110,17 @@ final class Token
             case self::VAR_START_TYPE:
                 $name = 'VAR_START_TYPE';
                 break;
+            case self::PRINT_START_TYPE:
+                $name = 'PRINT_START_TYPE';
+                break;
             case self::BLOCK_END_TYPE:
                 $name = 'BLOCK_END_TYPE';
                 break;
             case self::VAR_END_TYPE:
                 $name = 'VAR_END_TYPE';
+                break;
+            case self::PRINT_END_TYPE:
+                $name = 'PRINT_END_TYPE';
                 break;
             case self::NAME_TYPE:
                 $name = 'NAME_TYPE';

--- a/src/Token.php
+++ b/src/Token.php
@@ -107,17 +107,11 @@ final class Token
             case self::BLOCK_START_TYPE:
                 $name = 'BLOCK_START_TYPE';
                 break;
-            case self::VAR_START_TYPE:
-                $name = 'VAR_START_TYPE';
-                break;
             case self::PRINT_START_TYPE:
                 $name = 'PRINT_START_TYPE';
                 break;
             case self::BLOCK_END_TYPE:
                 $name = 'BLOCK_END_TYPE';
-                break;
-            case self::VAR_END_TYPE:
-                $name = 'VAR_END_TYPE';
                 break;
             case self::PRINT_END_TYPE:
                 $name = 'PRINT_END_TYPE';
@@ -165,11 +159,11 @@ final class Token
                 return 'text';
             case self::BLOCK_START_TYPE:
                 return 'begin of statement block';
-            case self::VAR_START_TYPE:
+            case self::PRINT_START_TYPE:
                 return 'begin of print statement';
             case self::BLOCK_END_TYPE:
                 return 'end of statement block';
-            case self::VAR_END_TYPE:
+            case self::PRINT_END_TYPE:
                 return 'end of print statement';
             case self::NAME_TYPE:
                 return 'name';

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -42,7 +42,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source($template, 'index'));
 
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $this->assertSame('§', $stream->expect(Token::NAME_TYPE)->getValue());
     }
 
@@ -99,7 +99,7 @@ class LexerTest extends TestCase
         // \n (after {% line %})
         $this->assertSame(10, $stream->expect(Token::TEXT_TYPE)->getLine());
         // {{
-        $this->assertSame(11, $stream->expect(Token::VAR_START_TYPE)->getLine());
+        $this->assertSame(11, $stream->expect(Token::PRINT_START_TYPE)->getLine());
         // baz
         $this->assertSame(12, $stream->expect(Token::NAME_TYPE)->getLine());
     }
@@ -117,7 +117,7 @@ class LexerTest extends TestCase
         // foo\nbar
         $this->assertSame(1, $stream->expect(Token::TEXT_TYPE)->getLine());
         // {{
-        $this->assertSame(10, $stream->expect(Token::VAR_START_TYPE)->getLine());
+        $this->assertSame(10, $stream->expect(Token::PRINT_START_TYPE)->getLine());
         // baz
         $this->assertSame(11, $stream->expect(Token::NAME_TYPE)->getLine());
     }
@@ -188,7 +188,7 @@ class LexerTest extends TestCase
     {
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source($template, 'index'));
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $token = $stream->expect(Token::STRING_TYPE);
         $this->assertSame($expected, $token->getValue());
     }
@@ -266,7 +266,7 @@ class LexerTest extends TestCase
 
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source($template, 'index'));
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $stream->expect(Token::STRING_TYPE, $expected);
 
         // add a dummy assertion here to satisfy PHPUnit, the only thing we want to test is that the code above
@@ -308,14 +308,14 @@ class LexerTest extends TestCase
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source($template, 'index'));
         $stream->expect(Token::TEXT_TYPE, 'foo ');
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $stream->expect(Token::STRING_TYPE, 'bar ');
         $stream->expect(Token::INTERPOLATION_START_TYPE);
         $stream->expect(Token::NAME_TYPE, 'baz');
         $stream->expect(Token::OPERATOR_TYPE, '+');
         $stream->expect(Token::NUMBER_TYPE, '1');
         $stream->expect(Token::INTERPOLATION_END_TYPE);
-        $stream->expect(Token::VAR_END_TYPE);
+        $stream->expect(Token::PRINT_END_TYPE);
 
         // add a dummy assertion here to satisfy PHPUnit, the only thing we want to test is that the code above
         // can be executed without throwing any exceptions
@@ -328,9 +328,9 @@ class LexerTest extends TestCase
 
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source($template, 'index'));
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $stream->expect(Token::STRING_TYPE, 'bar #{baz+1}');
-        $stream->expect(Token::VAR_END_TYPE);
+        $stream->expect(Token::PRINT_END_TYPE);
 
         // add a dummy assertion here to satisfy PHPUnit, the only thing we want to test is that the code above
         // can be executed without throwing any exceptions
@@ -343,9 +343,9 @@ class LexerTest extends TestCase
 
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source($template, 'index'));
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $stream->expect(Token::STRING_TYPE, 'bar # baz');
-        $stream->expect(Token::VAR_END_TYPE);
+        $stream->expect(Token::PRINT_END_TYPE);
 
         // add a dummy assertion here to satisfy PHPUnit, the only thing we want to test is that the code above
         // can be executed without throwing any exceptions
@@ -369,7 +369,7 @@ class LexerTest extends TestCase
 
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source($template, 'index'));
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $stream->expect(Token::STRING_TYPE, 'bar ');
         $stream->expect(Token::INTERPOLATION_START_TYPE);
         $stream->expect(Token::STRING_TYPE, 'foo');
@@ -377,7 +377,7 @@ class LexerTest extends TestCase
         $stream->expect(Token::NAME_TYPE, 'bar');
         $stream->expect(Token::INTERPOLATION_END_TYPE);
         $stream->expect(Token::INTERPOLATION_END_TYPE);
-        $stream->expect(Token::VAR_END_TYPE);
+        $stream->expect(Token::PRINT_END_TYPE);
 
         // add a dummy assertion here to satisfy PHPUnit, the only thing we want to test is that the code above
         // can be executed without throwing any exceptions
@@ -412,7 +412,7 @@ class LexerTest extends TestCase
 
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source($template, 'index'));
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $stream->expect(Token::NUMBER_TYPE, 1);
         $stream->expect(Token::OPERATOR_TYPE, 'and');
 
@@ -464,12 +464,12 @@ bar
         $lexer = new Lexer(new Environment(new ArrayLoader()), [
             'tag_comment' => ['[#', '#]'],
             'tag_block' => ['/#', '#/'],
-            'tag_variable' => ['{#', '#}'],
+            'tag_print' => ['{#', '#}'],
         ]);
         $stream = $lexer->tokenize(new Source($template, 'index'));
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $stream->expect(Token::NAME_TYPE, 'variable');
-        $stream->expect(Token::VAR_END_TYPE);
+        $stream->expect(Token::PRINT_END_TYPE);
         $stream->expect(Token::BLOCK_START_TYPE);
         $stream->expect(Token::NAME_TYPE, 'if');
         $stream->expect(Token::NAME_TYPE, 'true');
@@ -515,13 +515,13 @@ bar
         $template = '{{ "'.$expected.'" }}';
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source($template, 'index'));
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $stream->expect(Token::STRING_TYPE, $expected);
 
         $template = "{{ '".$expected."' }}";
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source($template, 'index'));
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $stream->expect(Token::STRING_TYPE, $expected);
 
         // add a dummy assertion here to satisfy PHPUnit, the only thing we want to test is that the code above
@@ -539,9 +539,9 @@ bar
     {
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source('{{ "me # this is NOT an inline comment" }}', 'index'));
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $stream->expect(Token::STRING_TYPE, 'me # this is NOT an inline comment');
-        $stream->expect(Token::VAR_END_TYPE);
+        $stream->expect(Token::PRINT_END_TYPE);
         $this->assertTrue($stream->isEOF());
     }
 
@@ -552,9 +552,9 @@ bar
     {
         $lexer = new Lexer(new Environment(new ArrayLoader()));
         $stream = $lexer->tokenize(new Source($template, 'index'));
-        $stream->expect(Token::VAR_START_TYPE);
+        $stream->expect(Token::PRINT_START_TYPE);
         $stream->expect(Token::STRING_TYPE, 'me');
-        $stream->expect(Token::VAR_END_TYPE);
+        $stream->expect(Token::PRINT_END_TYPE);
         $this->assertTrue($stream->isEOF());
     }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -149,9 +149,9 @@ class ParserTest extends TestCase
             new Token(Token::BLOCK_START_TYPE, '', 1),
             new Token(Token::NAME_TYPE, 'test', 1),
             new Token(Token::BLOCK_END_TYPE, '', 1),
-            new Token(Token::VAR_START_TYPE, '', 1),
+            new Token(Token::PRINT_START_TYPE, '', 1),
             new Token(Token::NAME_TYPE, 'foo', 1),
-            new Token(Token::VAR_END_TYPE, '', 1),
+            new Token(Token::PRINT_END_TYPE, '', 1),
             new Token(Token::EOF_TYPE, '', 1),
         ]));
 


### PR DESCRIPTION
While playing with the Lexer, using `Token::typeToEnglish()` and reading the docs, this change _felt_ more coherent to me. By keeping the old constants, I believe it will be BC-safe.

Please let me know what you think (especially if I'm missing something here..).