### PR TITLE
Add missing import

### DIFF
--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -14,6 +14,7 @@ namespace Twig\Extension;
 use Twig\ExpressionParser;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\NodeVisitor\NodeVisitorInterface;
+use Twig\OperatorPrecedenceChange;
 use Twig\TokenParser\TokenParserInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;


### PR DESCRIPTION
Hi @fabpot, the phpdoc was updated in https://github.com/twigphp/Twig/pull/4367 but the import was forgotten.
This leads to an error with all static analysis tools when implementing ExtensionInterface.

If possible a patch version would be helpful.

(Tests are already failing on 3.x)