### PR TITLE
[Twig 4] Introduce ForElseNode

### DIFF
--- a/src/Node/ForElseNode.php
+++ b/src/Node/ForElseNode.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ * (c) Armin Ronacher
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Node;
+
+use Twig\Attribute\YieldReady;
+use Twig\Compiler;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Expression\Variable\AssignContextVariable;
+
+/**
+ * Represents an else node in a for loop.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+#[YieldReady]
+class ForElseNode extends Node
+{
+    public function __construct(Node $body, int $lineno)
+    {
+        parent::__construct(['body' => $body], [], $lineno);
+    }
+
+    public function compile(Compiler $compiler): void
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->write("if (0 === \$iterator->getIndex0()) {\n")
+            ->indent()
+            ->subcompile($this->getNode('body'))
+            ->outdent()
+            ->write("}\n")
+        ;
+    }
+}

--- a/src/Node/ForNode.php
+++ b/src/Node/ForNode.php
@@ -25,7 +25,7 @@ use Twig\Node\Expression\Variable\AssignContextVariable;
 #[YieldReady]
 class ForNode extends Node
 {
-    public function __construct(AssignContextVariable $keyTarget, AssignContextVariable $valueTarget, AbstractExpression $seq, ?AbstractExpression $ifexpr, Node $body, ?Node $else, int $lineno)
+    public function __construct(AssignContextVariable $keyTarget, AssignContextVariable $valueTarget, AbstractExpression $seq, ?AbstractExpression $ifexpr, Node $body, ?ForElseNode $else, int $lineno)
     {
         if ($ifexpr) {
             $body = new IfNode(new Nodes([$ifexpr, $body]), null, $lineno);
@@ -72,13 +72,7 @@ class ForNode extends Node
         ;
 
         if ($this->hasNode('else')) {
-            $compiler
-                ->write("if (0 === \$iterator->getIndex0()) {\n")
-                ->indent()
-                ->subcompile($this->getNode('else'))
-                ->outdent()
-                ->write("}\n")
-            ;
+            $compiler->subcompile($this->getNode('else'));
         }
 
         // remove some "private" loop variables (needed for nested loops)

--- a/src/TokenParser/ForTokenParser.php
+++ b/src/TokenParser/ForTokenParser.php
@@ -13,6 +13,7 @@
 namespace Twig\TokenParser;
 
 use Twig\Node\Expression\Variable\AssignContextVariable;
+use Twig\Node\ForElseNode;
 use Twig\Node\ForNode;
 use Twig\Node\Node;
 use Twig\Token;
@@ -46,8 +47,11 @@ final class ForTokenParser extends AbstractTokenParser
         $stream->expect(Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse($this->decideForFork(...));
         if ('else' == $stream->next()->getValue()) {
-            $stream->expect(Token::BLOCK_END_TYPE);
-            $else = $this->parser->subparse($this->decideForEnd(...), true);
+            $elseLineno = $stream->expect(Token::BLOCK_END_TYPE)->getLine();
+            $else = new ForElseNode(
+                $this->parser->subparse($this->decideForEnd(...), true),
+                $elseLineno
+            );
         } else {
             $else = null;
         }

--- a/tests/Node/ForTest.php
+++ b/tests/Node/ForTest.php
@@ -16,6 +16,7 @@ use Twig\Loader\ArrayLoader;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\Variable\AssignContextVariable;
 use Twig\Node\Expression\Variable\ContextVariable;
+use Twig\Node\ForElseNode;
 use Twig\Node\ForNode;
 use Twig\Node\IfNode;
 use Twig\Node\Nodes;
@@ -43,7 +44,7 @@ class ForTest extends NodeTestCase
         $this->assertEquals($body, $node->getNode('body')->getNode('tests')->getNode(1));
         $this->assertFalse($node->hasNode('else'));
 
-        $else = new PrintNode(new ContextVariable('foo', 1), 1);
+        $else = new ForElseNode(new PrintNode(new ContextVariable('foo', 1), 1), 5);
         $node = new ForNode($keyTarget, $valueTarget, $seq, null, $body, $else, 1);
         $node->setAttribute('with_loop', false);
         $this->assertEquals($else, $node->getNode('else'));
@@ -136,7 +137,7 @@ EOF
         $seq = new ContextVariable('values', 1);
         $ifexpr = new ConstantExpression(true, 1);
         $body = new Nodes([new PrintNode(new ContextVariable('foo', 1), 1)], 1);
-        $else = new PrintNode(new ContextVariable('foo', 1), 1);
+        $else = new ForElseNode(new PrintNode(new ContextVariable('foo', 6), 6), 5);
         $node = new ForNode($keyTarget, $valueTarget, $seq, $ifexpr, $body, $else, 1);
         $node->setAttribute('with_loop', true);
 
@@ -152,7 +153,9 @@ yield from (\$_v1 = function (\$iterator, &\$context, \$blocks, \$recurseFunc, \
             yield {$fooGetter};
         }
     }
+    // line 5
     if (0 === \$iterator->getIndex0()) {
+        // line 6
         yield {$fooGetter};
     }
     unset(\$context['k'], \$context['v'], \$context['loop']);


### PR DESCRIPTION
Currently there is no line number information for `{% else %}` inside a `for` loop.

Normally, this wouldn't be such a big deal.

But TwigStan uses this line information to map errors in PHP back to the original Twig source.

Let's say you have the following template:

```twig
{% for product in products %}
    <h2>FOR</h2>
{% else %}
    <p>No products found</p>
{% endfor %}
```

And `products` is of type `non-empty-array<Product>`, it means that the else will never happen.

This is currently reported as:
```
Negated boolean expression is always false.
🔖 booleanNot.alwaysFalse
🐘 compiled_index.php:83
🌱 templates/product/index.html.twig:2
🎯 src/Controller/ProductController.php:15
```

But as you can see, it points to line number 2, instead of line number 3.

In the compiled code, it looks like this:
```php
// line 1
foreach ($context['_seq'] as $context["_key"] => $context["product"]) {
    // line 2
    yield "        <h2>FOR</h2>\n    ";
    $context['_iterated'] = \true;
}
if (!$context['_iterated']) {
    // line 4
    yield "        <p>No products found</p>\n    ";
}
```

With this change, we will change the compiled code to become:
```php
// line 1
foreach ($context['_seq'] as $context["_key"] => $context["product"]) {
    // line 2
    yield "        <h2>FOR</h2>\n    ";
    $context['_iterated'] = \true;
}
// line 3
if (!$context['_iterated']) {
    // line 4
    yield "        <p>No products found</p>\n    ";
}
```