### PR TITLE
Add invoke filter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,5 @@
 # 3.19.0 (2025-XX-XX)
 
- * Add `LastModifiedExtensionInterface` and implementation in `AbstractExtension` to track modification of runtime classes
  * Add the `invoke` filter
  * Make `{}` optional for the `types` tag
  * Add `LastModifiedExtensionInterface` and implementation in `AbstractExtension` to track modification of runtime classes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.19.0 (2025-XX-XX)
 
+ * Add `LastModifiedExtensionInterface` and implementation in `AbstractExtension` to track modification of runtime classes
  * Add the `invoke` filter
  * Make `{}` optional for the `types` tag
  * Add `LastModifiedExtensionInterface` and implementation in `AbstractExtension` to track modification of runtime classes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.19.0 (2025-XX-XX)
 
+ * Add the `invoke` filter
  * Make `{}` optional for the `types` tag
  * Add `LastModifiedExtensionInterface` and implementation in `AbstractExtension` to track modification of runtime classes
 

--- a/doc/filters/invoke.rst
+++ b/doc/filters/invoke.rst
@@ -1,0 +1,19 @@
+``invoke``
+=======
+
+The ``invoke`` filter invokes an arrow function with the the given arguments:
+
+.. code-block:: twig
+
+    {% set person = {first: "Bob", last: "Smith"} %}
+    {% set func = p => "#{p.first} #{p.last}" %}
+
+    {{ func|invoke(person) }}
+    {# outputs Bob Smith #}
+
+Note that the arrow function has access to the current context.
+
+Arguments
+---------
+
+All given arguments are passed to the arrow function

--- a/doc/filters/invoke.rst
+++ b/doc/filters/invoke.rst
@@ -1,7 +1,7 @@
 ``invoke``
 =======
 
-The ``invoke`` filter invokes an arrow function with the the given arguments:
+The ``invoke`` filter invokes an arrow function with the given arguments:
 
 .. code-block:: twig
 

--- a/doc/filters/invoke.rst
+++ b/doc/filters/invoke.rst
@@ -1,6 +1,10 @@
 ``invoke``
 ==========
 
+.. versionadded:: 3.19
+
+    The ``invoke`` filter has been added in Twig 3.19.
+
 The ``invoke`` filter invokes an arrow function with the given arguments:
 
 .. code-block:: twig
@@ -10,10 +14,3 @@ The ``invoke`` filter invokes an arrow function with the given arguments:
 
     {{ func|invoke(person) }}
     {# outputs Bob Smith #}
-
-Note that the arrow function has access to the current context.
-
-Arguments
----------
-
-All given arguments are passed to the arrow function.

--- a/doc/filters/invoke.rst
+++ b/doc/filters/invoke.rst
@@ -1,11 +1,11 @@
 ``invoke``
-=======
+==========
 
 The ``invoke`` filter invokes an arrow function with the given arguments:
 
 .. code-block:: twig
 
-    {% set person = {first: "Bob", last: "Smith"} %}
+    {% set person = { first: "Bob", last: "Smith" } %}
     {% set func = p => "#{p.first} #{p.last}" %}
 
     {{ func|invoke(person) }}
@@ -16,4 +16,4 @@ Note that the arrow function has access to the current context.
 Arguments
 ---------
 
-All given arguments are passed to the arrow function
+All given arguments are passed to the arrow function.

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -1018,7 +1018,8 @@ The following operators don't fit into any of the other categories:
     Arrow function support for functions, macros, and method calls was added in
     Twig 3.15 (filters and tests were already supported).
 
-  Arrow functions can be called using the ``invoke`` filter:
+  Arrow functions can be called using the :doc:`invoke </filters/invoke>`
+  filter.
 
   .. versionadded:: 3.19
 

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -1018,9 +1018,9 @@ The following operators don't fit into any of the other categories:
     Arrow function support for functions, macros, and method calls was added in
     Twig 3.15 (filters and tests were already supported).
 
-  Arrow functions can be invoked using the ``invoke`` filter.
+Arrow functions can be called using the ``invoke`` filter:
 
-    .. versionadded:: 3.19
+.. versionadded:: 3.19
 
     The ``invoke`` filter has been added in Twig 3.19.
 

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -1018,6 +1018,12 @@ The following operators don't fit into any of the other categories:
     Arrow function support for functions, macros, and method calls was added in
     Twig 3.15 (filters and tests were already supported).
 
+  Arrow functions can be invoked using the ``invoke`` filter.
+
+    .. versionadded:: 3.19
+
+    The ``invoke`` filter has been added in Twig 3.19.
+
 Operators
 ~~~~~~~~~
 

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -1018,9 +1018,9 @@ The following operators don't fit into any of the other categories:
     Arrow function support for functions, macros, and method calls was added in
     Twig 3.15 (filters and tests were already supported).
 
-Arrow functions can be called using the ``invoke`` filter:
+  Arrow functions can be called using the ``invoke`` filter:
 
-.. versionadded:: 3.19
+  .. versionadded:: 3.19
 
     The ``invoke`` filter has been added in Twig 3.19.
 

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -266,7 +266,7 @@ final class CoreExtension extends AbstractExtension
             // iteration and runtime
             new TwigFilter('default', [self::class, 'default'], ['node_class' => DefaultFilter::class]),
             new TwigFilter('keys', [self::class, 'keys']),
-            new TwigFilter('invoke', [self::class, 'invoke'], ['needs_environment' => true]),
+            new TwigFilter('invoke', [self::class, 'invoke']),
         ];
     }
 
