### PR TITLE
[String] Add SpanishInflector support for singular and plural

### DIFF
--- a/extra/string-extra/StringExtension.php
+++ b/extra/string-extra/StringExtension.php
@@ -15,17 +15,20 @@ use Symfony\Component\String\AbstractUnicodeString;
 use Symfony\Component\String\Inflector\EnglishInflector;
 use Symfony\Component\String\Inflector\FrenchInflector;
 use Symfony\Component\String\Inflector\InflectorInterface;
+use Symfony\Component\String\Inflector\SpanishInflector;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Component\String\Slugger\SluggerInterface;
 use Symfony\Component\String\UnicodeString;
+use Twig\Error\RuntimeError;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 final class StringExtension extends AbstractExtension
 {
     private $slugger;
-    private $frenchInflector;
     private $englishInflector;
+    private $spanishInflector;
+    private $frenchInflector;
 
     public function __construct(?SluggerInterface $slugger = null)
     {
@@ -79,10 +82,15 @@ final class StringExtension extends AbstractExtension
     private function getInflector(string $locale): InflectorInterface
     {
         switch ($locale) {
-            case 'fr':
-                return $this->frenchInflector ?? $this->frenchInflector = new FrenchInflector();
             case 'en':
                 return $this->englishInflector ?? $this->englishInflector = new EnglishInflector();
+            case 'es':
+                if (!class_exists(SpanishInflector::class)) {
+                    throw new RuntimeError('SpanishInflector is not available.');
+                }
+                return $this->spanishInflector ?? $this->spanishInflector = new SpanishInflector();
+            case 'fr':
+                return $this->frenchInflector ?? $this->frenchInflector = new FrenchInflector();
             default:
                 throw new \InvalidArgumentException(\sprintf('Locale "%s" is not supported.', $locale));
         }

--- a/extra/string-extra/Tests/Fixtures/plural.test
+++ b/extra/string-extra/Tests/Fixtures/plural.test
@@ -5,6 +5,8 @@
 {{ 'partition'|plural('fr', all=true)|join(',') }}
 {{ 'person'|plural('fr') }}
 {{ 'person'|plural('en', all=true)|join(',') }}
+{{ 'avión'|plural('es') }}
+{{ 'avión'|plural('es', all=true)|join(',') }}
 
 --DATA--
 return []
@@ -13,3 +15,5 @@ partitions
 partitions
 persons
 persons,people
+aviones
+aviones

--- a/extra/string-extra/Tests/Fixtures/singular.test
+++ b/extra/string-extra/Tests/Fixtures/singular.test
@@ -7,6 +7,8 @@
 {{ 'persons'|singular('en', all=true)|join(',') }}
 {{ 'people'|singular('en') }}
 {{ 'people'|singular('en', all=true)|join(',') }}
+{{ 'personas'|singular('es') }}
+{{ 'personas'|singular('es', all=true)|join(',') }}
 
 --DATA--
 return []
@@ -17,3 +19,5 @@ person
 person
 person
 person
+persona
+persona


### PR DESCRIPTION
This PR implement a new Inflector using Spanish (ISO Code = es) implemented in this PR symfony/symfony#58228.

* I sort the list of supported Inflectors to follow some rule (alphabet?)
* I just change invalid test from "it" to "qq" (qq doesn't exist as valid ISO code, but it is italian... don't be evil if anyone want to create the italian inflector 😅 )