### PR TITLE
Make the raw filter more "sticky"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 4.0.0 (2024-XX-XX)
 
+ * Make the `raw` filter sticky
  * Add back the `if` condition on `for` loops
  * Add return types to all ExtensionInterface methods (`getFunctions()`, `getFilters()`, etc.)
  * Add support for recursive loops (via the `loop()` function)

--- a/src/Node/Expression/Filter/RawFilter.php
+++ b/src/Node/Expression/Filter/RawFilter.php
@@ -32,6 +32,10 @@ class RawFilter extends FilterExpression
 
     public function compile(Compiler $compiler): void
     {
-        $compiler->subcompile($this->getNode('node'));
+        $compiler
+            ->raw('(is_scalar($tmp = ')
+            ->subcompile($this->getNode('node'))
+            ->raw(') ? new Markup($tmp, $this->env->getCharset()) : $tmp)')
+        ;
     }
 }

--- a/tests/Fixtures/filters/raw.test
+++ b/tests/Fixtures/filters/raw.test
@@ -2,7 +2,17 @@
 "raw" filter excludes a variable from being escaped
 --TEMPLATE--
 {{ br|raw }}
+{% set br1 = '<br>'|raw %}
+{{ br1 }}
+{{ include('included', {br: '<br>'|raw, br1: br1}) }}
+--TEMPLATE(included)--
+{{ br }}
+{{ br1 }}
 --DATA--
 return ['br' => '<br>']
 --EXPECT--
+<br>
+<br>
+
+<br>
 <br>

--- a/tests/Node/Expression/Filter/RawTest.php
+++ b/tests/Node/Expression/Filter/RawTest.php
@@ -32,7 +32,7 @@ class RawTest extends NodeTestCase
         $node = new RawFilter(new ConstantExpression('foo', 12));
 
         return [
-            [$node, '"foo"'],
+            [$node, '(is_scalar($tmp = "foo") ? new Markup($tmp, $this->env->getCharset()) : $tmp)'],
         ];
     }
 }

--- a/tests/Node/ForTest.php
+++ b/tests/Node/ForTest.php
@@ -177,7 +177,7 @@ yield from (\$_v1 = function (\$iterator, &\$context, \$blocks, \$recurseFunc, \
     \$parent = \$context;
     \$context['loop'] = new \Twig\Runtime\LoopContext(\$iterator, \$parent, \$blocks, \$recurseFunc, \$depth);
     foreach (\$iterator as \$context["_key"] => \$context["item"]) {
-        yield from CoreExtension::getAttribute(\$this->env, \$this->source, \$context["loop"], "__invoke", arguments: [CoreExtension::getAttribute(\$this->env, \$this->source, \$context["item"], "children", arguments: [], lineno: 1)], type: "method", lineno: 1);
+        yield from (is_scalar(\$tmp = CoreExtension::getAttribute(\$this->env, \$this->source, \$context["loop"], "__invoke", arguments: [CoreExtension::getAttribute(\$this->env, \$this->source, \$context["item"], "children", arguments: [], lineno: 1)], type: "method", lineno: 1)) ? new Markup(\$tmp, \$this->env->getCharset()) : \$tmp);
     }
     unset(\$context['_key'], \$context['item'], \$context['loop']);
     \$context = array_intersect_key(\$context, \$parent) + \$parent;


### PR DESCRIPTION
When using `{{ foo|raw }}`, the expression won't be escaped as expected.

But if you store the result and reuse it afterwards, the value is not considered "safe" anymore:

`{% set bar = foo|raw %}{{ bar }}`

Here `bar` will be escaped.

For Twig 4.x, I propose to make the `raw` filter "sticky" by wrapping the value with `Markup`. That way, the second example won't be escaped as expected.
