### PR TITLE
add back @dataProvider annotations

### DIFF
--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -100,6 +100,8 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * @dataProvider getTests
+     *
      * @return void
      */
     #[DataProvider('getTests')]
@@ -109,6 +111,8 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * @dataProvider getLegacyTests
+     *
      * @group legacy
      *
      * @return void

--- a/src/Test/NodeTestCase.php
+++ b/src/Test/NodeTestCase.php
@@ -36,6 +36,8 @@ abstract class NodeTestCase extends TestCase
     abstract public static function provideTests(): iterable;
 
     /**
+     * @dataProvider provideTests
+     *
      * @return void
      */
     #[DataProvider('provideTests')]


### PR DESCRIPTION
This partially reverts 50cdb7bf4ac098a5c5f4d2332f48b4136927781d to be able to run tests on the 3.x branch for the extra packages with Twig 4 being installed as we are still using PHPUnit 9.6 on the 3.x branch.