@@ -919,14 +919,10 @@ final class CoreExtension extends AbstractExtension
     /**
      * Invokes a callable
      *
-     * @param \Closure $arrow
-     *
      * @internal
      */
-    public static function invoke(Environment $env, $arrow, ...$arguments): mixed
+    public static function invoke(\Closure $arrow, ...$arguments): mixed
     {
-        self::checkArrow($env, $arrow, 'invoke', 'filter');
-
         return $arrow(...$arguments);
     }
 

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -266,7 +266,7 @@ final class CoreExtension extends AbstractExtension
             // iteration and runtime
             new TwigFilter('default', [self::class, 'default'], ['node_class' => DefaultFilter::class]),
             new TwigFilter('keys', [self::class, 'keys']),
-            new TwigFilter('invoke', [self::class, 'invoke']),
+            new TwigFilter('invoke', [self::class, 'invoke'], ['needs_environment' => true]),
         ];
     }
 
@@ -919,15 +919,15 @@ final class CoreExtension extends AbstractExtension
     /**
      * Invokes a callable
      *
-     * @param callable $callable
-     * @param ...$arguments
-     * @return mixed
+     * @param \Closure $arrow
      *
      * @internal
      */
-    public static function invoke(callable $callable, ...$arguments): mixed
+    public static function invoke(Environment $env, $arrow, ...$arguments): mixed
     {
-        return $callable(...$arguments);
+        self::checkArrow($env, $arrow, 'invoke', 'filter');
+
+        return $arrow(...$arguments);
     }
 
     /**

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -266,6 +266,7 @@ final class CoreExtension extends AbstractExtension
             // iteration and runtime
             new TwigFilter('default', [self::class, 'default'], ['node_class' => DefaultFilter::class]),
             new TwigFilter('keys', [self::class, 'keys']),
+            new TwigFilter('invoke', [self::class, 'invoke']),
         ];
     }
 
@@ -913,6 +914,20 @@ final class CoreExtension extends AbstractExtension
         }
 
         return array_keys($array);
+    }
+
+    /**
+     * Invokes a callable
+     *
+     * @param callable $callable
+     * @param ...$arguments
+     * @return mixed
+     *
+     * @internal
+     */
+    public static function invoke(callable $callable, ...$arguments): mixed
+    {
+        return $callable(...$arguments);
     }
 
     /**

--- a/tests/Fixtures/filters/invoke.test
+++ b/tests/Fixtures/filters/invoke.test
@@ -1,0 +1,14 @@
+--TEST--
+"invoke" filter
+--TEMPLATE--
+{% set func = x => 'Hello '~x %}
+{{ func|invoke('World') }}
+{% set func2 = (x, y) => x+y %}
+{{ func2|invoke(3, 2) }}
+--DATA--
+return []
+--CONFIG--
+return []
+--EXPECT--
+Hello World
+5


### PR DESCRIPTION
Adds a new filter `invoke`, to invoke arrow functions and other php callables.

See the discussion here: https://github.com/twigphp/Twig/pull/4378#issuecomment-2557389092
