### PR TITLE
Ignore static properties when using the dot operator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
  * Add the `invoke` filter
  * Make `{}` optional for the `types` tag
  * Add `LastModifiedExtensionInterface` and implementation in `AbstractExtension` to track modification of runtime classes
+ * Ignore static properties when using the dot operator
 
 # 3.18.0 (2024-12-29)
 

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -2151,7 +2151,7 @@ final class CoreExtension extends AbstractExtension
 
         $property = $class->getProperty($property);
 
-        if (!$property->isPublic()) {
+        if (!$property->isPublic() || $property->isStatic()) {
             static $false;
 
             return $false ??= static fn () => false;

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -67,6 +67,8 @@ class TwigTestFoo implements \Iterator
     public $position = 0;
     public $array = [1, 2];
 
+    public static $foo = 'Foo';
+
     public function bar($param1 = null, $param2 = null)
     {
         return 'bar'.($param1 ? '_'.$param1 : '').($param2 ? '-'.$param2 : '');


### PR DESCRIPTION
Fix #4547