### PR TITLE
Documentation for types tag uses Twig types in examples instead of PHP

### DIFF
--- a/doc/tags/types.rst
+++ b/doc/tags/types.rst
@@ -9,14 +9,13 @@ The ``types`` tag declares the types of template variables.
 
 To do this, specify a :ref:`mapping <twig-expressions>` of names to their types as strings.
 
-Here is how to declare that ``is_correct`` is a boolean, while ``score`` is an
-integer (see note below):
+Here is how to declare that ``is_correct`` is a boolean, while ``score`` is a number (see note below):
 
 .. code-block:: twig
 
     {% types {
-        is_correct: 'bool',
-        score: 'int',
+        is_correct: 'boolean',
+        score: 'number',
     } %}
 
 You can declare variables as optional by adding the ``?`` suffix:
@@ -24,8 +23,8 @@ You can declare variables as optional by adding the ``?`` suffix:
 .. code-block:: twig
 
     {% types {
-        is_correct: 'bool',
-        score?: 'int',
+        is_correct: 'boolean',
+        score?: 'number',
     } %}
 
 By default, this tag does not affect the template compilation or runtime behavior.

--- a/src/TokenParser/TypesTokenParser.php
+++ b/src/TokenParser/TypesTokenParser.php
@@ -20,7 +20,7 @@ use Twig\TokenStream;
 /**
  * Declare variable types.
  *
- *  {% types {foo: 'int', bar?: 'string'} %}
+ *  {% types {foo: 'number', bar?: 'string'} %}
  *
  * @author Jeroen Versteeg <jeroen@alisqi.com>
  *

--- a/tests/Node/TypesTest.php
+++ b/tests/Node/TypesTest.php
@@ -9,14 +9,14 @@ class TypesTest extends NodeTestCase
 {
     private static function getValidMapping(): array
     {
-        // {foo: 'string', bar?: 'int'}
+        // {foo: 'string', bar?: 'number'}
         return [
             'foo' => [
                 'type' => 'string',
                 'optional' => false,
             ],
             'bar' => [
-                'type' => 'int',
+                'type' => 'number',
                 'optional' => true,
             ],
         ];


### PR DESCRIPTION
Specifically, "bool" => "boolean" and "int" => "number".

This aligns the `types` documentation with templates.rst. See #4362

Thanks, @alexander-schranz!