### PR TITLE
Remove "dead method" in ModuleNode

### DIFF
--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -473,21 +473,4 @@ final class ModuleNode extends Node
             ->write("}\n")
         ;
     }
-
-    protected function compileLoadTemplate(Compiler $compiler, $node, $var)
-    {
-        if ($node instanceof ConstantExpression) {
-            $compiler
-                ->write(\sprintf('%s = $this->loadTemplate(', $var))
-                ->subcompile($node)
-                ->raw(', ')
-                ->repr($node->getTemplateName())
-                ->raw(', ')
-                ->repr($node->getTemplateLine())
-                ->raw(");\n")
-            ;
-        } else {
-            throw new \LogicException('Trait templates can only be constant nodes.');
-        }
-    }
 }


### PR DESCRIPTION
This method is not used after 1.x (it was used [in the compileConstructor](https://github.com/twigphp/Twig/blob/b1f009c449e435a0384814e67205d9190a4d050e/src/Node/ModuleNode.php#L206)) and has no caller anymore [in 2.x ](https://github.com/twigphp/Twig/blob/19185947ec75d433a3ac650af32fc05649b95ee1/src/Node/ModuleNode.php#L174)

ModuleNode is [marked final](https://github.com/twigphp/Twig/blob/d184e9fe12e1a8d219a95638ee78ad577a59e299/src/Node/ModuleNode.php#L31) in 3.x so I guess we can remove it safely.