### PR TITLE
Unset `_parent` when `for` loop is done

### DIFF
--- a/src/Node/ForNode.php
+++ b/src/Node/ForNode.php
@@ -101,7 +101,7 @@ class ForNode extends Node
         $compiler->write("\$_parent = \$context['_parent'];\n");
 
         // remove some "private" loop variables (needed for nested loops)
-        $compiler->write('unset($context[\'_seq\'], $context[\''.$this->getNode('key_target')->getAttribute('name').'\'], $context[\''.$this->getNode('value_target')->getAttribute('name').'\'], $context[\'_parent\']');
+        $compiler->write('unset($context[\'_parent\'], $context[\'_seq\'], $context[\''.$this->getNode('key_target')->getAttribute('name').'\'], $context[\''.$this->getNode('value_target')->getAttribute('name').'\'], $context[\'_parent\']');
         if ($this->hasNode('else')) {
             $compiler->raw(', $context[\'_iterated\']');
         }

--- a/tests/Node/ForTest.php
+++ b/tests/Node/ForTest.php
@@ -66,7 +66,7 @@ foreach (\$context['_seq'] as \$context["key"] => \$context["item"]) {
     yield $fooGetter;
 }
 \$_parent = \$context['_parent'];
-unset(\$context['_seq'], \$context['key'], \$context['item'], \$context['_parent']);
+unset(\$context['_parent'], \$context['_seq'], \$context['key'], \$context['item'], \$context['_parent']);
 \$context = array_intersect_key(\$context, \$_parent) + \$_parent;
 EOF
         ];
@@ -108,7 +108,7 @@ foreach (\$context['_seq'] as \$context["k"] => \$context["v"]) {
     }
 }
 \$_parent = \$context['_parent'];
-unset(\$context['_seq'], \$context['k'], \$context['v'], \$context['_parent'], \$context['loop']);
+unset(\$context['_parent'], \$context['_seq'], \$context['k'], \$context['v'], \$context['_parent'], \$context['loop']);
 \$context = array_intersect_key(\$context, \$_parent) + \$_parent;
 EOF
         ];
@@ -150,7 +150,7 @@ foreach (\$context['_seq'] as \$context["k"] => \$context["v"]) {
     }
 }
 \$_parent = \$context['_parent'];
-unset(\$context['_seq'], \$context['k'], \$context['v'], \$context['_parent'], \$context['loop']);
+unset(\$context['_parent'], \$context['_seq'], \$context['k'], \$context['v'], \$context['_parent'], \$context['loop']);
 \$context = array_intersect_key(\$context, \$_parent) + \$_parent;
 EOF
         ];
@@ -197,7 +197,7 @@ if (!\$context['_iterated']) {
     yield $fooGetter;
 }
 \$_parent = \$context['_parent'];
-unset(\$context['_seq'], \$context['k'], \$context['v'], \$context['_parent'], \$context['_iterated'], \$context['loop']);
+unset(\$context['_parent'], \$context['_seq'], \$context['k'], \$context['v'], \$context['_parent'], \$context['_iterated'], \$context['loop']);
 \$context = array_intersect_key(\$context, \$_parent) + \$_parent;
 EOF
         ];


### PR DESCRIPTION
By not doing this, PHPStan has a really hard time dealing with loops in loops.

See https://github.com/phpstan/phpstan/issues/11890

This feels like a breaking change for v3. But since `_parent` variable is not documented, it might be OK?

/cc @stof @fabpot 