### PR TITLE
Fix wrong type for cycle position

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -344,7 +344,7 @@ final class CoreExtension extends AbstractExtension
      * Cycles over a sequence.
      *
      * @param array|\ArrayAccess $values   A non-empty sequence of values
-     * @param positive-int       $position The position of the value to return in the cycle
+     * @param int<0, max>        $position The position of the value to return in the cycle
      *
      * @return mixed The value at the given position in the sequence, wrapping around as needed
      *


### PR DESCRIPTION
It also accepts 0, which is not a positive int.