### PR TITLE
Fix typo for html_cva code example

### DIFF
--- a/doc/functions/html_cva.rst
+++ b/doc/functions/html_cva.rst
@@ -45,7 +45,7 @@ Then use the ``color`` and ``size`` variants to select the needed classes:
 
     {# index.html.twig #}
     {{ include('alert.html.twig', {'color': 'blue', 'size': 'md'}) }}
-    // class="alert bg-red text-md"
+    // class="alert bg-blue text-md"
 
     {{ include('alert.html.twig', {'color': 'green', 'size': 'sm'}) }}
     // class="alert bg-green text-sm"


### PR DESCRIPTION
Fix a typo where 'red' should be 'blue' according to the code above.