### PR TITLE
Remove PHP 8.1 polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "php": ">=8.2",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-mbstring": "^1.3",
-        "symfony/polyfill-ctype": "^1.8",
-        "symfony/polyfill-php81": "^1.29"
+        "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {
         "psr/container": "^1.0|^2.0",


### PR DESCRIPTION
Not needed when the Twig 4 requires 8.2.
