### PR TITLE
Fix the string-extra tests when running with older symfony/string

### DIFF
--- a/extra/string-extra/Tests/Fixtures/plural.test
+++ b/extra/string-extra/Tests/Fixtures/plural.test
@@ -5,8 +5,6 @@
 {{ 'partition'|plural('fr', all=true)|join(',') }}
 {{ 'person'|plural('fr') }}
 {{ 'person'|plural('en', all=true)|join(',') }}
-{{ 'avión'|plural('es') }}
-{{ 'avión'|plural('es', all=true)|join(',') }}
 
 --DATA--
 return []
@@ -15,5 +13,3 @@ partitions
 partitions
 persons
 persons,people
-aviones
-aviones

--- a/extra/string-extra/Tests/Fixtures/plural_es.test
+++ b/extra/string-extra/Tests/Fixtures/plural_es.test
@@ -1,0 +1,13 @@
+--TEST--
+"plural" filter
+--CONDITION--
+class_exists('Symfony\Component\String\Inflector\SpanishInflector')
+--TEMPLATE--
+{{ 'avión'|plural('es') }}
+{{ 'avión'|plural('es', all=true)|join(',') }}
+
+--DATA--
+return []
+--EXPECT--
+aviones
+aviones

--- a/extra/string-extra/Tests/Fixtures/singular.test
+++ b/extra/string-extra/Tests/Fixtures/singular.test
@@ -7,8 +7,6 @@
 {{ 'persons'|singular('en', all=true)|join(',') }}
 {{ 'people'|singular('en') }}
 {{ 'people'|singular('en', all=true)|join(',') }}
-{{ 'personas'|singular('es') }}
-{{ 'personas'|singular('es', all=true)|join(',') }}
 
 --DATA--
 return []
@@ -19,5 +17,3 @@ person
 person
 person
 person
-persona
-persona

--- a/extra/string-extra/Tests/Fixtures/singular_es.test
+++ b/extra/string-extra/Tests/Fixtures/singular_es.test
@@ -1,0 +1,13 @@
+--TEST--
+"singular" filter
+--CONDITION--
+class_exists('Symfony\Component\String\Inflector\SpanishInflector')
+--TEMPLATE--
+{{ 'personas'|singular('es') }}
+{{ 'personas'|singular('es', all=true)|join(',') }}
+
+--DATA--
+return []
+--EXPECT--
+persona
+persona


### PR DESCRIPTION
My review comment in https://github.com/twigphp/Twig/pull/4426#discussion_r1822452803 was not taken into account to handle the case of using a version of `symfony/string` without the SpanishInflector, and the PR was merged with broken tests.