### PR TITLE
Remove `preg_quote` delimiter argument (minor)

### DIFF
--- a/src/ExtensionSet.php
+++ b/src/ExtensionSet.php
@@ -436,7 +436,7 @@ final class ExtensionSet
         foreach ($extension->getFilters() as $filter) {
             $this->filters[$name = $filter->getName()] = $filter;
             if (str_contains($name, '*')) {
-                $this->dynamicFilters['#^'.str_replace('\\*', '(.*?)', preg_quote($name, '#')).'$#'] = $filter;
+                $this->dynamicFilters['#^'.str_replace('\\*', '(.*?)', preg_quote($name)).'$#'] = $filter;
             }
         }
 
@@ -444,7 +444,7 @@ final class ExtensionSet
         foreach ($extension->getFunctions() as $function) {
             $this->functions[$name = $function->getName()] = $function;
             if (str_contains($name, '*')) {
-                $this->dynamicFunctions['#^'.str_replace('\\*', '(.*?)', preg_quote($name, '#')).'$#'] = $function;
+                $this->dynamicFunctions['#^'.str_replace('\\*', '(.*?)', preg_quote($name)).'$#'] = $function;
             }
         }
 
@@ -452,7 +452,7 @@ final class ExtensionSet
         foreach ($extension->getTests() as $test) {
             $this->tests[$name = $test->getName()] = $test;
             if (str_contains($name, '*')) {
-                $this->dynamicTests['#^'.str_replace('\\*', '(.*?)', preg_quote($name, '#')).'$#'] = $test;
+                $this->dynamicTests['#^'.str_replace('\\*', '(.*?)', preg_quote($name)).'$#'] = $test;
             }
         }
 

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -88,17 +88,16 @@ class Lexer
             return;
         }
 
-        // when PHP 7.3 is the min version, we will be able to remove the '#' part in preg_quote as it's part of the default
         $this->regexes = [
             // }}
             'lex_var' => '{
                 \s*
                 (?:'.
-                    preg_quote($this->options['whitespace_trim'].$this->options['tag_variable'][1], '#').'\s*'. // -}}\s*
+                    preg_quote($this->options['whitespace_trim'].$this->options['tag_variable'][1]).'\s*'. // -}}\s*
                     '|'.
-                    preg_quote($this->options['whitespace_line_trim'].$this->options['tag_variable'][1], '#').'['.$this->options['whitespace_line_chars'].']*'. // ~}}[ \t\0\x0B]*
+                    preg_quote($this->options['whitespace_line_trim'].$this->options['tag_variable'][1]).'['.$this->options['whitespace_line_chars'].']*'. // ~}}[ \t\0\x0B]*
                     '|'.
-                    preg_quote($this->options['tag_variable'][1], '#'). // }}
+                    preg_quote($this->options['tag_variable'][1]). // }}
                 ')
             }Ax',
 
@@ -106,28 +105,28 @@ class Lexer
             'lex_block' => '{
                 \s*
                 (?:'.
-                    preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '#').'\s*\n?'. // -%}\s*\n?
+                    preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1]).'\s*\n?'. // -%}\s*\n?
                     '|'.
-                    preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1], '#').'['.$this->options['whitespace_line_chars'].']*'. // ~%}[ \t\0\x0B]*
+                    preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1]).'['.$this->options['whitespace_line_chars'].']*'. // ~%}[ \t\0\x0B]*
                     '|'.
-                    preg_quote($this->options['tag_block'][1], '#').'\n?'. // %}\n?
+                    preg_quote($this->options['tag_block'][1]).'\n?'. // %}\n?
                 ')
             }Ax',
 
             // {% endverbatim %}
             'lex_raw_data' => '{'.
-                preg_quote($this->options['tag_block'][0], '#'). // {%
+                preg_quote($this->options['tag_block'][0]). // {%
                 '('.
                     $this->options['whitespace_trim']. // -
                     '|'.
                     $this->options['whitespace_line_trim']. // ~
                 ')?\s*endverbatim\s*'.
                 '(?:'.
-                    preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '#').'\s*'. // -%}
+                    preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1]).'\s*'. // -%}
                     '|'.
-                    preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1], '#').'['.$this->options['whitespace_line_chars'].']*'. // ~%}[ \t\0\x0B]*
+                    preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1]).'['.$this->options['whitespace_line_chars'].']*'. // ~%}[ \t\0\x0B]*
                     '|'.
