### PR TITLE
RFC / WIP - html_attributes function

### DIFF
--- a/extra/html-extra/HtmlAttributes.php
+++ b/extra/html-extra/HtmlAttributes.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Twig\Extra\Html;
+
+use Twig\Error\RuntimeError;
+
+final class HtmlAttributes
+{
+    /**
+     * Merges multiple attribute group arrays into a single array.
+     *
+     * `HtmlAttributes::merge(['id' => 'a', 'disabled' => true], ['hidden' => true])` becomes
+     * `['id' => 'a', 'disabled' => true, 'hidden' => true]`
+     *
+     * attributes override each other in the order they are provided.
+     *
+     * `HtmlAttributes::merge(['id' => 'a'], ['id' => 'b'])` becomes `['id' => 'b']`.
+     *
+     * However, `class` and `style` attributes are merged into an array so they can be concatenated in later processing.
+     *
+     * `HtmlAttributes::merge(['class' => 'a'], ['class' => 'b'], ['class' => 'c'])` becomes
+     * `['class' => ['a' => true, 'b' => true, 'c' => true]]`.
+     *
+     * style attributes are also merged into an array so they can be concatenated in later processing.
+     *
+     * `HtmlAttributes::merge(['style' => 'color: red'], ['style' => ['background-color' => 'blue']])` becomes
+     * `['style' => ['color: red;' => true, 'background-color: blue;' => true]]`.
+     *
+     * style attributes which are arrays with false and null values are also processed
+     *
+     * `HtmlAttributes::merge(['style' => ['color: red' => true]], ['style' => ['display: block' => false]]) becomes
+     * `['style' => ['color: red;' => true, 'display: block;' => false]]`.
+     *
+     * attributes can be provided as an array of key, value where the value can be true, false or null.
+     *
+     * Example:
+     * `HtmlAttributes::merge(['class' => ['a' => true, 'b' => false], ['class' => ['c' => null']])` becomes
+     * `['class' => ['a' => true, 'b' => false, 'c' => null]]`.
+     *
+     * `aria` and `data` arrays are expanded into `aria-*` and `data-*` attributes before further processing.
+     *
+     * Example:
+     *
+     * `HtmlAttributes::merge([data' => ['count' => '1']])` becomes `['data-count' => '1']`.
+     * `HtmlAttributes::merge(['aria' => ['hidden' => true]])` becomes `['aria-hidden' => true]`.
+     *
+     * @param ...$attributeGroup
+     * @return array
+     * @throws RuntimeError
+     * @see ./Tests/HtmlAttributesTest.php for usage examples
+     *
+     */
+    public static function merge(...$attributeGroup): array
+    {
+        $result = [];
+
+        $attributeGroupCount = 0;
+
+        foreach ($attributeGroup as $attributes) {
+
+            $attributeGroupCount++;
+
+            // Skip empty attributes
+            // Return early if no attributes are provided
+            // This could be false or null when using the twig ternary operator
+            if (!$attributes) {
+                continue;
+            }
+
+            if (!is_iterable($attributes)) {
+                throw new RuntimeError(sprintf('"%s" only works with mappings or "Traversable", got "%s" for argument %d.', self::class, \gettype($attributes), $attributeGroupCount));
+            }
+
+            // Alternative to is_iterable check above, cast the attributes to an array
+            // This would produce weird results but would not throw an error
+//            $attributes = (array)$attributes;
+
+            // data and aria arrays are expanded into data-* and aria-* attributes
+            $expanded = [];
+            foreach ($attributes as $key => $value) {
+                if (in_array($key, ['data', 'aria'])) {
+                    $value = (array)$value;
+                    foreach ($value as $k => $v) {
+                        $k = $key . '-' . $k;
+                        $expanded[$k] = $v;
+                    }
+                    continue;
+                }
+                $expanded[$key] = $value;
+            }
+
+            // Reset the attributes array to the flattened version
+            $attributes = $expanded;
+
+            foreach ($attributes as $key => $value) {
+
+                // Treat class and data-controller attributes as arrays
+                if (in_array($key, [
+                    'class',
+                    'data-controller',
+                    'data-action',
+                    'data-targets',
+                ])) {
+                    if (!array_key_exists($key, $result)) {
+                        $result[$key] = [];
+                    }
+                    $value = (array)$value;
+                    foreach ($value as $k => $v) {
+                        if (is_int($k)) {
+                            $classes = explode(' ', $v);
+                            foreach ($classes as $class) {
+                                $result[$key][$class] = true;
+                            }
+                        } else {
+                            $classes = explode(' ', $k);
+                            foreach ($classes as $class) {
+                                $result[$key][$class] = $v;
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                if ($key === 'style') {
+                    if (!array_key_exists('style', $result)) {
+                        $result['style'] = [];
+                    }
+                    $value = (array)$value;
+                    foreach ($value as $k => $v) {
+                        if (is_int($k)) {
+                            $styles = array_filter(explode(';', $v));
+                            foreach ($styles as $style) {
+                                $style = explode(':', $style);
+                                $sKey = trim($style[0]);
+                                $sValue = trim($style[1]);
+                                $result['style']["$sKey: $sValue;"] = true;
+                            }
+                        } elseif (is_bool($v) || is_null($v)) {
+                            $styles = array_filter(explode(';', $k));
+                            foreach ($styles as $style) {
+                                $style = explode(':', $style);
+                                $sKey = trim($style[0]);
+                                $sValue = trim($style[1]);
+                                $result['style']["$sKey: $sValue;"] = $v;
+                            }
+                        } else {
+                            $sKey = trim($k);
+                            $sValue = trim($v);
+                            $result['style']["$sKey: $sValue;"] = true;
+                        }
+                    }
+                    continue;
+                }
+
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    public static function renderAttributes($attributes): string
+    {
+        $return = [];
+
+        foreach ($attributes as $key => $value) {
+
+            // Skip null values regardless of attribute key
+            if ($value === null) {
+                continue;
+            }
+
+            // Handle class, style, data-controller value coercion
+            // array[] -> concatenate string
+            if (in_array($key, ['class', 'style', 'data-controller'])) {
+                $value = array_filter($value);
+                $value = array_keys($value);
+                $value = implode(' ', $value);
+            }
+
+            // Handle aria-* value coercion
+            // true -> 'true'
+            // false -> 'false,
+            // array[] ->  concatenate string
+            if (str_starts_with($key, 'aria-')) {
+                if ($value === true) {
+                    $value = 'true';
+                } elseif ($value === false) {
+                    $value = 'false';
+                } elseif(is_array($value)) {
+                    $value = join(" ", array_filter($value));
+                }
+
+            }
+
+            // Handle data-* value coercion
+            // array[] -> json
+            if (str_starts_with($key, 'data-')) {
+                if(is_array($value)) {
+                    $value = json_encode($value);
+                }
+            }
+
+            // Skip false values
+            if ($value === false) {
+                continue;
+            }
+
+            // Boolean attribute doesn't have a value
+             if ($value === true) {
+                $return[] = $key;
+                continue;
+            }
+
+            // Everything else gets added as an encoded value
+            $return[] = $key . '="' . htmlspecialchars($value) . '"';
+        }
+
+        return implode(' ', $return);
+    }
+}

--- a/extra/html-extra/Tests/HtmlAttributesTest.php
+++ b/extra/html-extra/Tests/HtmlAttributesTest.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Twig\Extra\Html\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Twig\Error\RuntimeError;
+use Twig\Extra\Html\HtmlAttributes;
+
+class HtmlAttributesTest extends TestCase
+{
+    /**
+     * @dataProvider htmlAttrProvider
+     * @throws RuntimeError
+     */
+    public function testMerge(array $attributes, array $expectedMergedAttributes, string $expectedAttributeString)
+    {
+        $mergedAttributes = HtmlAttributes::merge(...$attributes);
+        self::assertSame($expectedMergedAttributes, $mergedAttributes);
+        $attributeString = HtmlAttributes::renderAttributes($mergedAttributes);
+        self::assertSame($attributeString, $expectedAttributeString);
+    }
+
+    public function testNonIterableAttributeValuesThrowException()
+    {
+        $this->expectException(\Twig\Error\RuntimeError::class);
+        $result = HtmlAttributes::merge(['class' => 'a'], 'b');
+    }
+
+    /**
+     * Tests output of HtmlAttributes::merge() method can be used as an array of attributes.
+     * @return void
+     * @throws RuntimeError
+     */
+    public function testMultipleMerge()
+    {
+        $result1 = HtmlAttributes::merge(['a' => 'b', 'c' => 'd'],
+            true ? ['e' => 'f'] : null,
+            false ? ['g' => 'h'] : null,
+            ['i' => true],
+            ['j' => true],
+            ['j' => false],
+            ['k' => true],
+            ['k' => null]
+        );
+
+        $result2 = HtmlAttributes::merge(
+            ['class' => 'a b j'],
+            ['class' => ['c', 'd', 'e f']],
+            ['class' => ['g' => true, 'h' => false, 'i' => true]],
+            ['class' => ['h' => true]],
+            ['class' => ['i' => false]],
+            ['class' => ['j' => null]],
+        );
+
+        $result = HtmlAttributes::merge($result1, $result2);
+
+        self::assertSame([
+            'a' => 'b',
+            'c' => 'd',
+            'e' => 'f',
+            'i' => true,
+            'j' => false,
+            'k' => null,
+            'class' => [
+                'a' => true,
+                'b' => true,
+                'j' => null,
+                'c' => true,
+                'd' => true,
+                'e' => true,
+                'f' => true,
+                'g' => true,
+                'h' => true,
+                'i' => false,
+            ]
+        ], $result);
+    }
+
+    public function htmlAttrProvider(): \Generator
+    {
+        yield 'merging basic attributes' => [
+            [
+                ['a' => 'b', 'c' => 'd'],
+                true ? ['e' => 'f'] : null,
+                false ? ['g' => 'h'] : null,
+                ['i' => true],
+                ['j' => true],
+                ['j' => false],
+                ['k' => true],
+                ['k' => null],
+            ],
+            [
+                'a' => 'b',
+                'c' => 'd',
+                'e' => 'f',
+                'i' => true,
+                'j' => false,
+                'k' => null
+            ],
+            'a="b" c="d" e="f" i',
+        ];
+
+        /**
+         * class attributes are merged into an array so they can be concatenated in later processing.
+         */
+        yield 'merging class attributes' => [
+            [
+                ['class' => 'a b j'],
+                ['class' => ['c', 'd', 'e f']],
+                ['class' => ['g' => true, 'h' => false, 'i' => true]],
+                ['class' => ['h' => true]],
+                ['class' => ['i' => false]],
+                ['class' => ['j' => null]],
+            ],
+            ['class' => [
+                'a' => true,
+                'b' => true,
+                'j' => null,
+                'c' => true,
+                'd' => true,
+                'e' => true,
+                'f' => true,
+                'g' => true,
+                'h' => true,
+                'i' => false,
+            ]],
+            'class="a b c d e f g h"',
+        ];
+
+        /**
+         * style attributes are merged into an array so they can be concatenated in later processing.
+         * // Strings are true by default.
+         * `HtmlAttributes::merge(['color: red']) === ['color: red' => true]`
+         * // Arrays have a boolean / null value
+         * `HtmlAttributes::merge(['color: red' => true ]) === ['color: red' => true]`
+         * `HtmlAttributes::merge(['color: red' => false ]) === ['color: red' => false]`
+         * String values are split into key value pairs and then processed
+         * `HtmlAttributes::merge(['color: red; background: blue']) === ['color: red' => true, 'background: blue' => true]`
+         * `HtmlAttributes::merge(['color: red; background: blue' => true]) === ['color: red' => true, 'background: blue' => true]`
+         */
+        yield 'merging style attributes' => [
+            [
+                ['style' => 'a: b;'],
+                ['style' => ['c' => 'd', 'e' => 'f']],
+                ['style' => ['g: h;']],
+                ['style' => [
+                    'i: j; k: l' => true,
+                    'm: n' => false,
+                    'o: p' => null
+                ]],
+            ],
+            ['style' => [
+                'a: b;' => true,
+                'c: d;' => true,
+                'e: f;' => true,
+                'g: h;' => true,
+                'i: j;' => true,
+                'k: l;' => true,
+                'm: n;' => false,
+                'o: p;' => null,
+            ]],
+            'style="a: b; c: d; e: f; g: h; i: j; k: l;"',
+        ];
+
+        /**
+         * `data` arrays are expanded into `data-*` attributes before further processing.
+         */
+        yield 'merging data-* attributes' => [
+            [
+                ['data-string' => 'a'],
+                ['data-int' => 100],
+                ['data-bool-true' => true],
+                ['data-bool-false' => false],
+                ['data-null' => null],
+                ['data-array' => ['a' => 'b']],
+                ['data' => ['expanded-0' => true, 'expanded-1' => false, 'expanded-2' => null]],
+            ],
+            [
+                'data-string' => 'a',
+                'data-int' => 100,
+                'data-bool-true' => true,
+                'data-bool-false' => false,
+                'data-null' => null,
+                'data-array' => ['a' => 'b'],
+                'data-expanded-0' => true,
+                'data-expanded-1' => false,
+                'data-expanded-2' => null,
+            ],
+            'data-string="a" data-int="100" data-bool-true data-array="{&quot;a&quot;:&quot;b&quot;}" data-expanded-0'
+        ];
+
+        /**
+         * `aria` arrays are expanded into `aria-*` attributes before further processing.
+         */
+        yield 'merging aria-* attributes' => [
+            [
+                ['aria-string' => 'a'],
+                ['aria-int' => 100],
+                ['aria-bool-true' => true],
+                ['aria-bool-false' => false],
+                ['aria-null' => null],
+                ['aria-array' => ['a', 'b']],
+                ['aria' => ['expanded-0' => true, 'expanded-1' => false, 'expanded-2' => null]],
+            ],
+            [
+                'aria-string' => 'a',
+                'aria-int' => 100,
+                'aria-bool-true' => true,
+                'aria-bool-false' => false,
+                'aria-null' => null,
+                'aria-array' => ['a', 'b'],
+                'aria-expanded-0' => true,
+                'aria-expanded-1' => false,
+                'aria-expanded-2' => null,
+            ],
+            'aria-string="a" aria-int="100" aria-bool-true="true" aria-bool-false="false" aria-array="a b" aria-expanded-0="true" aria-expanded-1="false"'
+        ];
+
+        yield 'merging data-controller attributes' => [
+            [
+                ['data' => ['controller' => 'c1 c2']],
+                ['data-controller' => 'c3'],
+                ['data-controller' => ['c4' => true]],
+                ['data-controller' => ['c5' => false]],
+                ['data-controller' => ['c6' => null]],
+            ],
+            [
+                'data-controller' => [
+                    'c1' => true,
+                    'c2' => true,
+                    'c3' => true,
+                    'c4' => true,
+                    'c5' => false,
+                    'c6' => null
+                ],
+            ],
+            'data-controller="c1 c2 c3 c4"'
+        ];
+
+
+    }
+}


### PR DESCRIPTION
An alternative implementation to #3930

Addresses:

* https://github.com/twigphp/Twig/issues/3907
* https://github.com/twigphp/html-extra/pull/4
* https://github.com/twigphp/Twig/pull/3760

This WIP pr demonstrates a html attribute merging strategy for html attributes, aria-attributes with special handling for `class`, `style` `data` and `aria` attributes.

I've currently focussed on the `HtmlAttributes::merge` function which returns the merged attributes array.

## Examples

See [`./Tests/HtmlAttributesTest.php`](https://github.com/twigphp/Twig/pull/4405/files#diff-210291f849102679e6c0a1050d5bcd3076cf55b3cc9677c20fab26dcd15f543c) for usage examples

```php
// Basic attribute merging
HtmlAttributes::merge(
    ['id' => 'a', 'disabled' => true], 
    ['hidden' => true]
) 
=== 
['id' => 'a', 'disabled' => true, 'hidden' => true]
``` 

```php
// Attribute overriding
HtmlAttributes::merge(
    ['id' => 'a'], 
    ['id' => 'b']
) 
===
['id' => 'b']
``` 

```php
// class merging
// class attributes produce an array of key / values where the value is true, false, null.
// multiple classnames are split on spaces
HtmlAttributes::merge(
    ['class' => 'a'], 
    ['class' => 'b'], 
    ['class' => 'c'],
    ['class' => 'd e']
) 
===
['class' => ['a' => true, 'b' => true, 'c' => true, 'd' => true, 'e' => true]]
``` 

```php
// Style merging
// values provided as string, array of strings or key / value array
// styles are split on ":" and converted to key / value pairs
HtmlAttributes::merge(
    ['style' => 'color: red'], 
    ['style' => ['color: green']], 
    ['style' => ['background-color' => 'blue']],
    ['style' => ['display: block' => false]]
) 
===
['style' => ['color: green;' => 'true', 'background-color: blue;' => 'true', 'display: block;' => false]]
```

```php
// data expansion:
HtmlAttributes::merge(
    [data' => ['count' => '1']]
) 
===
['data-count' => '1']
``` 

```php
// aria expansion:
HtmlAttributes::merge(
    ['aria' => ['hidden' => true]]
) 
===
['aria-hidden' => true]
``` 

The return value of `HtmlAttributes::merge` should also be able to be used as an input for `HtmlAttributes::merge` as demonstrated here: 

https://github.com/twigphp/Twig/pull/4405/files#diff-210291f849102679e6c0a1050d5bcd3076cf55b3cc9677c20fab26dcd15f543cR27-R75

## Rendering Attributes

The `HtmlAttributes::renderAttributes` method that takes the output of `HtmlAttributes::merge` and creates the attribute string.

This method:

1. skips `null` attribute values
2. filters and implodes `class`, `style` and `data-controller` attribute values
3. coerces `aria-*` boolean attribute values to `'true'` `'false'` strings.
4. json encodes `data-*` array values
5. skips remaining `false` values (see `aria-*` coercion above)
6. returns attribute name for `true` boolean values
7. returns attribute name and encoded value for everything else

[`./Tests/HtmlAttributesTest.php`](https://github.com/twigphp/Twig/pull/4405/files#diff-210291f849102679e6c0a1050d5bcd3076cf55b3cc9677c20fab26dcd15f543c) demonstrate the return value of `HtmlAttributes::merge` and `HtmlAttributes::renderAttributes`

There was some consideration made to coerce `data-*` boolean values to string `'true'` and `'false'` but this was decided against. StimulusJs uses the following conditional to determine if a `data-*-value` attribute is `true` or `false` when internally coercing to a javascript `Boolean`.

```js
// https://stimulus.hotwired.dev/reference/values#types
!(value == "0" || value == "false")
```

Illustrated here: https://codepen.io/leevigraham/pen/MWNOyLr

## Challenges

The challenge with a `html_attributes` like function is that the merging strategy is arbitrary.

`class` and `style` attributes are usually merged together. Other attributes override the previous values.

Symfony [UX twig components](https://symfony.com/bundles/ux-twig-component/current/index.html) recommend [Stimulus](https://stimulus.hotwired.dev) for [interaction](https://symfony.com/bundles/ux-live-component/current/index.html#working-with-the-component-in-javascript). Stimulus uses `data-controller` attributes for functionality. The `data-controller` value can be a space delimited list of strings. In this case should the multiple `data-controller` values be merged or overridden? For StimulusJs also applies to `data-target` and `data-action`

## Alternative implementation ideas

### Merge strategy options

Given the challenges with `data-controller` above maybe the method should take 2 arguments:

1. The attributes to be merged
2. An array which defines the merging strategy

```php
HtmlAttributes::merge(
    attributes: ['style' => ['background-color' => 'blue', 'color' => 'red']],
    options: ['merge' => ['class', 'data-controller']]
)
```

In the example above the `$options` argument would be used to determine which values to merge. Other values would replace.

Given the return value of `HtmlAttributes::merge` can also be used as the `$attributes` argument of `HtmlAttributes::merge` the developer could call `HtmlAttributes::merge` multiple times which would be the equivalent of multiple attribute arrays / argument unpacking.

## References in other platforms / frameworks:

Yii2 has a similar function: https://github.com/yiisoft/yii2/blob/master/framework/helpers/BaseHtml.php#L1966-L2046

The [renderTagAttributes](https://www.yiiframework.com/doc/api/2.0/yii-helpers-basehtml#renderTagAttributes()-detail) method has the following rules:

* Attributes whose values are of boolean type will be treated as [boolean attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes).
* Attributes whose values are null will not be rendered.
* aria and data attributes get special handling when they are set to an array value. In these cases, the array will be "expanded" and a list of ARIA/data attributes will be rendered. For example, `'aria' => ['role' => 'checkbox', 'value' => 'true']` would be rendered as `aria-role="checkbox" aria-value="true`".
* If a nested data value is set to an array, it will be JSON-encoded. For example, `'data' => ['params' => ['id' => 1, 'name' => 'yii']]` would be rendered as `data-params='{"id":1,"name":"yii"}`'.

CraftCMS uses twig and provides an attr() twig method that implements renderTagAttributes. I've used this helper many times and the rules above are great. Especially the "Attributes whose values are null will not be rendered".

Vuejs v2 -> v3 also went through some changes for false values https://v3-migration.vuejs.org/breaking-changes/attribute-coercion.html. This aligns with "Attributes whose values are null will not be rendered." above.

## TODO

- [ ] add twig filter function
- [ ] cleanup code
- [ ] write docs