### PR TITLE
Add support for PHPUnit 11

### DIFF
--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -11,6 +11,9 @@
 
 namespace Twig\Test;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
 use Twig\Error\Error;
@@ -85,21 +88,53 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * @requires PHPUnit < 11
      * @dataProvider getTests
      */
+    #[RequiresPhpunit('< 11'), DataProvider('getTests')]
     public function testIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
     {
         $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
     }
 
     /**
+     * @requires PHPUnit < 11
      * @dataProvider getLegacyTests
      *
      * @group legacy
      */
+    #[RequiresPhpunit('< 11'), DataProvider('getLegacyTests'), Group('legacy')]
     public function testLegacyIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
     {
         $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
+    }
+
+    /**
+     * @requires PHPUnit >= 11
+     */
+    #[RequiresPhpunit('>= 11'), DataProvider('provideTests')]
+    public function testIntegrationTests($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
+    {
+        $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
+    }
+
+    /**
+     * @requires PHPUnit >= 11
+     */
+    #[RequiresPhpunit('>= 11'), DataProvider('provideLegacyTests'), Group('legacy')]
+    public function testLegacyIntegrationTests($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
+    {
+        $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
+    }
+
+    final public static function provideTests(): iterable
+    {
+        return self::assembleTests(false, static::getFixturesDirectory());
+    }
+
+    final public static function provideLegacyTests(): iterable
+    {
+        return self::assembleTests(true, static::getFixturesDirectory());
     }
 
     /**
@@ -114,6 +149,11 @@ abstract class IntegrationTestCase extends TestCase
             $fixturesDir = $this->getFixturesDir();
         }
 
+        return self::assembleTests($legacyTests, $fixturesDir);
+    }
+
+    private static function assembleTests(bool $legacyTests, string $fixturesDir): array
+    {
         $fixturesDir = realpath($fixturesDir);
         $tests = [];
 

--- a/src/Test/NodeTestCase.php
+++ b/src/Test/NodeTestCase.php
@@ -13,6 +13,7 @@ namespace Twig\Test;
 
 use PHPUnit\Framework\Attributes\BeforeClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 use Twig\Compiler;
 use Twig\Environment;
@@ -42,11 +43,21 @@ abstract class NodeTestCase extends TestCase
     }
 
     /**
+     * @requires PHPUnit < 11
      * @dataProvider getTests
      * @dataProvider provideTests
      */
-    #[DataProvider('getTests'), DataProvider('provideTests')]
+    #[RequiresPhpunit('< 11'), DataProvider('getTests'), DataProvider('provideTests')]
     public function testCompile($node, $source, $environment = null, $isPattern = false)
+    {
+        $this->assertNodeCompilation($source, $node, $environment, $isPattern);
+    }
+
+    /**
+     * @requires PHPUnit >= 11
+     */
+    #[RequiresPhpunit('>= 11'), DataProvider('provideTests')]
+    public function testNodeCompile($node, $source, $environment = null, $isPattern = false)
     {
         $this->assertNodeCompilation($source, $node, $environment, $isPattern);
     }


### PR DESCRIPTION
This is my last attempt to add support for PHPUnit 11 for Twig 3.

This pull request adds new test methods that only runs in PHPUnit >= 11 and makes the current test methods to only run with PHPUnit < 11.

I think this addresses the @stof concerns about BC break, as the there's no change for PHPUnit < 11 besides the skipped tests that requires PHPUnit >= 11, but no test is actually skipped as they all run with the test methods that requires PHPUnit < 11.

Running on PHPUnit 11 requires `Twig\Test\NodeTestCase::provideTests()` and `Twig\Test\IntegrationTestCase::getFixturesDirectory()` to be implemented.
So it's recommended to first fix the deprecations with PHPUnit 10 before running the tests with PHPUnit 11, or the tests will fail.

- https://github.com/twigphp/Twig/pull/4317
- https://github.com/twigphp/Twig/pull/4313