### PR TITLE
[Doc] Fix intro for operator precedence table ?

### DIFF
--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -1012,7 +1012,7 @@ Twig uses operators to perform various operations within templates.
 Understanding the precedence of these operators is crucial for writing correct
 and efficient Twig templates.
 
-The operator precedence rules are as follows, with the lowest-precedence
+The operator precedence rules are as follows, with the highest-precedence
 operators listed first.
 
 .. include:: operators_precedence.rst


### PR DESCRIPTION
The table introductory paragraph says operator with lowest precedence are listed first ( I assume it means "listed first in the operator table" ).

However, the table starts with a precedence of 500, which seems to be the highest.

Am I completely misreading this ?