### PR TITLE
reduce the number of deprecations being triggered

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.21.0 (2025-XX-XX)
 
+ * Deprecate `Template::loadTemplate()`
  * Fix testing and expression when it evaluates to an instance of `Markup`
  * Add `ReturnPrimitiveTypeInterface` (and sub-interfaces for number, boolean, string, and array)
  * Add `SupportDefinedTestInterface` for expression nodes supporting the `defined` test

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -259,10 +259,10 @@ Token
 Templates
 ---------
 
+* The method ``Template::loadTemplate()`` is deprecated.
 * Passing ``Twig\Template`` instances to Twig public API is deprecated (like
-  in ``Environment::resolveTemplate()``, ``Environment::load()``, and
-  ``Template::loadTemplate()``); pass instances of ``Twig\TemplateWrapper``
-  instead.
+  in ``Environment::resolveTemplate()`` and ``Environment::load()``); pass
+  instances of ``Twig\TemplateWrapper`` instead.
 
 Filters
 -------

--- a/src/Template.php
+++ b/src/Template.php
@@ -313,21 +313,17 @@ abstract class Template
     /**
      * @param string|TemplateWrapper|array<string|TemplateWrapper> $template
      *
-     * @deprecated since 3.21 and will be removed in 4.0. Use Template::load() instead.
+     * @deprecated since Twig 3.21 and will be removed in 4.0. Use Template::load() instead.
      */
     protected function loadTemplate($template, $templateName = null, int|null $line = null, int|null $index = null): self|TemplateWrapper
     {
         trigger_deprecation('twig/twig', '3.21', 'The "%s" method is deprecated.', __METHOD__);
 
         if (null === $line) {
-            trigger_deprecation('twig/twig', '3.21', 'Passing a "null" line number to "%s" is deprecated.', __METHOD__);
-
             $line = -1;
         }
 
         if ($template instanceof self) {
-            trigger_deprecation('twig/twig', '3.9', 'Passing a "%s" instance to "%s" is deprecated.', self::class, __METHOD__);
-
             return $template;
         }
 


### PR DESCRIPTION
Triggering deprecations for specific arguments is not needed as the method itself is deprecated as well.