-                    preg_quote($this->options['tag_block'][1], '#'). // %}
+                    preg_quote($this->options['tag_block'][1]). // %}
                 ')
             }sx',
 
@@ -136,11 +135,11 @@ class Lexer
             // #}
             'lex_comment' => '{
                 (?:'.
-                    preg_quote($this->options['whitespace_trim'].$this->options['tag_comment'][1], '#').'\s*\n?'. // -#}\s*\n?
+                    preg_quote($this->options['whitespace_trim'].$this->options['tag_comment'][1]).'\s*\n?'. // -#}\s*\n?
                     '|'.
-                    preg_quote($this->options['whitespace_line_trim'].$this->options['tag_comment'][1], '#').'['.$this->options['whitespace_line_chars'].']*'. // ~#}[ \t\0\x0B]*
+                    preg_quote($this->options['whitespace_line_trim'].$this->options['tag_comment'][1]).'['.$this->options['whitespace_line_chars'].']*'. // ~#}[ \t\0\x0B]*
                     '|'.
-                    preg_quote($this->options['tag_comment'][1], '#').'\n?'. // #}\n?
+                    preg_quote($this->options['tag_comment'][1]).'\n?'. // #}\n?
                 ')
             }sx',
 
@@ -148,32 +147,32 @@ class Lexer
             'lex_block_raw' => '{
                 \s*verbatim\s*
                 (?:'.
-                    preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '#').'\s*'. // -%}\s*
+                    preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1]).'\s*'. // -%}\s*
                     '|'.
-                    preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1], '#').'['.$this->options['whitespace_line_chars'].']*'. // ~%}[ \t\0\x0B]*
+                    preg_quote($this->options['whitespace_line_trim'].$this->options['tag_block'][1]).'['.$this->options['whitespace_line_chars'].']*'. // ~%}[ \t\0\x0B]*
                     '|'.
-                    preg_quote($this->options['tag_block'][1], '#'). // %}
+                    preg_quote($this->options['tag_block'][1]). // %}
                 ')
             }Asx',
 
-            'lex_block_line' => '{\s*line\s+(\d+)\s*'.preg_quote($this->options['tag_block'][1], '#').'}As',
+            'lex_block_line' => '{\s*line\s+(\d+)\s*'.preg_quote($this->options['tag_block'][1]).'}As',
 
             // {{ or {% or {#
             'lex_tokens_start' => '{
                 ('.
-                    preg_quote($this->options['tag_variable'][0], '#'). // {{
+                    preg_quote($this->options['tag_variable'][0]). // {{
                     '|'.
-                    preg_quote($this->options['tag_block'][0], '#'). // {%
+                    preg_quote($this->options['tag_block'][0]). // {%
                     '|'.
-                    preg_quote($this->options['tag_comment'][0], '#'). // {#
+                    preg_quote($this->options['tag_comment'][0]). // {#
                 ')('.
-                    preg_quote($this->options['whitespace_trim'], '#'). // -
+                    preg_quote($this->options['whitespace_trim']). // -
                     '|'.
-                    preg_quote($this->options['whitespace_line_trim'], '#'). // ~
+                    preg_quote($this->options['whitespace_line_trim']). // ~
                 ')?
             }sx',
-            'interpolation_start' => '{'.preg_quote($this->options['interpolation'][0], '#').'\s*}A',
-            'interpolation_end' => '{\s*'.preg_quote($this->options['interpolation'][1], '#').'}A',
+            'interpolation_start' => '{'.preg_quote($this->options['interpolation'][0]).'\s*}A',
+            'interpolation_end' => '{\s*'.preg_quote($this->options['interpolation'][1]).'}A',
         ];
 
         $this->isInitialized = true;


### PR DESCRIPTION
Following code source instructions

[src/Lexer.php#L91](https://github.com/smnandre/Twig/blob/c1f7277b7b6dc66859686347d359229e9edd2be9/src/Lexer.php#L91)

```
// when PHP 7.3 is the min version, we will be able to remove the '#' part in preg_quote as it's part of the default
```

Same thing in ExtensionSet.php

I think this has already been done in 4.0 so please close if you did not want to update 3.x code for now 