### PR TITLE
Fix SafeAnalysisNodeVisitor::getSafe() return value

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # 3.16.0 (2024-XX-XX)
 
  * Deprecate not passing a `Source` instance to `TokenStream`
+ * Deprecate returning `null` from `TwigFilter::getSafe()` and `TwigFunction::getSafe()`, return `[]` instead
 
 # 3.15.0 (2024-11-17)
  

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -319,6 +319,10 @@ Functions/Filters/Tests
   arrow functions is deprecated as of Twig 3.15; these arguments will have a
   ``\Closure`` type hint in 4.0.
 
+* Returning ``null`` from ``TwigFilter::getSafe()`` and
+  ``TwigFunction::getSafe()`` is deprecated as of Twig 3.16; return ``[]``
+  instead.
+
 Node
 ----
 

--- a/src/NodeVisitor/EscaperNodeVisitor.php
+++ b/src/NodeVisitor/EscaperNodeVisitor.php
@@ -172,7 +172,7 @@ final class EscaperNodeVisitor implements NodeVisitorInterface
     {
         $safe = $this->safeAnalysis->getSafe($expression);
 
-        if (null === $safe) {
+        if (!$safe) {
             if (null === $this->traverser) {
                 $this->traverser = new NodeTraverser($env, [$this->safeAnalysis]);
             }

--- a/src/TwigFilter.php
+++ b/src/TwigFilter.php
@@ -54,12 +54,12 @@ final class TwigFilter extends AbstractTwigCallable
             return $this->options['is_safe_callback']($filterArgs);
         }
 
-        return null;
+        return [];
     }
 
-    public function getPreservesSafety(): ?array
+    public function getPreservesSafety(): array
     {
-        return $this->options['preserves_safety'];
+        return $this->options['preserves_safety'] ?? [];
     }
 
     public function getPreEscape(): ?string


### PR DESCRIPTION
`SafeAnalysisNodeVisitor::getSafe()` can return `[]` or `null`. Both mean the same thing, but `null` is partially supported as `EscaperNodeVisitor` does not support `null` everywhere (as the node visitor never set `safe` to `null`). But a third party might return `null`. This PR makes the code more robust by deprecating using `null`.
