### PR TITLE
Set return type of Node::count()

### DIFF
--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -256,8 +256,7 @@ class Node implements \Countable, \IteratorAggregate
     /**
      * @return int
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return \count($this->nodes);
     }


### PR DESCRIPTION
There seems to be no reason to use the #[\ReturnTypeWillChange] attribute here as the method should always return an int.