### PR TITLE
Clarify documentation for escape filter

### DIFF
--- a/doc/filters/escape.rst
+++ b/doc/filters/escape.rst
@@ -42,7 +42,9 @@ documents:
 * ``html``: escapes a string for the **HTML body** context, 
   or for HTML attributes values **inside quotes**.
 
-* ``js``: escapes a string for the **JavaScript** context.
+* ``js``: escapes a string for the **JavaScript** context. This is intended for 
+  use in JavaScript or JSON strings, and encodes values using backslash escape 
+  sequences.
 
 * ``css``: escapes a string for the **CSS** context. CSS escaping can be
   applied to any string being inserted into CSS and escapes everything except


### PR DESCRIPTION
It was somewhat unclear from the documentation what the intended purpose of the 'js' escape strategy is. I wasn't certain *where* exactly in JavaScript such strings were intended to be output. Someone (by that I mean me--though maybe I'm just an idiot...) might inadvertently think the filter was meant to be used somewhere in actual JavaScript code, rather than simply in strings.