### PR TITLE
Define missing macros variable in constructor

### DIFF
--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -187,6 +187,7 @@ final class ModuleNode extends Node
             ->indent()
             ->subcompile($this->getNode('constructor_start'))
             ->write("parent::__construct(\$env);\n\n")
+            ->write("\$macros = \$this->macros;\n")
             ->write("\$this->source = \$this->getSourceContext();\n\n")
         ;
 

--- a/tests/Node/ModuleTest.php
+++ b/tests/Node/ModuleTest.php
@@ -90,6 +90,7 @@ class __TwigTemplate_%x extends Template
     {
         parent::__construct(\$env);
 
+        \$macros = \$this->macros;
         \$this->source = \$this->getSourceContext();
 
         \$this->parent = false;
@@ -120,7 +121,7 @@ class __TwigTemplate_%x extends Template
      */
     public function getDebugInfo(): array
     {
-        return array (  42 => 1,);
+        return array (  43 => 1,);
     }
 
     public function getSourceContext(): Source
@@ -167,6 +168,7 @@ class __TwigTemplate_%x extends Template
     {
         parent::__construct(\$env);
 
+        \$macros = \$this->macros;
         \$this->source = \$this->getSourceContext();
 
         \$this->blocks = [
@@ -211,7 +213,7 @@ class __TwigTemplate_%x extends Template
      */
     public function getDebugInfo(): array
     {
-        return array (  48 => 1,  46 => 2,  39 => 1,);
+        return array (  49 => 1,  47 => 2,  40 => 1,);
     }
 
     public function getSourceContext(): Source
@@ -263,6 +265,7 @@ class __TwigTemplate_%x extends Template
     {
         parent::__construct(\$env);
 
+        \$macros = \$this->macros;
         \$this->source = \$this->getSourceContext();
 
         \$this->blocks = [
@@ -306,7 +309,7 @@ class __TwigTemplate_%x extends Template
      */
     public function getDebugInfo(): array
     {
-        return array (  48 => 2,  46 => 4,  39 => 2,);
+        return array (  49 => 2,  47 => 4,  40 => 2,);
     }
 
     public function getSourceContext(): Source


### PR DESCRIPTION
When defining a macro in a template, the constructor looks like this:

```php
    public function __construct(\Twig\Environment $env)
    {
        parent::__construct($env);
        $this->source = $this->getSourceContext();
        $this->parent = \false;
        $this->blocks = [];
        $macros["_self"] = $this->macros["_self"] = $this;
    }
```

The `$macros` variable does not exist resulting in:

> Implicit array creation is not allowed - variable $macros does not exist.

/cc @fabpot Is this the best way to do it? Or would it be better to make this conditional instead?
https://github.com/twigphp/Twig/blob/f3db1d1a0c5cc21fad255bd6690bbde16d378459/src/Node/Expression/Variable/AssignTemplateVariable.php#L31-L36