### PR TITLE
Fixing minor typo in inline_css.rst

### DIFF
--- a/doc/filters/inline_css.rst
+++ b/doc/filters/inline_css.rst
@@ -1,7 +1,7 @@
 ``inline_css``
 ==============
 
-The ``inline_css`` filter inline CSS styles in HTML documents:
+The ``inline_css`` filter inlines CSS styles in HTML documents:
 
 .. code-block:: html+twig
 


### PR DESCRIPTION
The inline_css filter ~inline~ inlines CSS styles in HTML documents: