### PR TITLE
Prevent calling yield() on false

### DIFF
--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -339,7 +339,6 @@ final class ModuleNode extends Node
                     ->raw(");\n")
                 ;
             }
-
             $compiler->write('yield from ');
 
             if ($parent instanceof ConstantExpression) {
@@ -347,7 +346,6 @@ final class ModuleNode extends Node
             } else {
                 $compiler->raw('$this->getParent($context)?');
             }
-
             $compiler->raw("->unwrap()->yield(\$context, array_merge(\$this->blocks, \$blocks));\n");
         }
 

--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -190,11 +190,6 @@ final class ModuleNode extends Node
             ->write("\$this->source = \$this->getSourceContext();\n\n")
         ;
 
-        // parent
-        if (!$this->hasNode('parent')) {
-            $compiler->write("\$this->parent = false;\n\n");
-        }
-
         $countTraits = \count($this->getNode('traits'));
         if ($countTraits) {
             // traits
@@ -344,13 +339,15 @@ final class ModuleNode extends Node
                     ->raw(");\n")
                 ;
             }
+
             $compiler->write('yield from ');
 
             if ($parent instanceof ConstantExpression) {
                 $compiler->raw('$this->parent');
             } else {
-                $compiler->raw('$this->getParent($context)');
+                $compiler->raw('$this->getParent($context)?');
             }
+
             $compiler->raw("->unwrap()->yield(\$context, array_merge(\$this->blocks, \$blocks));\n");
         }
 

--- a/src/Template.php
+++ b/src/Template.php
@@ -32,7 +32,7 @@ abstract class Template
     public const ARRAY_CALL = 'array';
     public const METHOD_CALL = 'method';
 
-    protected $parent;
+    protected ?self $parent = null;
     protected $parents = [];
     protected $blocks = [];
     protected $traits = [];
@@ -74,14 +74,14 @@ abstract class Template
      *
      * @return self|TemplateWrapper|false The parent template or false if there is no parent
      */
-    public function getParent(array $context): self|TemplateWrapper|false
+    public function getParent(array $context): self|TemplateWrapper|null
     {
         if (null !== $this->parent) {
             return $this->parent;
         }
 
         if (!$parent = $this->doGetParent($context)) {
-            return false;
+            return null;
         }
 
         if ($parent instanceof self || $parent instanceof TemplateWrapper) {

--- a/tests/Node/ModuleTest.php
+++ b/tests/Node/ModuleTest.php
@@ -92,8 +92,6 @@ class __TwigTemplate_%x extends Template
 
         \$this->source = \$this->getSourceContext();
 
-        \$this->parent = false;
-
         \$this->blocks = [
         ];
     }
@@ -120,7 +118,7 @@ class __TwigTemplate_%x extends Template
      */
     public function getDebugInfo(): array
     {
-        return array (  42 => 1,);
+        return array (  40 => 1,);
     }
 
     public function getSourceContext(): Source
@@ -281,7 +279,7 @@ class __TwigTemplate_%x extends Template
         // line 4
         \$context["foo"] = "foo";
         // line 2
-        yield from \$this->getParent(\$context)->unwrap()->yield(\$context, array_merge(\$this->blocks, \$blocks));
+        yield from \$this->getParent(\$context)?->unwrap()->yield(\$context, array_merge(\$this->blocks, \$blocks));
     }
 
     /**


### PR DESCRIPTION
When Template::getParent returns false, calling yield() will fail.

> Cannot call method yield() on Twig\\Template|Twig\\TemplateWrapper|false.

Let's change the return type of `getTemplate` from false to null.

This allows us to use the null safe operator introduced in PHP 8.