### PR TITLE
Fix `ModuleNode` instanciation when `$embeddedTemplates` is null

### DIFF
--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -41,7 +41,7 @@ final class ModuleNode extends Node
         if (!$embeddedTemplates instanceof Node) {
             trigger_deprecation('twig/twig', '3.21', \sprintf('Not passing a "%s" instance as the "embedded_templates" argument of the "%s" constructor is deprecated.', Node::class, static::class));
 
-            $embeddedTemplates = new Nodes($embeddedTemplates);
+            $embeddedTemplates = new Nodes($embeddedTemplates ?? []);
         }
 
         $nodes = [


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/pull/59886, in case `$embeddedTemplates` is null