### PR TITLE
Change `=` to `:` for named arguments

### DIFF
--- a/doc/functions/html_cva.rst
+++ b/doc/functions/html_cva.rst
@@ -20,8 +20,8 @@ function where you define ``base`` classes that should always be present and the
 
     {# templates/alert.html.twig #}
     {% set alert = html_cva(
-        base='alert',
-        variants={
+        base: 'alert',
+        variants: {
             color: {
                 blue: 'bg-blue',
                 red: 'bg-red',
@@ -84,8 +84,8 @@ when multiple other variant conditions are met:
 .. code-block:: html+twig
 
     {% set alert = html_cva(
-        base='alert',
-        variants={
+        base: 'alert',
+        variants: {
             color: {
                 blue: 'bg-blue',
                 red: 'bg-red',
@@ -97,7 +97,7 @@ when multiple other variant conditions are met:
                 lg: 'text-lg',
             }
         },
-        compoundVariants=[{
+        compoundVariants: [{
             // if color = red AND size = (md or lg), add the `font-bold` class
             color: ['red'],
             size: ['md', 'lg'],
@@ -128,8 +128,8 @@ If no variants match, you can define a default set of classes to apply:
 .. code-block:: html+twig
 
     {% set alert = html_cva(
-        base='alert',
-        variants={
+        base: 'alert',
+        variants: {
             color: {
                 blue: 'bg-blue',
                 red: 'bg-red',
@@ -146,7 +146,7 @@ If no variants match, you can define a default set of classes to apply:
                 lg: 'rounded-lg',
             }
         },
-        defaultVariant={
+        defaultVariant: {
             rounded: 'md',
         }
     ) %}


### PR DESCRIPTION
Hi,
I changed `=` to `:` because it better follows best practices for named arguments.