### PR TITLE
Require "erusev/parsedown": "dev-master as 1.x-dev"

### DIFF
--- a/extra/markdown-extra/composer.json
+++ b/extra/markdown-extra/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^6.4|^7.0",
-        "erusev/parsedown": "^1.7",
+        "erusev/parsedown": "dev-master as 1.x-dev",
         "league/commonmark": "^1.0|^2.0",
         "league/html-to-markdown": "^4.8|^5.0",
         "michelf/php-markdown": "^1.8|^2.0"


### PR DESCRIPTION
Should fix the CI until https://github.com/erusev/parsedown/pull/891 is merged.