### PR TITLE
[Twig 4] Add PHPUnit as dev dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
                   coverage: "none"
                   php-version: ${{ matrix.php-version }}
                   ini-values: memory_limit=-1
-                  tools: phpunit:11.3
 
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -41,7 +40,7 @@ jobs:
             - run: composer install
 
             - name: "Run tests"
-              run: phpunit
+              run: vendor/bin/phpunit
 
     extension-tests:
         needs:

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "keywords": ["templating"],
     "homepage": "https://twig.symfony.com",
     "license": "BSD-3-Clause",
-    "minimum-stability": "dev",
     "authors": [
         {
             "name": "Fabien Potencier",
@@ -32,7 +31,8 @@
     },
     "require-dev": {
         "psr/container": "^1.0|^2.0",
-        "phpstan/phpstan": "^2.0"
+        "phpstan/phpstan": "^2.0",
+        "phpunit/phpunit": "^11.4"
     },
     "autoload": {
         "psr-4" : {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="vendor/autoload.php"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          cacheDirectory=".phpunit.cache"
          backupStaticProperties="false"
          failOnDeprecation="true"

--- a/tests/DeprecatedCallableInfoTest.php
+++ b/tests/DeprecatedCallableInfoTest.php
@@ -11,14 +11,13 @@ namespace Twig\Tests;
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Twig\DeprecatedCallableInfo;
 
 class DeprecatedCallableInfoTest extends TestCase
 {
-    /**
-     * @dataProvider provideTestsForTriggerDeprecation
-     */
+    #[DataProvider('provideTestsForTriggerDeprecation')]
     public function testTriggerDeprecation($expected, DeprecatedCallableInfo $info)
     {
         $info->setType('function');

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -491,9 +491,7 @@ bar
         $this->assertTrue($stream->isEOF());
     }
 
-    /**
-     * @dataProvider getTemplateForInlineCommentsForVariable
-     */
+    #[DataProvider('getTemplateForInlineCommentsForVariable')]
     public function testInlineCommentForVariable(string $template)
     {
         $lexer = new Lexer(new Environment(new ArrayLoader()));
@@ -524,9 +522,7 @@ bar
         }}'];
     }
 
-    /**
-     * @dataProvider getTemplateForInlineCommentsForBlock
-     */
+    #[DataProvider('getTemplateForInlineCommentsForBlock')]
     public function testInlineCommentForBlock(string $template)
     {
         $lexer = new Lexer(new Environment(new ArrayLoader()));
@@ -562,9 +558,7 @@ bar
         %}me{% endif %}'];
     }
 
-    /**
-     * @dataProvider getTemplateForInlineCommentsForComment
-     */
+    #[DataProvider('getTemplateForInlineCommentsForComment')]
     public function testInlineCommentForComment(string $template)
     {
         $lexer = new Lexer(new Environment(new ArrayLoader()));

--- a/tests/Util/CallableArgumentsExtractorTest.php
+++ b/tests/Util/CallableArgumentsExtractorTest.php
@@ -11,6 +11,7 @@ namespace Twig\Tests\Util;
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Twig\Error\SyntaxError;
 use Twig\Node\EmptyNode;
@@ -83,9 +84,7 @@ class CallableArgumentsExtractorTest extends TestCase
         $this->assertEquals(['arg1'], $this->getArguments('custom_static_function', __CLASS__.'::customStaticFunction', ['arg1' => 'arg1']));
     }
 
-    /**
-     * @dataProvider getGetArgumentsConversionData
-     */
+    #[DataProvider('getGetArgumentsConversionData')]
     public function testGetArgumentsConversion($arg1, $arg2)
     {
         $this->assertEquals([null], $this->getArguments('custom', eval("return fn (\$$arg1) => '';"), [$arg1 => null]));


### PR DESCRIPTION
This makes it easier to run the tests locally.

I understand we didn't do this previously (Twig 3) because of `symfony/simple-phpunit`. But that is now removed in Twig 4, so maybe we can do this as well?