### PR TITLE
Fix the exception message to match the expected one for not ready nodes

### DIFF
--- a/src/NodeVisitor/YieldNotReadyNodeVisitor.php
+++ b/src/NodeVisitor/YieldNotReadyNodeVisitor.php
@@ -38,7 +38,7 @@ final class YieldNotReadyNodeVisitor implements NodeVisitorInterface
 
         if (!$this->yieldReadyNodes[$class] = (bool) (new \ReflectionClass($class))->getAttributes(YieldReady::class)) {
             if ($this->useYield) {
-                throw new \LogicException(\sprintf('You cannot enable the "use_yield" option of Twig as node "%s" is not marked as ready for it; please make it ready and then flag it with the #[YieldReady] attribute.', $class));
+                throw new \LogicException(\sprintf('You cannot enable the "use_yield" option of Twig as node "%s" is not marked as ready for it; please make it ready and then flag it with the #[\Twig\Attribute\YieldReady] attribute.', $class));
             }
 
             trigger_deprecation('twig/twig', '3.9', 'Twig node "%s" is not marked as ready for using "yield" instead of "echo"; please make it ready and then flag it with the #[\Twig\Attribute\YieldReady] attribute.', $class);


### PR DESCRIPTION
This fixes the tests that got broken in https://github.com/twigphp/Twig/pull/4446 because that PR updated the expected message to include the FQCN of the attribute for both the deprecation and the exception, but forgot to use the FQCN in the actual exception.