### PR TITLE
Update phpstan-baseline.neon

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -23,3 +23,8 @@ parameters:
 			identifier: binaryOp.invalid
 			count: 1
 			path: src/Lexer.php
+
+		- # phpstan is right that a child class might override the protected properties with hooks but that's not a case we want to support
+			identifier: unset.possiblyHookedProperty
+			count: 2
+			path: src/Node/Node.php


### PR DESCRIPTION
Ignore errors about Node protected properties that could be overridden in child classes with properties using hooks that would not allow unsetting array items. For now, we ignore this potential issue.

The solution to fix this would be to define the properties as private in 4.0, forcing child classes to use the public methods to access them. Another solution could be to mark the property as final, but this requires PHP 8.4+