### PR TITLE
do not drop none digit characters from generated variable names

### DIFF
--- a/src/Node/Expression/TempNameExpression.php
+++ b/src/Node/Expression/TempNameExpression.php
@@ -41,7 +41,7 @@ class TempNameExpression extends AbstractExpression
     public function compile(Compiler $compiler): void
     {
         if (null === $this->getAttribute('name')) {
-            $this->setAttribute('name', \sprintf('_l%d', $compiler->getVarName()));
+            $this->setAttribute('name', $compiler->getVarName());
         }
 
         $compiler->raw('$'.$this->getAttribute('name'));


### PR DESCRIPTION
I was wondering if it was really intended to cast the var name generated by the compiler to an int as done in #4398. Doesn't this create the risk of variable names being reused at some point?