### PR TITLE
Add return type annotations on Twig 3 to prepare Twig 4

### DIFF
--- a/src/AbstractTwigCallable.php
+++ b/src/AbstractTwigCallable.php
@@ -79,6 +79,9 @@ abstract class AbstractTwigCallable implements TwigCallableInterface
         return $this->dynamicName;
     }
 
+    /**
+     * @return callable|array{class-string, string}|null
+     */
     public function getCallable()
     {
         return $this->callable;

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -155,6 +155,8 @@ class Environment
 
     /**
      * Enables debugging mode.
+     *
+     * @return void
      */
     public function enableDebug()
     {
@@ -164,6 +166,8 @@ class Environment
 
     /**
      * Disables debugging mode.
+     *
+     * @return void
      */
     public function disableDebug()
     {
@@ -183,6 +187,8 @@ class Environment
 
     /**
      * Enables the auto_reload option.
+     *
+     * @return void
      */
     public function enableAutoReload()
     {
@@ -191,6 +197,8 @@ class Environment
 
     /**
      * Disables the auto_reload option.
+     *
+     * @return void
      */
     public function disableAutoReload()
     {
@@ -209,6 +217,8 @@ class Environment
 
     /**
      * Enables the strict_variables option.
+     *
+     * @return void
      */
     public function enableStrictVariables()
     {
@@ -218,6 +228,8 @@ class Environment
 
     /**
      * Disables the strict_variables option.
+     *
+     * @return void
      */
     public function disableStrictVariables()
     {
@@ -267,6 +279,8 @@ class Environment
      * @param CacheInterface|string|false $cache A Twig\Cache\CacheInterface implementation,
      *                                           an absolute path to the compiled templates,
      *                                           or false to disable cache
+     *
+     * @return void
      */
     public function setCache($cache)
     {
@@ -503,6 +517,9 @@ class Environment
         throw new LoaderError(\sprintf('Unable to find one of the following templates: "%s".', implode('", "', $names)));
     }
 
+    /**
+     * @return void
+     */
     public function setLexer(Lexer $lexer)
     {
         $this->lexer = $lexer;
@@ -520,6 +537,9 @@ class Environment
         return $this->lexer->tokenize($source);
     }
 
+    /**
+     * @return void
+     */
     public function setParser(Parser $parser)
     {
         $this->parser = $parser;
@@ -539,6 +559,9 @@ class Environment
         return $this->parser->parse($stream);
     }
 
+    /**
+     * @return void
+     */
     public function setCompiler(Compiler $compiler)
     {
         $this->compiler = $compiler;
@@ -573,6 +596,9 @@ class Environment
         }
     }
 
+    /**
+     * @return void
+     */
     public function setLoader(LoaderInterface $loader)
     {
         $this->loader = $loader;
@@ -583,6 +609,9 @@ class Environment
         return $this->loader;
     }
 
+    /**
+     * @return void
+     */
     public function setCharset(string $charset)
     {
         if ('UTF8' === $charset = strtoupper($charset ?: '')) {
@@ -603,6 +632,9 @@ class Environment
         return $this->extensionSet->hasExtension($class);
     }
 
+    /**
+     * @return void
+     */
     public function addRuntimeLoader(RuntimeLoaderInterface $loader)
     {
         $this->runtimeLoaders[] = $loader;
@@ -650,6 +682,9 @@ class Environment
         throw new RuntimeError(\sprintf('Unable to load the "%s" runtime.', $class));
     }
 
+    /**
+     * @return void
+     */
     public function addExtension(ExtensionInterface $extension)
     {
         $this->extensionSet->addExtension($extension);
@@ -658,6 +693,8 @@ class Environment
 
     /**
      * @param ExtensionInterface[] $extensions An array of extensions
+     *                                         
+     * @return void
      */
     public function setExtensions(array $extensions)
     {
@@ -673,6 +710,9 @@ class Environment
         return $this->extensionSet->getExtensions();
     }
 
+    /**
+     * @return void
+     */
     public function addTokenParser(TokenParserInterface $parser)
     {
         $this->extensionSet->addTokenParser($parser);
@@ -701,6 +741,9 @@ class Environment
         $this->extensionSet->registerUndefinedTokenParserCallback($callable);
     }
 
+    /**
+     * @return void
+     */
     public function addNodeVisitor(NodeVisitorInterface $visitor)
     {
         $this->extensionSet->addNodeVisitor($visitor);
@@ -716,6 +759,9 @@ class Environment
         return $this->extensionSet->getNodeVisitors();
     }
 
+    /**
+     * @return void
+     */
     public function addFilter(TwigFilter $filter)
     {
         $this->extensionSet->addFilter($filter);
@@ -750,6 +796,9 @@ class Environment
         return $this->extensionSet->getFilters();
     }
 
+    /**
+     * @return void
+     */
     public function addTest(TwigTest $test)
     {
         $this->extensionSet->addTest($test);
@@ -773,6 +822,9 @@ class Environment
         return $this->extensionSet->getTest($name);
     }
 
+    /**
+     * @return void
+     */
     public function addFunction(TwigFunction $function)
     {
         $this->extensionSet->addFunction($function);
@@ -814,6 +866,8 @@ class Environment
      * but after, you can only update existing globals.
      *
      * @param mixed $value The global value
+     *
+     * @return void
      */
     public function addGlobal(string $name, $value)
     {

--- a/src/Extension/EscaperExtension.php
+++ b/src/Extension/EscaperExtension.php
@@ -80,6 +80,8 @@ final class EscaperExtension extends AbstractExtension
     }
 
     /**
+     * @return void
+     *
      * @deprecated since Twig 3.10
      */
     public function setEscaperRuntime(EscaperRuntime $escaper)
@@ -130,6 +132,8 @@ final class EscaperExtension extends AbstractExtension
      * @param string                                        $strategy The strategy name that should be used as a strategy in the escape call
      * @param callable(Environment, string, string): string $callable A valid PHP callable
      *
+     * @return void
+     *
      * @deprecated since Twig 3.10
      */
     public function setEscaper($strategy, callable $callable)
@@ -163,6 +167,8 @@ final class EscaperExtension extends AbstractExtension
     }
 
     /**
+     * @return void
+     *
      * @deprecated since Twig 3.10
      */
     public function setSafeClasses(array $safeClasses = [])
@@ -177,6 +183,8 @@ final class EscaperExtension extends AbstractExtension
     }
 
     /**
+     * @return void
+     *
      * @deprecated since Twig 3.10
      */
     public function addSafeClass(string $class, array $strategies)
@@ -192,6 +200,8 @@ final class EscaperExtension extends AbstractExtension
 
     /**
      * @internal
+     *
+     * @return array<string>
      */
     public static function escapeFilterIsSafe(Node $filterArgs)
     {

--- a/src/Extension/SandboxExtension.php
+++ b/src/Extension/SandboxExtension.php
@@ -72,7 +72,7 @@ final class SandboxExtension extends AbstractExtension
         return $this->sourcePolicy->enableSandbox($source);
     }
 
-    public function setSecurityPolicy(SecurityPolicyInterface $policy)
+    public function setSecurityPolicy(SecurityPolicyInterface $policy): void
     {
         $this->policy = $policy;
     }
@@ -117,6 +117,13 @@ final class SandboxExtension extends AbstractExtension
         }
     }
 
+    /**
+     * @param mixed $obj
+     *
+     * @return mixed
+     *
+     * @throws SecurityNotAllowedMethodError
+     */
     public function ensureToStringAllowed($obj, int $lineno = -1, ?Source $source = null)
     {
         if (\is_array($obj)) {

--- a/src/ExtensionSet.php
+++ b/src/ExtensionSet.php
@@ -62,6 +62,9 @@ final class ExtensionSet
         $this->staging = new StagingExtension();
     }
 
+    /**
+     * @return void
+     */
     public function initRuntime()
     {
         $this->runtimeInitialized = true;

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -53,7 +53,7 @@ class Lexer
         (?<DNUM>(?&LNUM)(?:(?&FRAC))?)          # Decimal number                123_456.456
     )(?:(?&DNUM)(?:(?&EXPONENT))?)              #                               123_456.456E+10
     /Ax';
-    
+
     public const REGEX_DQ_STRING_DELIM = '/"/A';
     public const REGEX_DQ_STRING_PART = '/[^#"\\\\]*(?:(?:\\\\.|#(?!\{))[^#"\\\\]*)*/As';
     public const REGEX_INLINE_COMMENT = '/#[^\n]*/A';
@@ -82,7 +82,7 @@ class Lexer
         ], $options);
     }
 
-    private function initialize()
+    private function initialize(): void
     {
         if ($this->isInitialized) {
             return;

--- a/src/Markup.php
+++ b/src/Markup.php
@@ -27,7 +27,7 @@ class Markup implements \Countable, \JsonSerializable, \Stringable
         $this->charset = $charset;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->content;
     }

--- a/src/Node/CheckSecurityCallNode.php
+++ b/src/Node/CheckSecurityCallNode.php
@@ -20,6 +20,9 @@ use Twig\Compiler;
 #[YieldReady]
 class CheckSecurityCallNode extends Node
 {
+    /**
+     * @return void
+     */
     public function compile(Compiler $compiler)
     {
         $compiler

--- a/src/Node/Expression/CallExpression.php
+++ b/src/Node/Expression/CallExpression.php
@@ -26,6 +26,9 @@ abstract class CallExpression extends AbstractExpression
 {
     private $reflector = null;
 
+    /**
+     * @return void
+     */
     protected function compileCallable(Compiler $compiler)
     {
         $twigCallable = $this->getTwigCallable();

--- a/src/Node/Expression/FunctionExpression.php
+++ b/src/Node/Expression/FunctionExpression.php
@@ -44,6 +44,9 @@ class FunctionExpression extends CallExpression
         $this->deprecateAttribute('dynamic_name', new NameDeprecation('twig/twig', '3.12'));
     }
 
+    /**
+     * @return void
+     */
     public function compile(Compiler $compiler)
     {
         $name = $this->getAttribute('name');

--- a/src/Node/Expression/Test/DefinedTest.php
+++ b/src/Node/Expression/Test/DefinedTest.php
@@ -75,7 +75,7 @@ class DefinedTest extends TestExpression
         parent::__construct($node, $name, $arguments, $lineno);
     }
 
-    private function changeIgnoreStrictCheck(GetAttrExpression $node)
+    private function changeIgnoreStrictCheck(GetAttrExpression $node): void
     {
         $node->setAttribute('optimizable', false);
         $node->setAttribute('ignore_strict_check', true);

--- a/src/Node/IncludeNode.php
+++ b/src/Node/IncludeNode.php
@@ -78,6 +78,9 @@ class IncludeNode extends Node implements NodeOutputInterface
         }
     }
 
+    /**
+     * @return void
+     */
     protected function addGetTemplate(Compiler $compiler/* , string $template = '' */)
     {
         $compiler
@@ -91,6 +94,9 @@ class IncludeNode extends Node implements NodeOutputInterface
         ;
     }
 
+    /**
+     * @return void
+     */
     protected function addTemplateArguments(Compiler $compiler)
     {
         if (!$this->hasNode('variables')) {

--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -64,6 +64,9 @@ final class ModuleNode extends Node
         $this->setSourceContext($source);
     }
 
+    /**
+     * @return void
+     */
     public function setIndex($index)
     {
         $this->setAttribute('index', $index);
@@ -78,6 +81,9 @@ final class ModuleNode extends Node
         }
     }
 
+    /**
+     * @return void
+     */
     protected function compileTemplate(Compiler $compiler)
     {
         if (!$this->getAttribute('index')) {
@@ -107,6 +113,9 @@ final class ModuleNode extends Node
         $this->compileClassFooter($compiler);
     }
 
+    /**
+     * @return void
+     */
     protected function compileGetParent(Compiler $compiler)
     {
         if (!$this->hasNode('parent')) {
@@ -142,6 +151,9 @@ final class ModuleNode extends Node
         ;
     }
 
+    /**
+     * @return void
+     */
     protected function compileClassHeader(Compiler $compiler)
     {
         $compiler
@@ -180,6 +192,9 @@ final class ModuleNode extends Node
         ;
     }
 
+    /**
+     * @return void
+     */
     protected function compileConstructor(Compiler $compiler)
     {
         $compiler
@@ -319,6 +334,9 @@ final class ModuleNode extends Node
         ;
     }
 
+    /**
+     * @return void
+     */
     protected function compileDisplay(Compiler $compiler)
     {
         $compiler
@@ -366,6 +384,9 @@ final class ModuleNode extends Node
         ;
     }
 
+    /**
+     * @return void
+     */
     protected function compileClassFooter(Compiler $compiler)
     {
         $compiler
@@ -375,11 +396,17 @@ final class ModuleNode extends Node
         ;
     }
 
+    /**
+     * @return void
+     */
     protected function compileMacros(Compiler $compiler)
     {
         $compiler->subcompile($this->getNode('macros'));
     }
 
+    /**
+     * @return void
+     */
     protected function compileGetTemplateName(Compiler $compiler)
     {
         $compiler
@@ -396,6 +423,9 @@ final class ModuleNode extends Node
         ;
     }
 
+    /**
+     * @return void
+     */
     protected function compileIsTraitable(Compiler $compiler)
     {
         // A template can be used as a trait if:
@@ -443,6 +473,9 @@ final class ModuleNode extends Node
         ;
     }
 
+    /**
+     * @return void
+     */
     protected function compileDebugInfo(Compiler $compiler)
     {
         $compiler
@@ -457,6 +490,9 @@ final class ModuleNode extends Node
         ;
     }
 
+    /**
+     * @return void
+     */
     protected function compileGetSourceContext(Compiler $compiler)
     {
         $compiler

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -65,7 +65,7 @@ class Node implements \Countable, \IteratorAggregate
         }
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $repr = static::class;
 
@@ -142,6 +142,9 @@ class Node implements \Countable, \IteratorAggregate
         return \array_key_exists($name, $this->attributes);
     }
 
+    /**
+     * @return mixed
+     */
     public function getAttribute(string $name)
     {
         if (!\array_key_exists($name, $this->attributes)) {

--- a/src/Node/TypesNode.php
+++ b/src/Node/TypesNode.php
@@ -21,6 +21,9 @@ class TypesNode extends Node
         parent::__construct([], ['mapping' => $types], $lineno);
     }
 
+    /**
+     * @return void
+     */
     public function compile(Compiler $compiler)
     {
         // Don't compile anything.

--- a/src/NodeVisitor/EscaperNodeVisitor.php
+++ b/src/NodeVisitor/EscaperNodeVisitor.php
@@ -157,7 +157,10 @@ final class EscaperNodeVisitor implements NodeVisitorInterface
         return \in_array($type, $safe) || \in_array('all', $safe);
     }
 
-    private function needEscaping()
+    /**
+     * @return string|false
+     */
+    private function needEscaping(): string|bool
     {
         if (\count($this->statusStack)) {
             return $this->statusStack[\count($this->statusStack) - 1];

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -227,6 +227,9 @@ class Parser
         return $this->blockStack;
     }
 
+    /**
+     * @return string|null
+     */
     public function peekBlockStack()
     {
         return $this->blockStack[\count($this->blockStack) - 1] ?? null;
@@ -289,6 +292,9 @@ class Parser
         return \count($this->traits) > 0;
     }
 
+    /**
+     * @return void
+     */
     public function embedTemplate(ModuleNode $template)
     {
         $template->setIndex(mt_rand());
@@ -307,6 +313,9 @@ class Parser
         $this->importedSymbols[0][$type][$alias] = ['name' => $name, 'node' => $internalRef];
     }
 
+    /**
+     * @return array{name: string, node: AssignTemplateVariable|null}|null
+     */
     public function getImportedSymbol(string $type, string $alias)
     {
         // if the symbol does not exist in the current scope (0), try in the main/global scope (last index)
@@ -340,6 +349,9 @@ class Parser
         return $this->parent;
     }
 
+    /**
+     * @return bool
+     */
     public function hasInheritance()
     {
         return $this->parent || 0 < \count($this->traits);

--- a/src/Profiler/Dumper/BlackfireDumper.php
+++ b/src/Profiler/Dumper/BlackfireDumper.php
@@ -40,7 +40,7 @@ EOF;
         return $str;
     }
 
-    private function dumpChildren(string $parent, Profile $profile, &$data)
+    private function dumpChildren(string $parent, Profile $profile, &$data): void
     {
         foreach ($profile as $p) {
             if ($p->isTemplate()) {
@@ -53,7 +53,7 @@ EOF;
         }
     }
 
-    private function dumpProfile(string $edge, Profile $profile, &$data)
+    private function dumpProfile(string $edge, Profile $profile, &$data): void
     {
         if (isset($data[$edge])) {
             ++$data[$edge]['ct'];

--- a/src/Runtime/EscaperRuntime.php
+++ b/src/Runtime/EscaperRuntime.php
@@ -36,6 +36,8 @@ final class EscaperRuntime implements RuntimeExtensionInterface
      *
      * @param string                                            $strategy The strategy name that should be used as a strategy in the escape call
      * @param callable(string $string, string $charset): string $callable A valid PHP callable
+     *
+     * @return void
      */
     public function setEscaper($strategy, callable $callable)
     {
@@ -54,6 +56,8 @@ final class EscaperRuntime implements RuntimeExtensionInterface
 
     /**
      * @param array<class-string<\Stringable>, string[]> $safeClasses
+     *
+     * @return void
      */
     public function setSafeClasses(array $safeClasses = [])
     {
@@ -67,6 +71,8 @@ final class EscaperRuntime implements RuntimeExtensionInterface
     /**
      * @param class-string<\Stringable> $class
      * @param string[]                  $strategies
+     *
+     * @return void                                        
      */
     public function addSafeClass(string $class, array $strategies)
     {

--- a/src/Sandbox/SecurityNotAllowedFilterError.php
+++ b/src/Sandbox/SecurityNotAllowedFilterError.php
@@ -18,7 +18,7 @@ namespace Twig\Sandbox;
  */
 final class SecurityNotAllowedFilterError extends SecurityError
 {
-    private $filterName;
+    private string $filterName;
 
     public function __construct(string $message, string $functionName)
     {

--- a/src/Sandbox/SecurityNotAllowedFunctionError.php
+++ b/src/Sandbox/SecurityNotAllowedFunctionError.php
@@ -18,7 +18,7 @@ namespace Twig\Sandbox;
  */
 final class SecurityNotAllowedFunctionError extends SecurityError
 {
-    private $functionName;
+    private string $functionName;
 
     public function __construct(string $message, string $functionName)
     {

--- a/src/Sandbox/SecurityNotAllowedMethodError.php
+++ b/src/Sandbox/SecurityNotAllowedMethodError.php
@@ -18,8 +18,8 @@ namespace Twig\Sandbox;
  */
 final class SecurityNotAllowedMethodError extends SecurityError
 {
-    private $className;
-    private $methodName;
+    private string $className;
+    private string $methodName;
 
     public function __construct(string $message, string $className, string $methodName)
     {
@@ -33,7 +33,7 @@ final class SecurityNotAllowedMethodError extends SecurityError
         return $this->className;
     }
 
-    public function getMethodName()
+    public function getMethodName(): string
     {
         return $this->methodName;
     }

--- a/src/Sandbox/SecurityNotAllowedPropertyError.php
+++ b/src/Sandbox/SecurityNotAllowedPropertyError.php
@@ -18,8 +18,8 @@ namespace Twig\Sandbox;
  */
 final class SecurityNotAllowedPropertyError extends SecurityError
 {
-    private $className;
-    private $propertyName;
+    private string $className;
+    private string $propertyName;
 
     public function __construct(string $message, string $className, string $propertyName)
     {
@@ -33,7 +33,7 @@ final class SecurityNotAllowedPropertyError extends SecurityError
         return $this->className;
     }
 
-    public function getPropertyName()
+    public function getPropertyName(): string
     {
         return $this->propertyName;
     }

--- a/src/Sandbox/SecurityNotAllowedTagError.php
+++ b/src/Sandbox/SecurityNotAllowedTagError.php
@@ -18,7 +18,7 @@ namespace Twig\Sandbox;
  */
 final class SecurityNotAllowedTagError extends SecurityError
 {
-    private $tagName;
+    private string $tagName;
 
     public function __construct(string $message, string $tagName)
     {

--- a/src/TemplateWrapper.php
+++ b/src/TemplateWrapper.php
@@ -51,6 +51,9 @@ final class TemplateWrapper
         return $this->template->render($context);
     }
 
+    /**
+     * @return void
+     */
     public function display(array $context = [])
     {
         // using func_get_args() allows to not expose the blocks argument
@@ -76,6 +79,9 @@ final class TemplateWrapper
         return $this->template->renderBlock($name, $context + $this->env->getGlobals());
     }
 
+    /**
+     * @return void
+     */
     public function displayBlock(string $name, array $context = [])
     {
         $context += $this->env->getGlobals();

--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -86,6 +86,8 @@ abstract class IntegrationTestCase extends TestCase
 
     /**
      * @dataProvider getTests
+     *
+     * @return void
      */
     public function testIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
     {
@@ -96,6 +98,8 @@ abstract class IntegrationTestCase extends TestCase
      * @dataProvider getLegacyTests
      *
      * @group legacy
+     *
+     * @return void
      */
     public function testLegacyIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
     {
@@ -103,6 +107,8 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * @return iterable
+     *
      * @final since Twig 3.13
      */
     public function getTests($name, $legacyTests = false)
@@ -159,12 +165,17 @@ abstract class IntegrationTestCase extends TestCase
 
     /**
      * @final since Twig 3.13
+     *
+     * @return iterable
      */
     public function getLegacyTests()
     {
         return $this->getTests('testLegacyIntegration', true);
     }
 
+    /**
+     * @return void
+     */
     protected function doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
     {
         if (!$outputs) {
@@ -275,6 +286,9 @@ abstract class IntegrationTestCase extends TestCase
         }
     }
 
+    /**
+     * @return array<string, string>
+     */
     protected static function parseTemplates($test)
     {
         $templates = [];

--- a/src/Test/NodeTestCase.php
+++ b/src/Test/NodeTestCase.php
@@ -26,6 +26,9 @@ abstract class NodeTestCase extends TestCase
      */
     private $currentEnv;
 
+    /**
+     * @return iterable<array{0: Node, 1: string, 2?: Environment|null, 3?: bool}>
+     */
     public function getTests()
     {
         return [];
@@ -44,6 +47,8 @@ abstract class NodeTestCase extends TestCase
     /**
      * @dataProvider getTests
      * @dataProvider provideTests
+     *
+     * @return void
      */
     #[DataProvider('getTests'), DataProvider('provideTests')]
     public function testCompile($node, $source, $environment = null, $isPattern = false)
@@ -51,6 +56,9 @@ abstract class NodeTestCase extends TestCase
         $this->assertNodeCompilation($source, $node, $environment, $isPattern);
     }
 
+    /**
+     * @return void
+     */
     public function assertNodeCompilation($source, Node $node, ?Environment $environment = null, $isPattern = false)
     {
         $compiler = $this->getCompiler($environment);
@@ -63,12 +71,17 @@ abstract class NodeTestCase extends TestCase
         }
     }
 
+    /**
+     * @return Compiler
+     */
     protected function getCompiler(?Environment $environment = null)
     {
         return new Compiler($environment ?? $this->getEnvironment());
     }
 
     /**
+     * @return Environment
+     *
      * @final since Twig 3.13
      */
     protected function getEnvironment()
@@ -82,6 +95,8 @@ abstract class NodeTestCase extends TestCase
     }
 
     /**
+     * @return string
+     *
      * @deprecated since Twig 3.13, use createVariableGetter() instead.
      */
     protected function getVariableGetter($name, $line = false)
@@ -99,6 +114,8 @@ abstract class NodeTestCase extends TestCase
     }
 
     /**
+     * @return string
+     *
      * @deprecated since Twig 3.13, use createAttributeGetter() instead.
      */
     protected function getAttributeGetter()

--- a/src/Token.php
+++ b/src/Token.php
@@ -40,7 +40,7 @@ final class Token
     ) {
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return \sprintf('%s(%s)', self::typeToString($this->type, true), $this->value);
     }
@@ -80,6 +80,9 @@ final class Token
         return $this->type;
     }
 
+    /**
+     * @return mixed
+     */
     public function getValue()
     {
         return $this->value;

--- a/src/TokenParser/IncludeTokenParser.php
+++ b/src/TokenParser/IncludeTokenParser.php
@@ -12,6 +12,7 @@
 
 namespace Twig\TokenParser;
 
+use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\IncludeNode;
 use Twig\Node\Node;
 use Twig\Token;
@@ -36,6 +37,9 @@ class IncludeTokenParser extends AbstractTokenParser
         return new IncludeNode($expr, $variables, $only, $ignoreMissing, $token->getLine());
     }
 
+    /**
+     * @return array{0: ?AbstractExpression, 1: bool, 2: bool}
+     */
     protected function parseArguments()
     {
         $stream = $this->parser->getStream();

--- a/src/TokenStream.php
+++ b/src/TokenStream.php
@@ -34,11 +34,14 @@ final class TokenStream
         }
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return implode("\n", $this->tokens);
     }
 
+    /**
+     * @return void
+     */
     public function injectTokens(array $tokens)
     {
         $this->tokens = array_merge(\array_slice($this->tokens, 0, $this->current), $tokens, \array_slice($this->tokens, $this->current));

--- a/src/Util/ReflectionCallable.php
+++ b/src/Util/ReflectionCallable.php
@@ -80,6 +80,9 @@ final class ReflectionCallable
         return $this->reflector;
     }
 
+    /**
+     * @return callable
+     */
     public function getCallable()
     {
         return $this->callable;


### PR DESCRIPTION
Started to add missing type annotation following @stof comment [here](https://github.com/twigphp/Twig/pull/4523#discussion_r1901915880).

Update:  I checked here every class (but one) in the `src` directory.

But you should ~~probably~~ **certainely** have another look.

Remains:
- src/ExpressionParser.php, where i'm not confident enough about the best return types (AbstractExpression|null works almost everytime, but lack some precision)
- extra directory
- tests directory

I'm happy to let them to someone else.... this was less fun than I expected 😅 