### PR TITLE
Fix the intl-extra tests

### DIFF
--- a/extra/intl-extra/Tests/Fixtures/currency_names.test
+++ b/extra/intl-extra/Tests/Fixtures/currency_names.test
@@ -10,7 +10,7 @@
 return [];
 --EXPECT--
 0
-293
-293
+294
+294
 US Dollar
 dollar des États-Unis

--- a/extra/intl-extra/Tests/Fixtures/script_names.test
+++ b/extra/intl-extra/Tests/Fixtures/script_names.test
@@ -10,7 +10,7 @@
 return [];
 --EXPECT--
 0
-201
-201
+208
+208
 Marchen
 Marchen


### PR DESCRIPTION
symfony/intl has updated its data from ICU 75.1 to ICU 76.1, which includes new currency and scripts.