### PR TITLE
Add `$this` return type to Template::unwrap

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -318,6 +318,7 @@ abstract class Template
 
     /**
      * @internal
+     * @return $this
      */
     public function unwrap(): self
     {


### PR DESCRIPTION
See https://phpstan.org/writing-php-code/phpdoc-types#static-and-%24this

This way, PHPStan understands that the returned template is the exact same instance, and not just a Template.