### PR TITLE
Add return type to compiled macro

### DIFF
--- a/src/Node/MacroNode.php
+++ b/src/Node/MacroNode.php
@@ -14,6 +14,7 @@ namespace Twig\Node;
 use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Error\SyntaxError;
+use Twig\Markup;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\Variable\LocalVariable;
 
@@ -76,7 +77,7 @@ class MacroNode extends Node
 
         $compiler
             ->raw('...$varargs')
-            ->raw(")\n")
+            ->raw("): string|Markup\n")
             ->write("{\n")
             ->indent()
             ->write("\$macros = \$this->macros;\n")

--- a/tests/Node/MacroTest.php
+++ b/tests/Node/MacroTest.php
@@ -49,7 +49,7 @@ class MacroTest extends NodeTestCase
 
         yield 'with use_yield = true' => [$node, <<<EOF
 // line 1
-public function macro_foo(\$foo = null, \$bar = "Foo", ...\$varargs)
+public function macro_foo(\$foo = null, \$bar = "Foo", ...\$varargs): string|Markup
 {
     \$macros = \$this->macros;
     \$context = [
@@ -71,7 +71,7 @@ EOF
 
         yield 'with use_yield = false' => [$node, <<<EOF
 // line 1
-public function macro_foo(\$foo = null, \$bar = "Foo", ...\$varargs)
+public function macro_foo(\$foo = null, \$bar = "Foo", ...\$varargs): string|Markup
 {
     \$macros = \$this->macros;
     \$context = [


### PR DESCRIPTION
This makes it easier for TwigStan to analyze the return type.