### PR TITLE
Make `in_array()` calls strict

### DIFF
--- a/extra/cache-extra/TokenParser/CacheTokenParser.php
+++ b/extra/cache-extra/TokenParser/CacheTokenParser.php
@@ -30,7 +30,7 @@ class CacheTokenParser extends AbstractTokenParser
         $tags = null;
         while ($stream->test(Token::NAME_TYPE)) {
             $k = $stream->getCurrent()->getValue();
-            if (!\in_array($k, ['ttl', 'tags'])) {
+            if (!\in_array($k, ['ttl', 'tags'], true)) {
                 throw new SyntaxError(\sprintf('Unknown "%s" configuration.', $k), $stream->getCurrent()->getLine(), $stream->getSourceContext());
             }
 

--- a/extra/html-extra/Cva.php
+++ b/extra/html-extra/Cva.php
@@ -119,7 +119,7 @@ final class Cva
             if ('class' === $compoundName) {
                 continue;
             }
-            if (!isset($recipes[$compoundName]) || !\in_array($recipes[$compoundName], (array) $compoundValues)) {
+            if (!isset($recipes[$compoundName]) || !\in_array($recipes[$compoundName], (array) $compoundValues, true)) {
                 return [];
             }
         }

--- a/extra/twig-extra-bundle/Extensions.php
+++ b/extra/twig-extra-bundle/Extensions.php
@@ -99,7 +99,7 @@ final class Extensions
     public static function getFilter(string $name): array
     {
         foreach (self::EXTENSIONS as $extension) {
-            if (\in_array($name, $extension['filters'])) {
+            if (\in_array($name, $extension['filters'], true)) {
                 return [$extension['class_name'], $extension['package']];
             }
         }
@@ -110,7 +110,7 @@ final class Extensions
     public static function getFunction(string $name): array
     {
         foreach (self::EXTENSIONS as $extension) {
-            if (\in_array($name, $extension['functions'])) {
+            if (\in_array($name, $extension['functions'], true)) {
                 return [$extension['class_name'], $extension['package']];
             }
         }
@@ -121,7 +121,7 @@ final class Extensions
     public static function getTag(string $name): array
     {
         foreach (self::EXTENSIONS as $extension) {
-            if (\in_array($name, $extension['tags'])) {
+            if (\in_array($name, $extension['tags'], true)) {
                 return [$extension['class_name'], $extension['package']];
             }
         }

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1836,7 +1836,7 @@ final class CoreExtension extends AbstractExtension
                 } elseif ('h' === $lcName[0] && str_starts_with($lcName, 'has')) {
                     $name = substr($method, 3);
                     $lcName = substr($lcName, 3);
-                    if (\in_array('is'.$lcName, $lcMethods)) {
+                    if (\in_array('is'.$lcName, $lcMethods, true)) {
                         continue;
                     }
                 } else {

--- a/src/FileExtensionEscapingStrategy.php
+++ b/src/FileExtensionEscapingStrategy.php
@@ -33,7 +33,7 @@ class FileExtensionEscapingStrategy
      */
     public static function guess(string $name)
     {
-        if (\in_array(substr($name, -1), ['/', '\\'])) {
+        if (\in_array(substr($name, -1), ['/', '\\'], true)) {
             return 'html'; // return html for directories
         }
 

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -337,7 +337,7 @@ class Lexer
         // operators
         if (preg_match($this->regexes['operator'], $this->code, $match, 0, $this->cursor)) {
             $operator = preg_replace('/\s+/', ' ', $match[0]);
-            if (\in_array($operator, $this->openingBrackets)) {
+            if (\in_array($operator, $this->openingBrackets, true)) {
                 $this->checkBrackets($operator);
             }
             $this->pushToken(Token::OPERATOR_TYPE, $operator);
@@ -574,9 +574,9 @@ class Lexer
     private function checkBrackets(string $code): void
     {
         // opening bracket
-        if (\in_array($code, $this->openingBrackets)) {
+        if (\in_array($code, $this->openingBrackets, true)) {
             $this->brackets[] = [$code, $this->lineno];
-        } elseif (\in_array($code, $this->closingBrackets)) {
+        } elseif (\in_array($code, $this->closingBrackets, true)) {
             // closing bracket
             if (!$this->brackets) {
                 throw new SyntaxError(\sprintf('Unexpected "%s".', $code), $this->lineno, $this->source);

--- a/src/Node/Expression/AssignNameExpression.php
+++ b/src/Node/Expression/AssignNameExpression.php
@@ -26,7 +26,7 @@ class AssignNameExpression extends ContextVariable
         }
 
         // All names supported by ExpressionParser::parsePrimaryExpression() should be excluded
-        if (\in_array(strtolower($name), ['true', 'false', 'none', 'null'])) {
+        if (\in_array(strtolower($name), ['true', 'false', 'none', 'null'], true)) {
             throw new SyntaxError(\sprintf('You cannot assign a value to "%s".', $name), $lineno);
         }
 

--- a/src/Node/Expression/TempNameExpression.php
+++ b/src/Node/Expression/TempNameExpression.php
@@ -21,7 +21,7 @@ class TempNameExpression extends AbstractExpression
     public function __construct(string|int|null $name, int $lineno)
     {
         // All names supported by ExpressionParser::parsePrimaryExpression() should be excluded
-        if ($name && \in_array(strtolower($name), ['true', 'false', 'none', 'null'])) {
+        if ($name && \in_array(strtolower($name), ['true', 'false', 'none', 'null'], true)) {
             throw new SyntaxError(\sprintf('You cannot assign a value to "%s".', $name), $lineno);
         }
 
@@ -31,7 +31,7 @@ class TempNameExpression extends AbstractExpression
 
         if (null !== $name && (\is_int($name) || ctype_digit($name))) {
             $name = (int) $name;
-        } elseif (\in_array($name, self::RESERVED_NAMES)) {
+        } elseif (\in_array($name, self::RESERVED_NAMES, true)) {
             $name = "\u{035C}".$name;
         }
 

--- a/src/NodeVisitor/EscaperNodeVisitor.php
+++ b/src/NodeVisitor/EscaperNodeVisitor.php
@@ -154,7 +154,7 @@ final class EscaperNodeVisitor implements NodeVisitorInterface
             $safe = $this->safeAnalysis->getSafe($expression);
         }
 
-        return \in_array($type, $safe) || \in_array('all', $safe);
+        return \in_array($type, $safe, true) || \in_array('all', $safe, true);
     }
 
     /**

--- a/src/NodeVisitor/OptimizerNodeVisitor.php
+++ b/src/NodeVisitor/OptimizerNodeVisitor.php
@@ -143,7 +143,7 @@ final class OptimizerNodeVisitor implements NodeVisitorInterface
         }
 
         // optimize access to loop targets
-        elseif ($node instanceof ContextVariable && \in_array($node->getAttribute('name'), $this->loopsTargets)) {
+        elseif ($node instanceof ContextVariable && \in_array($node->getAttribute('name'), $this->loopsTargets, true)) {
             $node->setAttribute('always_defined', true);
         }
 

--- a/src/NodeVisitor/SafeAnalysisNodeVisitor.php
+++ b/src/NodeVisitor/SafeAnalysisNodeVisitor.php
@@ -52,7 +52,7 @@ final class SafeAnalysisNodeVisitor implements NodeVisitorInterface
                 continue;
             }
 
-            if (\in_array('html_attr', $bucket['value'])) {
+            if (\in_array('html_attr', $bucket['value'], true)) {
                 $bucket['value'][] = 'html';
             }
 
@@ -148,7 +148,7 @@ final class SafeAnalysisNodeVisitor implements NodeVisitorInterface
             $this->setSafe($node, ['all']);
         } elseif ($node instanceof GetAttrExpression && $node->getNode('node') instanceof ContextVariable) {
             $name = $node->getNode('node')->getAttribute('name');
-            if (\in_array($name, $this->safeVars)) {
+            if (\in_array($name, $this->safeVars, true)) {
                 $this->setSafe($node, ['all']);
             }
         }
@@ -162,11 +162,11 @@ final class SafeAnalysisNodeVisitor implements NodeVisitorInterface
             return [];
         }
 
-        if (\in_array('all', $a)) {
+        if (\in_array('all', $a, true)) {
             return $b;
         }
 
-        if (\in_array('all', $b)) {
+        if (\in_array('all', $b, true)) {
             return $a;
         }
 

--- a/src/Runtime/EscaperRuntime.php
+++ b/src/Runtime/EscaperRuntime.php
@@ -124,7 +124,7 @@ final class EscaperRuntime implements RuntimeExtensionInterface
                 }
 
                 $string = (string) $string;
-            } elseif (\in_array($strategy, ['html', 'js', 'css', 'html_attr', 'url'])) {
+            } elseif (\in_array($strategy, ['html', 'js', 'css', 'html_attr', 'url'], true)) {
                 // we return the input as is (which can be of any type)
                 return $string;
             }

--- a/src/Sandbox/SecurityPolicy.php
+++ b/src/Sandbox/SecurityPolicy.php
@@ -67,7 +67,7 @@ final class SecurityPolicy implements SecurityPolicyInterface
     public function checkSecurity($tags, $filters, $functions): void
     {
         foreach ($tags as $tag) {
-            if (!\in_array($tag, $this->allowedTags)) {
+            if (!\in_array($tag, $this->allowedTags, true)) {
                 if ('extends' === $tag) {
                     trigger_deprecation('twig/twig', '3.12', 'The "extends" tag is always allowed in sandboxes, but won\'t be in 4.0, please enable it explicitly in your sandbox policy if needed.');
                 } elseif ('use' === $tag) {
@@ -79,13 +79,13 @@ final class SecurityPolicy implements SecurityPolicyInterface
         }
 
         foreach ($filters as $filter) {
-            if (!\in_array($filter, $this->allowedFilters)) {
+            if (!\in_array($filter, $this->allowedFilters, true)) {
                 throw new SecurityNotAllowedFilterError(\sprintf('Filter "%s" is not allowed.', $filter), $filter);
             }
         }
 
         foreach ($functions as $function) {
-            if (!\in_array($function, $this->allowedFunctions)) {
+            if (!\in_array($function, $this->allowedFunctions, true)) {
                 throw new SecurityNotAllowedFunctionError(\sprintf('Function "%s" is not allowed.', $function), $function);
             }
         }
@@ -100,7 +100,7 @@ final class SecurityPolicy implements SecurityPolicyInterface
         $allowed = false;
         $method = strtolower($method);
         foreach ($this->allowedMethods as $class => $methods) {
-            if ($obj instanceof $class && \in_array($method, $methods)) {
+            if ($obj instanceof $class && \in_array($method, $methods, true)) {
                 $allowed = true;
                 break;
             }
@@ -116,7 +116,7 @@ final class SecurityPolicy implements SecurityPolicyInterface
     {
         $allowed = false;
         foreach ($this->allowedProperties as $class => $properties) {
-            if ($obj instanceof $class && \in_array($property, \is_array($properties) ? $properties : [$properties])) {
+            if ($obj instanceof $class && \in_array($property, \is_array($properties) ? $properties : [$properties], true)) {
                 $allowed = true;
                 break;
             }

--- a/src/Token.php
+++ b/src/Token.php
@@ -87,9 +87,9 @@ final class Token
         }
 
         $typeMatches = $this->type === $type;
-        if ($typeMatches && self::PUNCTUATION_TYPE === $type && \in_array($this->value, ['(', '[', '|', '.', '?', '?:']) && $values) {
+        if ($typeMatches && self::PUNCTUATION_TYPE === $type && \in_array($this->value, ['(', '[', '|', '.', '?', '?:'], true) && $values) {
             foreach ((array) $values as $value) {
-                if (\in_array($value, ['(', '[', '|', '.', '?', '?:'])) {
+                if (\in_array($value, ['(', '[', '|', '.', '?', '?:'], true)) {
                     trigger_deprecation('twig/twig', '3.21', 'The "%s" token is now an "%s" token instead of a "%s" one.', $this->value, self::typeToEnglish(self::OPERATOR_TYPE), $this->toEnglish());
 
                     break;
@@ -100,7 +100,7 @@ final class Token
             if (self::OPERATOR_TYPE === $type && self::PUNCTUATION_TYPE === $this->type) {
                 if ($values) {
                     foreach ((array) $values as $value) {
-                        if (\in_array($value, ['(', '[', '|', '.', '?', '?:'])) {
+                        if (\in_array($value, ['(', '[', '|', '.', '?', '?:'], true)) {
                             $typeMatches = true;
 
                             break;
@@ -114,7 +114,7 @@ final class Token
 
         return $typeMatches && (
             null === $values
-            || (\is_array($values) && \in_array($this->value, $values))
+            || (\is_array($values) && \in_array($this->value, $values, true))
             || $this->value == $values
         );
     }

--- a/src/TokenParser/GuardTokenParser.php
+++ b/src/TokenParser/GuardTokenParser.php
@@ -26,7 +26,7 @@ final class GuardTokenParser extends AbstractTokenParser
     {
         $stream = $this->parser->getStream();
         $typeToken = $stream->expect(Token::NAME_TYPE);
-        if (!\in_array($typeToken->getValue(), ['function', 'filter', 'test'])) {
+        if (!\in_array($typeToken->getValue(), ['function', 'filter', 'test'], true)) {
             throw new SyntaxError(\sprintf('Supported guard types are function, filter and test, "%s" given.', $typeToken->getValue()), $typeToken->getLine(), $stream->getSourceContext());
         }
         $method = 'get'.$typeToken->getValue();


### PR DESCRIPTION
I propose to add `strict: true` to all calls to `in_array()`, making the calls faster.