### PR TITLE
[Doc] Fix `code-block` in html_cva

### DIFF
--- a/doc/functions/html_cva.rst
+++ b/doc/functions/html_cva.rst
@@ -61,7 +61,7 @@ To "merge" conflicting classes together and keep only the ones you need, use the
 ``tailwind_merge()`` filter from `tales-from-a-dev/twig-tailwind-extra`_
 with the ``html_cva()`` function:
 
-.. code-block:: terminal
+.. code-block:: bash
 
     $ composer require tales-from-a-dev/twig-tailwind-extra
 


### PR DESCRIPTION
There is no `terminal` code-block in the current Twig documentation.

Using `bash` here instead is more in line with the other pages.

(...and will allow to simplify CSS needed for code blocks)