### PR TITLE
This PR adds support for the optional chaining operator (?.) to Twig.

### DIFF
--- a/src/ExpressionParser/Infix/OptionalChainExpressionParser.php
+++ b/src/ExpressionParser/Infix/OptionalChainExpressionParser.php
@@ -35,11 +35,7 @@ final class OptionalChainExpressionParser extends AbstractExpressionParser imple
         $arguments = new ArrayExpression([], $lineno);
         $type = Template::ANY_CALL;
         $isOptionalChain = true;
-
-        // Проверка, является ли левое выражение переменной
         $isVariable = $expr instanceof NameExpression;
-
-        // Для обработки квадратных скобок
         if ($stream->test(Token::OPERATOR_TYPE, '[')) {
             $token = $stream->next();
             $attribute = $parser->parseExpression();
@@ -73,11 +69,11 @@ final class OptionalChainExpressionParser extends AbstractExpressionParser imple
                 || '_self' === $expr->getAttribute('name') && $attribute instanceof ConstantExpression
             )
         ) {
-            // Для макросов не используем optional chaining
+   
             return new MacroReferenceExpression(new TemplateVariable($expr->getAttribute('name'), $expr->getTemplateLine()), 'macro_'.$attribute->getAttribute('value'), $arguments, $expr->getTemplateLine());
         }
 
-        // Создаем специальный флаг для проверки существования переменной
+  
         if ($isVariable && $expr instanceof NameExpression) {
             $expr->setAttribute('optional_chain', true);
         }

--- a/src/ExpressionParser/Infix/OptionalChainExpressionParser.php
+++ b/src/ExpressionParser/Infix/OptionalChainExpressionParser.php
@@ -97,7 +97,7 @@ final class OptionalChainExpressionParser extends AbstractExpressionParser imple
 
     public function getPrecedence(): int
     {
-        return 512; // Тот же приоритет, что и у оператора "."
+        return 512;
     }
 
     public function getAssociativity(): InfixAssociativity

--- a/src/ExpressionParser/Infix/OptionalChainExpressionParser.php
+++ b/src/ExpressionParser/Infix/OptionalChainExpressionParser.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Twig\ExpressionParser\Infix;
+
+use Twig\Error\SyntaxError;
+use Twig\ExpressionParser\AbstractExpressionParser;
+use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
+use Twig\ExpressionParser\InfixAssociativity;
+use Twig\ExpressionParser\InfixExpressionParserInterface;
+use Twig\Lexer;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\GetAttrExpression;
+use Twig\Node\Expression\MacroReferenceExpression;
+use Twig\Node\Expression\NameExpression;
+use Twig\Node\Expression\Variable\TemplateVariable;
+use Twig\Parser;
+use Twig\Template;
+use Twig\Token;
+
+/**
+ * @internal
+ */
+final class OptionalChainExpressionParser extends AbstractExpressionParser implements InfixExpressionParserInterface, ExpressionParserDescriptionInterface
+{
+    use ArgumentsTrait;
+
+
+    public function parse(Parser $parser, AbstractExpression $expr, Token $token): AbstractExpression
+    {
+        $stream = $parser->getStream();
+        $token = $stream->getCurrent();
+        $lineno = $token->getLine();
+        $arguments = new ArrayExpression([], $lineno);
+        $type = Template::ANY_CALL;
+        $isOptionalChain = true;
+
+        // Проверка, является ли левое выражение переменной
+        $isVariable = $expr instanceof NameExpression;
+
+        // Для обработки квадратных скобок
+        if ($stream->test(Token::OPERATOR_TYPE, '[')) {
+            $token = $stream->next();
+            $attribute = $parser->parseExpression();
+            $stream->expect(Token::PUNCTUATION_TYPE, ']');
+            $type = Template::ARRAY_CALL;
+        } elseif ($stream->nextIf(Token::OPERATOR_TYPE, '(')) {
+            $attribute = $parser->parseExpression();
+            $stream->expect(Token::PUNCTUATION_TYPE, ')');
+        } else {
+            $token = $stream->next();
+            if (
+                $token->test(Token::NAME_TYPE)
+                || $token->test(Token::NUMBER_TYPE)
+                || ($token->test(Token::OPERATOR_TYPE) && preg_match(Lexer::REGEX_NAME, $token->getValue()))
+            ) {
+                $attribute = new ConstantExpression($token->getValue(), $token->getLine());
+            } else {
+                throw new SyntaxError(\sprintf('Expected name or number, got value "%s" of type %s.', $token->getValue(), $token->toEnglish()), $token->getLine(), $stream->getSourceContext());
+            }
+        }
+
+        if ($stream->test(Token::OPERATOR_TYPE, '(')) {
+            $type = Template::METHOD_CALL;
+            $arguments = $this->parseCallableArguments($parser, $token->getLine());
+        }
+
+        if (
+            $expr instanceof NameExpression
+            && (
+                null !== $parser->getImportedSymbol('template', $expr->getAttribute('name'))
+                || '_self' === $expr->getAttribute('name') && $attribute instanceof ConstantExpression
+            )
+        ) {
+            // Для макросов не используем optional chaining
+            return new MacroReferenceExpression(new TemplateVariable($expr->getAttribute('name'), $expr->getTemplateLine()), 'macro_'.$attribute->getAttribute('value'), $arguments, $expr->getTemplateLine());
+        }
+
+        // Создаем специальный флаг для проверки существования переменной
+        if ($isVariable && $expr instanceof NameExpression) {
+            $expr->setAttribute('optional_chain', true);
+        }
+
+        return new GetAttrExpression($expr, $attribute, $arguments, $type, $lineno, $isOptionalChain);
+    }
+
+    public function getName(): string
+    {
+        return '?.';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Optional chaining to safely access an attribute on a potentially null variable';
+    }
+
+    public function getPrecedence(): int
+    {
+        return 512; // Тот же приоритет, что и у оператора "."
+    }
+
+    public function getAssociativity(): InfixAssociativity
+    {
+        return InfixAssociativity::Left;
+    }
+}

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -24,6 +24,7 @@ use Twig\ExpressionParser\Infix\FilterExpressionParser;
 use Twig\ExpressionParser\Infix\FunctionExpressionParser;
 use Twig\ExpressionParser\Infix\IsExpressionParser;
 use Twig\ExpressionParser\Infix\IsNotExpressionParser;
