### PR TITLE
Fix constant() behavior when used with ??

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.19.0 (2025-XX-XX)
 
+ * Fix `constant()` behavior when used with `??`
  * Add the `invoke` filter
  * Make `{}` optional for the `types` tag
  * Add `LastModifiedExtensionInterface` and implementation in `AbstractExtension` to track modification of runtime classes

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -105,6 +105,13 @@ class Node implements \Countable, \IteratorAggregate
         return $repr;
     }
 
+    public function __clone()
+    {
+        foreach ($this->nodes as $name => $node) {
+            $this->nodes[$name] = clone $node;
+        }
+    }
+
     /**
      * @return void
      */

--- a/tests/Fixtures/functions/constant.test
+++ b/tests/Fixtures/functions/constant.test
@@ -4,9 +4,11 @@
 {{ constant('DATE_W3C') == expect ? 'true' : 'false' }}
 {{ constant('ARRAY_AS_PROPS', object) }}
 {{ constant('class', object) }}
+{{ constant('ARRAY_AS_PROPS', object) ?? 'KO' }}
 --DATA--
 return ['expect' => DATE_W3C, 'object' => new \ArrayObject(['hi'])]
 --EXPECT--
 true
 2
 ArrayObject
+2


### PR DESCRIPTION
The fix is broader than just this bug. Basically, it happens when we clone a Node for which an referenced Node will be modified later on.
