### PR TITLE
Fix ArrayAccess with objects as keys

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1644,7 +1644,7 @@ final class CoreExtension extends AbstractExtension
 
         // array
         if (Template::METHOD_CALL !== $type) {
-            $arrayItem = \is_bool($item) || \is_float($item) ? (int) $item : $item = (string) $item;
+            $arrayItem = \is_bool($item) || \is_float($item) ? (int) $item : $item;
 
             if ($sandboxed && $object instanceof \ArrayAccess && !\in_array($object::class, self::ARRAY_LIKE_CLASSES, true)) {
                 try {

--- a/tests/Fixtures/expressions/array.test
+++ b/tests/Fixtures/expressions/array.test
@@ -42,12 +42,19 @@ Twig supports array notation
 {# ArrayAccess #}
 {{ array_access['a'] }}
 
+{# ObjectStorage #}
+{{ object_storage[object] }}
+{{ object_storage[object_storage]|default('bar') }}
+
 {# array that does not exist #}
 {{ does_not_exist[0]|default('ok') }}
 {{ does_not_exist[0].does_not_exist_either|default('ok') }}
 {{ does_not_exist[0]['does_not_exist_either']|default('ok') }}
 --DATA--
-return ['bar' => 'bar', 'foo' => ['bar' => 'bar'], 'array_access' => new \ArrayObject(['a' => 'b'])]
+$objectStorage = new SplObjectStorage();
+$object = new stdClass();
+$objectStorage[$object] = 'foo';
+return ['bar' => 'bar', 'foo' => ['bar' => 'bar'], 'array_access' => new \ArrayObject(['a' => 'b']), 'object_storage' => $objectStorage, 'object' => $object]
 --EXPECT--
 1,2
 foo,bar
@@ -71,11 +78,14 @@ a,b,c,d,e
 
 b
 
+foo
+bar
+
 ok
 ok
 ok
 --DATA--
-return ['bar' => 'bar', 'foo' => ['bar' => 'bar'], 'array_access' => new \ArrayObject(['a' =>  'b'])]
+return ['bar' => 'bar', 'foo' => ['bar' => 'bar'], 'array_access' => new \ArrayObject(['a' =>  'b']), 'object' => new stdClass()]
 --CONFIG--
 return ['strict_variables' => false]
 --EXPECT--
@@ -100,6 +110,9 @@ FOO,BAR,
 a,b,c,d,e
 
 b
+
+
+bar
 
 ok
 ok


### PR DESCRIPTION
fixes #4476
The bug was introduced in 3.15 via https://github.com/twigphp/Twig/pull/4425#discussion_r1869120001