### PR TITLE
Simplify code

### DIFF
--- a/src/NodeVisitor/EscaperNodeVisitor.php
+++ b/src/NodeVisitor/EscaperNodeVisitor.php
@@ -77,7 +77,7 @@ final class EscaperNodeVisitor implements NodeVisitorInterface
             return $this->preEscapeFilterNode($node, $env);
         } elseif ($node instanceof PrintNode && false !== $type = $this->needEscaping()) {
             $expression = $node->getNode('expr');
-            if ($expression instanceof ConditionalExpression && $this->shouldUnwrapConditional($expression, $env, $type)) {
+            if ($expression instanceof ConditionalExpression) {
                 return new DoNode($this->unwrapConditional($expression, $env, $type), $expression->getTemplateLine());
             }
 
@@ -93,32 +93,19 @@ final class EscaperNodeVisitor implements NodeVisitorInterface
         return $node;
     }
 
-    private function shouldUnwrapConditional(ConditionalExpression $expression, Environment $env, string $type): bool
-    {
-        /** @var AbstractExpression $expr2 */
-        $expr2 = $expression->getNode('expr2');
-        /** @var AbstractExpression $expr3 */
-        $expr3 = $expression->getNode('expr3');
-
-        $expr2Safe = $this->isSafeFor($type, $expr2, $env);
-        $expr3Safe = $this->isSafeFor($type, $expr3, $env);
-
-        return $expr2Safe !== $expr3Safe;
-    }
-
     private function unwrapConditional(ConditionalExpression $expression, Environment $env, string $type): ConditionalExpression
     {
         // convert "echo a ? b : c" to "a ? echo b : echo c" recursively
         /** @var AbstractExpression $expr2 */
         $expr2 = $expression->getNode('expr2');
-        if ($expr2 instanceof ConditionalExpression && $this->shouldUnwrapConditional($expr2, $env, $type)) {
+        if ($expr2 instanceof ConditionalExpression) {
             $expr2 = $this->unwrapConditional($expr2, $env, $type);
         } else {
             $expr2 = $this->escapeInlinePrintNode(new InlinePrint($expr2, $expr2->getTemplateLine()), $env, $type);
         }
         /** @var AbstractExpression $expr3 */
         $expr3 = $expression->getNode('expr3');
-        if ($expr3 instanceof ConditionalExpression && $this->shouldUnwrapConditional($expr3, $env, $type)) {
+        if ($expr3 instanceof ConditionalExpression) {
             $expr3 = $this->unwrapConditional($expr3, $env, $type);
         } else {
             $expr3 = $this->escapeInlinePrintNode(new InlinePrint($expr3, $expr3->getTemplateLine()), $env, $type);


### PR DESCRIPTION
The current "optimizes" the generated code when possible, but it's probably useless (and removing the code makes compilation a bit faster):

```php
// Before
yield ((a) ? ("a") : ("b"));

// After
((a) ? (yield "a") : (yield "b"));
```
