### PR TITLE
Simplify EscaperNodeVisitor code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.16.0 (2024-XX-XX)
 
+ * Deprecate `InlinePrint`
  * Fix having macro variables starting with an underscore
  * Deprecate not passing a `Source` instance to `TokenStream`
  * Deprecate returning `null` from `TwigFilter::getSafe()` and `TwigFunction::getSafe()`, return `[]` instead

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -189,6 +189,8 @@ Nodes
   made ready for ``yield``; the ``use_yield`` Environment option can be turned
   on when all nodes use the ``#[\Twig\Attribute\YieldReady]`` attribute.
 
+ * The ``InlinePrint`` class is deprecated as of Twig 3.16 with no replacement.
+
 Node Visitors
 -------------
 

--- a/src/Node/Expression/InlinePrint.php
+++ b/src/Node/Expression/InlinePrint.php
@@ -24,9 +24,7 @@ final class InlinePrint extends AbstractExpression
      */
     public function __construct(Node $node, int $lineno)
     {
-        if (!$node instanceof AbstractExpression) {
-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($node));
-        }
+        trigger_deprecation('twig/twig', '3.16', \sprintf('The "%s" class is deprecated with no replacement.', static::class));
 
         parent::__construct(['node' => $node], [], $lineno);
     }

--- a/src/NodeVisitor/EscaperNodeVisitor.php
+++ b/src/NodeVisitor/EscaperNodeVisitor.php
@@ -16,12 +16,10 @@ use Twig\Extension\EscaperExtension;
 use Twig\Node\AutoEscapeNode;
 use Twig\Node\BlockNode;
 use Twig\Node\BlockReferenceNode;
-use Twig\Node\DoNode;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Expression\ConditionalExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FilterExpression;
-use Twig\Node\Expression\InlinePrint;
 use Twig\Node\ImportNode;
 use Twig\Node\ModuleNode;
 use Twig\Node\Node;
@@ -78,10 +76,12 @@ final class EscaperNodeVisitor implements NodeVisitorInterface
         } elseif ($node instanceof PrintNode && false !== $type = $this->needEscaping()) {
             $expression = $node->getNode('expr');
             if ($expression instanceof ConditionalExpression) {
-                return new DoNode($this->unwrapConditional($expression, $env, $type), $expression->getTemplateLine());
+                $node->setNode('expr', $this->escapeConditional($expression, $env, $type));
+            } else {
+                $node->setNode('expr', $this->escapeExpression($expression, $env, $type));
             }
 
-            return $this->escapePrintNode($node, $env, $type);
+            return $node;
         }
 
         if ($node instanceof AutoEscapeNode || $node instanceof BlockNode) {
@@ -93,22 +93,21 @@ final class EscaperNodeVisitor implements NodeVisitorInterface
         return $node;
     }
 
-    private function unwrapConditional(ConditionalExpression $expression, Environment $env, string $type): ConditionalExpression
+    private function escapeConditional(ConditionalExpression $expression, Environment $env, string $type): ConditionalExpression
     {
-        // convert "echo a ? b : c" to "a ? echo b : echo c" recursively
         /** @var AbstractExpression $expr2 */
         $expr2 = $expression->getNode('expr2');
         if ($expr2 instanceof ConditionalExpression) {
-            $expr2 = $this->unwrapConditional($expr2, $env, $type);
+            $expr2 = $this->escapeConditional($expr2, $env, $type);
         } else {
-            $expr2 = $this->escapeInlinePrintNode(new InlinePrint($expr2, $expr2->getTemplateLine()), $env, $type);
+            $expr2 = $this->escapeExpression($expr2, $env, $type);
         }
         /** @var AbstractExpression $expr3 */
         $expr3 = $expression->getNode('expr3');
         if ($expr3 instanceof ConditionalExpression) {
-            $expr3 = $this->unwrapConditional($expr3, $env, $type);
+            $expr3 = $this->escapeConditional($expr3, $env, $type);
         } else {
-            $expr3 = $this->escapeInlinePrintNode(new InlinePrint($expr3, $expr3->getTemplateLine()), $env, $type);
+            $expr3 = $this->escapeExpression($expr3, $env, $type);
         }
 
         /** @var AbstractExpression $expr1 */
@@ -117,30 +116,9 @@ final class EscaperNodeVisitor implements NodeVisitorInterface
         return new ConditionalExpression($expr1, $expr2, $expr3, $expression->getTemplateLine());
     }
 
-    private function escapeInlinePrintNode(InlinePrint $node, Environment $env, string $type): AbstractExpression
+    private function escapeExpression(AbstractExpression $expression, Environment $env, string $type): AbstractExpression
     {
-        /** @var AbstractExpression $expression */
-        $expression = $node->getNode('node');
-
-        if ($this->isSafeFor($type, $expression, $env)) {
-            return $node;
-        }
-
-        return new InlinePrint($this->getEscaperFilter($env, $type, $expression), $node->getTemplateLine());
-    }
-
-    private function escapePrintNode(PrintNode $node, Environment $env, string $type): Node
-    {
-        /** @var AbstractExpression $expression */
-        $expression = $node->getNode('expr');
-
-        if ($this->isSafeFor($type, $expression, $env)) {
-            return $node;
-        }
-
-        $class = \get_class($node);
-
-        return new $class($this->getEscaperFilter($env, $type, $expression), $node->getTemplateLine());
+        return $this->isSafeFor($type, $expression, $env) ? $expression : $this->getEscaperFilter($env, $type, $expression);
     }
 
     private function preEscapeFilterNode(FilterExpression $filter, Environment $env): FilterExpression


### PR DESCRIPTION
This PR simplifies how we escape the ternary operator, and simplifies the whole strategy.
Instead of replacing the `PrintNode`s, we instead "just" wrap the inner expressions.

For the ternary operator, the `InlinePrint` expression is useless and even weird as printing something in the middle of an expression looks very wrong. This is not done anymore and the node is deprecated.

Overall, this PR makes fewer changes to the Node tree which should make things use a bit less memory.