+use Twig\ExpressionParser\Infix\OptionalChainExpressionParser;
 use Twig\ExpressionParser\Infix\SquareBracketExpressionParser;
 use Twig\ExpressionParser\InfixAssociativity;
 use Twig\ExpressionParser\PrecedenceChange;
@@ -391,6 +392,7 @@ final class CoreExtension extends AbstractExtension
 
             // all literals
             new LiteralExpressionParser(),
+            new OptionalChainExpressionParser(),
         ];
     }
 

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -61,8 +61,6 @@ class Lexer
     public const REGEX_INLINE_COMMENT = '/#[^\n]*/A';
     public const PUNCTUATION = '()[]{}?:.,|';
 
-    const TOKEN_OPTIONAL_CHAIN = 17;
-    private const REGEX_OPTIONAL_CHAIN = '/\?\./A';
 
     private const SPECIAL_CHARS = [
         'f' => "\f",

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -61,6 +61,9 @@ class Lexer
     public const REGEX_INLINE_COMMENT = '/#[^\n]*/A';
     public const PUNCTUATION = '()[]{}?:.,|';
 
+    const TOKEN_OPTIONAL_CHAIN = 17;
+    private const REGEX_OPTIONAL_CHAIN = '/\?\./A';
+
     private const SPECIAL_CHARS = [
         'f' => "\f",
         'n' => "\n",

--- a/src/Node/Expression/GetAttrExpression.php
+++ b/src/Node/Expression/GetAttrExpression.php
@@ -25,7 +25,7 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
     /**
      * @param ArrayExpression|NameExpression|null $arguments
      */
-    public function __construct(AbstractExpression $node, AbstractExpression $attribute, ?AbstractExpression $arguments, string $type, int $lineno)
+    public function __construct(AbstractExpression $node, AbstractExpression $attribute, ?AbstractExpression $arguments, string $type, int $lineno, bool $isOptionalChain = false)
     {
         $nodes = ['node' => $node, 'attribute' => $attribute];
         if (null !== $arguments) {
@@ -36,7 +36,7 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
             trigger_deprecation('twig/twig', '3.15', \sprintf('Not passing a "%s" instance as the "arguments" argument of the "%s" constructor is deprecated ("%s" given).', ArrayExpression::class, static::class, $arguments::class));
         }
 
-        parent::__construct($nodes, ['type' => $type, 'ignore_strict_check' => false, 'optimizable' => true], $lineno);
+        parent::__construct($nodes, ['type' => $type, 'ignore_strict_check' => false, 'optimizable' => true, 'is_optional_chain' => $isOptionalChain], $lineno);
     }
 
     public function enableDefinedTest(): void
@@ -50,6 +50,106 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
         $env = $compiler->getEnvironment();
         $arrayAccessSandbox = false;
 
+        // Если используется optional chaining
+        if ($this->getAttribute('is_optional_chain')) {
+            $var = '$'.$compiler->getVarName();
+
+            // Проверяем, является ли node NameExpression с флагом optional_chain
+            $isOptionalName = $this->getNode('node') instanceof NameExpression &&
+                $this->getNode('node')->getAttribute('optional_chain', false);
+
+            if ($isOptionalName) {
+                // Безопасный доступ к переменным контекста без выброса исключения
+                $compiler
+                    ->raw('(array_key_exists(')
+                    ->string($this->getNode('node')->getAttribute('name'))
+                    ->raw(', $context) ? ');
+
+                $compiler
+                    ->raw('(null !== (')
+                    ->raw($var)
+                    ->raw(' = $context[')
+                    ->string($this->getNode('node')->getAttribute('name'))
+                    ->raw(']) ? ');
+            } else {
+                // Обычная проверка null для нормальных выражений
+                $compiler
+                    ->raw('(null !== (')
+                    ->raw($var)
+                    ->raw(' = ');
+
+                // Обращение к полю через ->subcompile может вызвать исключение
+                $this->getNode('node')->setAttribute('ignore_strict_check', true);
+                $compiler->subcompile($this->getNode('node'));
+                $compiler->raw(') ? ');
+            }
+
+            // Генерируем код для доступа к атрибуту в зависимости от типа
+            if ($this->getAttribute('type') === Template::METHOD_CALL) {
+                // Вызов метода
+                $compiler->raw('CoreExtension::getAttribute($this->env, $this->source, ');
+                $compiler
+                    ->raw($var)
+                    ->raw(', ')
+                    ->subcompile($this->getNode('attribute'));
+
+                if ($this->hasNode('arguments')) {
+                    $compiler->raw(', ')->subcompile($this->getNode('arguments'));
+                } else {
+                    $compiler->raw(', []');
+                }
+
+                $compiler->raw(', ')
+                    ->repr($this->getAttribute('type'))
+                    ->raw(', ')->repr($this->definedTest ?? false)
+                    ->raw(', ')->repr(true) // ignore_strict_check = true для optional chaining
+                    ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
+                    ->raw(', ')->repr($this->getNode('node')->getTemplateLine())
+                    ->raw(')');
+            } elseif ($this->getAttribute('type') === Template::ARRAY_CALL) {
+                // Доступ к массиву
+                $compiler->raw('(is_array(')
+                    ->raw($var)
+                    ->raw(') || ')
+                    ->raw($var)
+                    ->raw(' instanceof ArrayAccess ? (')
+                    ->raw($var)
+                    ->raw('[')
+                    ->subcompile($this->getNode('attribute'))
+                    ->raw('] ?? null) : null)');
+            } else {
+                // Доступ к свойству
+                $compiler->raw('CoreExtension::getAttribute($this->env, $this->source, ');
+                $compiler
+                    ->raw($var)
+                    ->raw(', ')
+                    ->subcompile($this->getNode('attribute'));
+
+                if ($this->hasNode('arguments')) {
+                    $compiler->raw(', ')->subcompile($this->getNode('arguments'));
+                } else {
+                    $compiler->raw(', []');
+                }
+
+                $compiler->raw(', ')
+                    ->repr($this->getAttribute('type'))
+                    ->raw(', ')->repr($this->definedTest ?? false)
+                    ->raw(', ')->repr(true) // ignore_strict_check = true для optional chaining
+                    ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
+                    ->raw(', ')->repr($this->getNode('node')->getTemplateLine())
+                    ->raw(')');
+            }
+
+            if ($isOptionalName) {
+                $compiler->raw(' : null) : null)');
+            } else {
+                $compiler->raw(' : null)');
+            }
+
+            return;
+        }
+
+        // Оригинальный код для обычного доступа к атрибутам
         // optimize array calls
         if (
             $this->getAttribute('optimizable')
@@ -113,7 +213,7 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
 
         $compiler->raw(', ')
             ->repr($this->getAttribute('type'))
-            ->raw(', ')->repr($this->definedTest)
+            ->raw(', ')->repr($this->definedTest ?? false)
             ->raw(', ')->repr($this->getAttribute('ignore_strict_check'))
             ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
             ->raw(', ')->repr($this->getNode('node')->getTemplateLine())
@@ -124,7 +224,6 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
             $compiler->raw(')');
         }
     }
-
     private function changeIgnoreStrictCheck(GetAttrExpression $node): void
     {
         $node->setAttribute('optimizable', false);
@@ -132,6 +231,68 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
 
         if ($node->getNode('node') instanceof GetAttrExpression) {
             $this->changeIgnoreStrictCheck($node->getNode('node'));
+        }
+    }
+    private function compileGetAttr(Compiler $compiler, string $varName): void
+    {
+        $env = $compiler->getEnvironment();
+
+        if (\PHP_VERSION_ID >= 80000) {
+            $compiler->raw($varName);
+            if ($this->getAttribute('type') === Template::METHOD_CALL) {
+                $compiler->raw('?->');
+                if ($this->getNode('attribute') instanceof ConstantExpression) {
+                    $compiler->raw($this->getNode('attribute')->getAttribute('value'));
+                } else {
+                    $compiler->raw('{');
+                    $compiler->subcompile($this->getNode('attribute'));
+                    $compiler->raw('}');
+                }
+
+                $compiler->raw('(');
+
+                if ($this->hasNode('arguments')) {
+                    $first = true;
+                    foreach ($this->getNode('arguments') as $argNode) {
+                        if (!$first) {
+                            $compiler->raw(', ');
+                        }
+                        $compiler->subcompile($argNode);
+                        $first = false;
+                    }
+                }
+
+                $compiler->raw(')');
+            } else {
+                $compiler->raw('?->');
+
+                if ($this->getNode('attribute') instanceof ConstantExpression) {
+                    $compiler->raw($this->getNode('attribute')->getAttribute('value'));
+                } else {
+                    $compiler->raw('{');
+                    $compiler->subcompile($this->getNode('attribute'));
+                    $compiler->raw('}');
+                }
+            }
+        } else {
+            $compiler->raw('CoreExtension::getAttribute($this->env, $this->source, ');
+            $compiler
+                ->raw($varName)
+                ->raw(', ')
+                ->subcompile($this->getNode('attribute'));
+
+            if ($this->hasNode('arguments')) {
+                $compiler->raw(', ')->subcompile($this->getNode('arguments'));
+            } else {
+                $compiler->raw(', []');
+            }
+            $compiler->raw(', ')
+                ->repr($this->getAttribute('type'))
+                ->raw(', ')->repr($this->definedTest ?? false)
+                ->raw(', ')->repr($this->getAttribute('ignore_strict_check'))
+                ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
+                ->raw(', ')->repr($this->getNode('node')->getTemplateLine())
+                ->raw(')');
         }
     }
 }

