### PR TITLE
Add type for join method

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -766,9 +766,9 @@ final class CoreExtension extends AbstractExtension
      *  {{ [1, 2, 3]|join }}
      *  {# returns 123 #}
      *
-     * @param array       $value An array
-     * @param string      $glue  The separator
-     * @param string|null $and   The separator for the last pair
+     * @param iterable|array|string|float|int|bool|null  $value An array
+     * @param string                                     $glue  The separator
+     * @param string|null                                $and   The separator for the last pair
      *
      * @internal
      */


### PR DESCRIPTION
Looking at the code, this method is very forgiving in what it accepts.

This helps PHPStan to not complain when something other than an array is passed.

Did I miss other types?

/cc @stof 