### PR TITLE
Support underscores in number literals

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 # 3.17.0 (2024-XX-XX)
 
- * n/a
+ * Support underscores in number literals
 
 # 3.16.0 (2024-11-29)
 

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -612,7 +612,8 @@ exist:
 
 * ``42`` / ``42.23``: Integers and floating point numbers are created by
   writing the number down. If a dot is present the number is a float,
-  otherwise an integer.
+  otherwise an integer. Underscores can be used as digits separator to 
+  improve readability (``-3_141.592_65`` is equivalent to ``-3141.59265``).
 
 * ``["first_name", "last_name"]``: Sequences are defined by a sequence of expressions
   separated by a comma (``,``) and wrapped with squared brackets (``[]``).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -23,3 +23,9 @@ parameters:
 			identifier: parameter.phpDocType
 			count: 5
 			path: src/Node/Node.php
+
+		- # Adding 0 to the string representation of a number is valid and what we want here
+			message: '#^Binary operation "\+" between 0 and string results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/Lexer.php

--- a/tests/Fixtures/expressions/underscored_numbers.test
+++ b/tests/Fixtures/expressions/underscored_numbers.test
@@ -1,0 +1,24 @@
+--TEST--
+Twig compile numbers literals with underscores correctly
+--TEMPLATE--
+{{ 0_0 is same as 0 ? 'ok' : 'ko' }}
+{{ 1_23 is same as 123 ? 'ok' : 'ko' }}
+{{ 12_3 is same as 123 ? 'ok' : 'ko' }}
+{{ 1_2_3 is same as 123 ? 'ok' : 'ko' }}
+{{ -1_2 is same as -12 ? 'ok' : 'ko' }}
+{{ 1_2.3_4 is same as 12.34 ? 'ok' : 'ko' }}
+{{ -1_2.3_4 is same as -12.34 ? 'ok' : 'ko' }}
+{{ 1.2_3e-4 is same as 1.23e-4 ? 'ok' : 'ko' }}
+{{ -1.2_3e+4 is same as -1.23e+4 ? 'ok' : 'ko' }}
+--DATA--
+return []
+--EXPECT--
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok

--- a/tests/Fixtures/expressions/underscored_numbers_error.test
+++ b/tests/Fixtures/expressions/underscored_numbers_error.test
@@ -1,0 +1,8 @@
+--TEST--
+Twig does not allow to use 2 underscored between digits in numbers
+--TEMPLATE--
+{{ 1__2 }}
+--DATA--
+return []
+--EXCEPTION--
+Twig\Error\SyntaxError: Unexpected token "name" of value "__2" ("end of print statement" expected) in "index.twig" at line 2.


### PR DESCRIPTION
```twig
{{ 1000 == 1_000 ? 'yes' : 'no' }}
# now: syntax error
# this PR: "yes"
```

> As of PHP 7.4.0, integer literals may contain underscores (_) between digits, for better readability of literals. These underscores are removed by PHP's scanner.

https://www.php.net/manual/en/language.types.integer.php

This PR replicates that behaviour, using the regexp to match the literals and then remove the "_".

I'm targeting **Twig4** but maybe 3.x would be ok?

I cannot think of a real case that
- does not trigger an error currently
- would work differently after this PR