--- a/src/Node/Expression/GetAttrExpression.php
+++ b/src/Node/Expression/GetAttrExpression.php
@@ -50,16 +50,13 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
         $env = $compiler->getEnvironment();
         $arrayAccessSandbox = false;
 
-        // Если используется optional chaining
         if ($this->getAttribute('is_optional_chain')) {
             $var = '$'.$compiler->getVarName();
 
-            // Проверяем, является ли node NameExpression с флагом optional_chain
             $isOptionalName = $this->getNode('node') instanceof NameExpression &&
                 $this->getNode('node')->getAttribute('optional_chain', false);
 
             if ($isOptionalName) {
-                // Безопасный доступ к переменным контекста без выброса исключения
                 $compiler
                     ->raw('(array_key_exists(')
                     ->string($this->getNode('node')->getAttribute('name'))
@@ -72,21 +69,17 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
                     ->string($this->getNode('node')->getAttribute('name'))
                     ->raw(']) ? ');
             } else {
-                // Обычная проверка null для нормальных выражений
                 $compiler
                     ->raw('(null !== (')
                     ->raw($var)
                     ->raw(' = ');
 
-                // Обращение к полю через ->subcompile может вызвать исключение
                 $this->getNode('node')->setAttribute('ignore_strict_check', true);
                 $compiler->subcompile($this->getNode('node'));
                 $compiler->raw(') ? ');
             }
 
-            // Генерируем код для доступа к атрибуту в зависимости от типа
             if ($this->getAttribute('type') === Template::METHOD_CALL) {
-                // Вызов метода
                 $compiler->raw('CoreExtension::getAttribute($this->env, $this->source, ');
                 $compiler
                     ->raw($var)
@@ -107,7 +100,6 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
                     ->raw(', ')->repr($this->getNode('node')->getTemplateLine())
                     ->raw(')');
             } elseif ($this->getAttribute('type') === Template::ARRAY_CALL) {
-                // Доступ к массиву
                 $compiler->raw('(is_array(')
                     ->raw($var)
                     ->raw(') || ')
@@ -118,7 +110,6 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
                     ->subcompile($this->getNode('attribute'))
                     ->raw('] ?? null) : null)');
             } else {
-                // Доступ к свойству
                 $compiler->raw('CoreExtension::getAttribute($this->env, $this->source, ');
                 $compiler
                     ->raw($var)
@@ -149,8 +140,6 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
             return;
         }
 
-        // Оригинальный код для обычного доступа к атрибутам
-        // optimize array calls
         if (
             $this->getAttribute('optimizable')
             && (!$env->isStrictVariables() || $this->getAttribute('ignore_strict_check'))
@@ -231,68 +220,6 @@ class GetAttrExpression extends AbstractExpression implements SupportDefinedTest
 
         if ($node->getNode('node') instanceof GetAttrExpression) {
             $this->changeIgnoreStrictCheck($node->getNode('node'));
-        }
-    }
-    private function compileGetAttr(Compiler $compiler, string $varName): void
-    {
-        $env = $compiler->getEnvironment();
-
-        if (\PHP_VERSION_ID >= 80000) {
-            $compiler->raw($varName);
-            if ($this->getAttribute('type') === Template::METHOD_CALL) {
-                $compiler->raw('?->');
-                if ($this->getNode('attribute') instanceof ConstantExpression) {
-                    $compiler->raw($this->getNode('attribute')->getAttribute('value'));
-                } else {
-                    $compiler->raw('{');
-                    $compiler->subcompile($this->getNode('attribute'));
-                    $compiler->raw('}');
-                }
-
-                $compiler->raw('(');
-
-                if ($this->hasNode('arguments')) {
-                    $first = true;
-                    foreach ($this->getNode('arguments') as $argNode) {
-                        if (!$first) {
-                            $compiler->raw(', ');
-                        }
-                        $compiler->subcompile($argNode);
-                        $first = false;
-                    }
-                }
-
-                $compiler->raw(')');
-            } else {
-                $compiler->raw('?->');
-
-                if ($this->getNode('attribute') instanceof ConstantExpression) {
-                    $compiler->raw($this->getNode('attribute')->getAttribute('value'));
-                } else {
-                    $compiler->raw('{');
-                    $compiler->subcompile($this->getNode('attribute'));
-                    $compiler->raw('}');
-                }
-            }
-        } else {
-            $compiler->raw('CoreExtension::getAttribute($this->env, $this->source, ');
-            $compiler
-                ->raw($varName)
-                ->raw(', ')
-                ->subcompile($this->getNode('attribute'));
-
-            if ($this->hasNode('arguments')) {
-                $compiler->raw(', ')->subcompile($this->getNode('arguments'));
-            } else {
-                $compiler->raw(', []');
-            }
-            $compiler->raw(', ')
-                ->repr($this->getAttribute('type'))
-                ->raw(', ')->repr($this->definedTest ?? false)
-                ->raw(', ')->repr($this->getAttribute('ignore_strict_check'))
-                ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
-                ->raw(', ')->repr($this->getNode('node')->getTemplateLine())
-                ->raw(')');
         }
     }
 }

