### PR TITLE
Ignore exceptions from undefined handlers when using the guard tag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.18.0 (2024-XX-XX)
 
+ * Ignore `SyntaxError` exceptions from undefined handlers when using the `guard` tag
  * Add a way to stream template rendering (`TemplateWrapper::stream()` and `TemplateWrapper::streamBlock()` )
 
 # 3.17.1 (2024-12-12)

--- a/src/TokenParser/GuardTokenParser.php
+++ b/src/TokenParser/GuardTokenParser.php
@@ -33,7 +33,11 @@ final class GuardTokenParser extends AbstractTokenParser
 
         $nameToken = $stream->expect(Token::NAME_TYPE);
 
-        $exists = null !== $this->parser->getEnvironment()->$method($nameToken->getValue());
+        try {
+            $exists = null !== $this->parser->getEnvironment()->$method($nameToken->getValue());
+        } catch (SyntaxError) {
+            $exists = false;
+        }
 
         $stream->expect(Token::BLOCK_END_TYPE);
         if ($exists) {

--- a/tests/TokenParser/GuardTokenParserTest.php
+++ b/tests/TokenParser/GuardTokenParserTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Twig\Tests\TokenParser;
+
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Error\SyntaxError;
+use Twig\Loader\ArrayLoader;
+use Twig\Parser;
+use Twig\Source;
+
+class GuardTokenParserTest extends TestCase
+{
+    public function testUndefinedHandlers()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $env = new Environment(new ArrayLoader(), ['cache' => false, 'autoescape' => false]);
+        $env->registerUndefinedFunctionCallback(fn ($name) => throw new SyntaxError('boom.'));
+        (new Parser($env))->parse($env->tokenize(new Source('{% guard function boom %}{% endguard %}', '')));
+    }
+}


### PR DESCRIPTION
Fixes #4505