### PR TITLE
reduce the deprecation noise when more than one argument is passed

### DIFF
--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -697,15 +697,11 @@ class ExpressionParser
     {
         $namedArguments = false;
         $definition = false;
-        if (func_num_args() > 2) {
-            trigger_deprecation('twig/twig', '3.15', 'Passing a third argument ($allowArrow) to "%s()" is deprecated.', __METHOD__);
-        }
         if (func_num_args() > 1) {
-            trigger_deprecation('twig/twig', '3.15', 'Passing a second argument ($definition) to "%s()" is deprecated.', __METHOD__);
             $definition = func_get_arg(1);
         }
         if (func_num_args() > 0) {
-            trigger_deprecation('twig/twig', '3.15', 'Passing a first argument ($namedArguments) to "%s()" is deprecated.', __METHOD__);
+            trigger_deprecation('twig/twig', '3.15', 'Passing arguments to "%s()" is deprecated.', __METHOD__);
             $namedArguments = func_get_arg(0);
         }
 


### PR DESCRIPTION
When more than one argument is passed to parseArguments(), one deprecation is triggered for each argument. Since passing any argument is deprecated the number of triggered deprecations can be reduced for more than one argument being passed.