--- a/tests/Extension/OptionalChainingTest.php
+++ b/tests/Extension/OptionalChainingTest.php
@@ -1,0 +1,14 @@
+<?php
+// tests/Extension/OptionalChainingTest.php
+
+namespace Twig\Tests\Extension;
+
+use Twig\Test\IntegrationTestCase;
+
+class OptionalChainingTest extends IntegrationTestCase
+{
+    public function getFixturesDir(): string
+    {
+        return __DIR__.'/../Fixtures/extensions/optional_chaining';
+    }
+}

--- a/tests/Fixtures/extensions/optional_chaining/array_access.test
+++ b/tests/Fixtures/extensions/optional_chaining/array_access.test
@@ -1,0 +1,12 @@
+--TEST--
+Optional chaining with array access
+--TEMPLATE--
+{{ foo?.bar }}
+{{ foo?.[0] }}
+--DATA--
+return [
+    'foo' => ['bar' => 'value', 0 => 'zero']
+]
+--EXPECT--
+value
+zero

--- a/tests/Fixtures/extensions/optional_chaining/basic.test
+++ b/tests/Fixtures/extensions/optional_chaining/basic.test
@@ -1,0 +1,8 @@
+--TEST--
+Basic optional chaining
+--TEMPLATE--
+{{ foo?.bar }}
+{{ foo?.bar?.baz }}
+--DATA--
+return ['foo' => null]
+--EXPECT--

