### PR TITLE
Add recursion prevention

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -488,7 +488,7 @@ won't be allowed and will generate a ``\Twig\Sandbox\SecurityError`` exception.
 
 .. note::
 
-    As of Twig 1.14.1 (and on Twig 3.11.2), if the ``Article`` class implements
+    As of Twig 3.14.1 (and on Twig 3.11.2), if the ``Article`` class implements
     the ``ArrayAccess`` interface, the templates will only be able to access
     the ``title`` and ``body`` attributes.
 

--- a/tests/Extension/SandboxTest.php
+++ b/tests/Extension/SandboxTest.php
@@ -41,7 +41,10 @@ class SandboxTest extends TestCase
             'some_array' => [5, 6, 7, new FooObject()],
             'array_like' => new ArrayLikeObject(),
             'magic' => new MagicObject(),
+            'recursion' => [4],
         ];
+        self::$params['recursion'][] = &self::$params['recursion'];
+        self::$params['recursion'][] = new FooObject();
 
         self::$templates = [
             '1_basic1' => '{{ obj.foo }}',
@@ -240,6 +243,7 @@ class SandboxTest extends TestCase
             'context' => ['{{ _context|join(", ") }}'],
             'spread_array_operator' => ['{{ [1, 2, ...[5, 6, 7, obj]]|join(",") }}'],
             'spread_array_operator_var' => ['{{ [1, 2, ...some_array]|join(",") }}'],
+            'recursion' => ['{{ recursion|join(", ") }}'],
         ];
     }
 
@@ -573,13 +577,13 @@ class ArrayLikeObject extends \ArrayObject
 {
     public function offsetExists($offset): bool
     {
-        throw new \BadMethodCallException('Should not be called');
+        throw new \BadMethodCallException('Should not be called.');
     }
 
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
-        throw new \BadMethodCallException('Should not be called');
+        throw new \BadMethodCallException('Should not be called.');
     }
 
     public function offsetSet($offset, $value): void
@@ -596,11 +600,11 @@ class MagicObject
     #[\ReturnTypeWillChange]
     public function __get($name)
     {
-        throw new \BadMethodCallException('Should not be called');
+        throw new \BadMethodCallException('Should not be called.');
     }
 
     public function __isset($name): bool
     {
-        throw new \BadMethodCallException('Should not be called');
+        throw new \BadMethodCallException('Should not be called.');
     }
 }


### PR DESCRIPTION
Resolves #4439

Drupal allows printing arrays direct in templates, as we have a node visitor/render function that can 'render' our 'render arrays'.

This adds some recursion prevention.