### PR TITLE
Fix timezone conversion on strings

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -576,7 +576,7 @@ final class CoreExtension extends AbstractExtension
         if (ctype_digit($asString) || ('' !== $asString && '-' === $asString[0] && ctype_digit(substr($asString, 1)))) {
             $date = new \DateTime('@'.$date);
         } else {
-            $date = new \DateTime($date, $this->getTimezone());
+            $date = new \DateTime($date);
         }
 
         if (false !== $timezone) {

--- a/tests/Fixtures/filters/date_time_zone_conversion.test
+++ b/tests/Fixtures/filters/date_time_zone_conversion.test
@@ -1,0 +1,91 @@
+--TEST--
+"date" filter with time zone conversion
+--TEMPLATE--
+{{ date1|date }}
+{{ date1|date('d/m/Y') }}
+{{ date1|date('d/m/Y H:i:s', 'Asia/Hong_Kong') }}
+{{ date1|date('d/m/Y H:i:s P', 'Asia/Hong_Kong') }}
+{{ date1|date('d/m/Y H:i:s P', 'America/Chicago') }}
+{{ date1|date('e') }}
+{{ date1|date('d/m/Y H:i:s') }}
+
+{{ date2|date }}
+{{ date2|date('d/m/Y') }}
+{{ date2|date('d/m/Y H:i:s', 'Asia/Hong_Kong') }}
+{{ date2|date('d/m/Y H:i:s', timezone1) }}
+{{ date2|date('d/m/Y H:i:s') }}
+
+{{ date3|date }}
+{{ date3|date('d/m/Y') }}
+
+{{ date4|date }}
+{{ date4|date('d/m/Y') }}
+
+{{ date5|date }}
+{{ date5|date('d/m/Y') }}
+
+{{ date6|date('d/m/Y H:i:s P', 'Europe/Paris') }}
+{{ date6|date('d/m/Y H:i:s P', 'Asia/Hong_Kong') }}
+{{ date6|date('d/m/Y H:i:s P', false) }}
+{{ date6|date('e', 'Europe/Paris') }}
+{{ date6|date('e', false) }}
+
+{{ date7|date }}
+{{ date7|date(timezone='Europe/Paris') }}
+{{ date7|date(timezone='Asia/Hong_Kong') }}
+{{ date7|date(timezone=false) }}
+{{ date7|date(timezone='Indian/Mauritius') }}
+
+{{ '2010-01-28 15:00:00'|date(timezone="Europe/Paris") }}
+{{ '2010-01-28 15:00:00'|date(timezone="Asia/Hong_Kong") }}
+--DATA--
+date_default_timezone_set('Europe/Paris');
+$twig->getExtension(\Twig\Extension\CoreExtension::class)->setTimezone('UTC');
+return [
+    'date1' => mktime(13, 45, 0, 10, 4, 2010),
+    'date2' => new \DateTime('2010-10-04 13:45'),
+    'date3' => '2010-10-04 13:45',
+    'date4' => 1286199900, // \DateTime::createFromFormat('Y-m-d H:i', '2010-10-04 13:45', new \DateTimeZone('UTC'))->getTimestamp() -- A unixtimestamp is always GMT
+    'date5' => -189291360, // \DateTime::createFromFormat('Y-m-d H:i', '1964-01-02 03:04', new \DateTimeZone('UTC'))->getTimestamp(),
+    'date6' => new \DateTime('2010-10-04 13:45', new \DateTimeZone('America/New_York')),
+    'date7' => '2010-01-28T15:00:00+04:00',
+    'timezone1' => new \DateTimeZone('America/New_York'),
+]
+--EXPECT--
+October 4, 2010 11:45
+04/10/2010
+04/10/2010 19:45:00
+04/10/2010 19:45:00 +08:00
+04/10/2010 06:45:00 -05:00
+UTC
+04/10/2010 11:45:00
+
+October 4, 2010 11:45
+04/10/2010
+04/10/2010 19:45:00
+04/10/2010 07:45:00
+04/10/2010 11:45:00
+
+October 4, 2010 11:45
+04/10/2010
+
+October 4, 2010 13:45
+04/10/2010
+
+January 2, 1964 03:04
+02/01/1964
+
+04/10/2010 19:45:00 +02:00
+05/10/2010 01:45:00 +08:00
+04/10/2010 13:45:00 -04:00
+Europe/Paris
+America/New_York
+
+January 28, 2010 11:00
+January 28, 2010 12:00
+January 28, 2010 19:00
+January 28, 2010 15:00
+January 28, 2010 15:00
+
+January 28, 2010 15:00
+January 28, 2010 22:00


### PR DESCRIPTION
When setting a default application timezone, and a display timezone:
```php
date_default_timezone_set('UTC');
$twig->getExtension(\Twig\Extension\CoreExtension::class)->setTimezone('Europe/Paris');
```

Date objects get converted, but strings don't. See #4545. 

For most other paths in `convertDate`, the dateTime object is initialized, and afterwards the timezone gets set. For strings, the timezone is passed as a constructor argument before having the timezone set again, losing its converting behaviour. This makes the convertDate method work identical for DateTime objects as strings. This different behaviour was already spotted in #3568.

Fixes #4545 #3568 #2819