--- a/tests/Fixtures/extensions/optional_chaining/method_call.test
+++ b/tests/Fixtures/extensions/optional_chaining/method_call.test
@@ -1,0 +1,20 @@
+--TEST--
+Optional chaining with method calls
+--TEMPLATE--
+{{ foo?.getBar() }}
+{{ foo_with_nested?.bar?.getBaz() }}
+--DATA--
+class TestObject {
+    public function getBar() { return 'bar_value'; }
+}
+class NestedObject {
+    public function getBaz() { return 'baz_value'; }
+}
+return [
+    'foo' => new TestObject(),
+    'null_foo' => null,
+    'foo_with_nested' => ['bar' => new NestedObject()]
+]
+--EXPECT--
+bar_value
+baz_value

--- a/tests/Fixtures/extensions/optional_chaining/mixed.test
+++ b/tests/Fixtures/extensions/optional_chaining/mixed.test
@@ -1,0 +1,12 @@
+--TEST--
+Mixed optional and normal chaining
+--TEMPLATE--
+{{ foo?.bar.baz }}
+{{ foo.bar?.baz }}
+--DATA--
+return [
+    'foo' => ['bar' => ['baz' => 'value']],
+]
+--EXPECT--
+value
+value

--- a/tests/Fixtures/extensions/optional_chaining/undefined.test
+++ b/tests/Fixtures/extensions/optional_chaining/undefined.test
@@ -1,0 +1,7 @@
+--TEST--
+Optional chaining with undefined variables
+--TEMPLATE--
+{{ undefinedVar?.bar }}
+--DATA--
+return []
+--EXPECT--

--- a/tests/Fixtures/extensions/optional_chaining/with_values.test
+++ b/tests/Fixtures/extensions/optional_chaining/with_values.test
@@ -1,0 +1,9 @@
+--TEST--
+Optional chaining with values
+--TEMPLATE--
+{{ foo?.bar }}
+{{ foo?.bar?.baz }}
+--DATA--
+return ['foo' => ['bar' => 'value', 'baz' => ['qux' => 'nested']]]
+--EXPECT--
+value


### PR DESCRIPTION
This PR adds support for the optional chaining operator (?.) to Twig.

The optional chaining operator (?.) enables developers to read the value of a property
located deep within a chain of connected objects without having to check that each
reference in the chain is valid.

Example usage:
```twig
{{ foo?.bar?.baz }}
```
This is equivalent to:
```twig
{{ foo.bar.baz is defined ? foo.bar.baz }}`
