### PR TITLE
Add base64_encode twig filter

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -246,6 +246,7 @@ final class CoreExtension extends AbstractExtension
             new TwigFilter('url_encode', [self::class, 'urlencode']),
             new TwigFilter('json_encode', 'json_encode'),
             new TwigFilter('convert_encoding', [self::class, 'convertEncoding']),
+            new TwigFilter('base64_encode', 'base64_encode'),
 
             // string filters
             new TwigFilter('title', [self::class, 'titleCase'], ['needs_charset' => true]),

--- a/tests/Fixtures/filters/base64_encode.test
+++ b/tests/Fixtures/filters/base64_encode.test
@@ -1,0 +1,10 @@
+--TEST--
+"base64_encode" filter
+--TEMPLATE--
+{{ "foo"|base64_encode|raw }}
+{{ foo|base64_encode|raw }}
+--DATA--
+return ['foo' => new \Twig\Markup('foo', 'UTF-8')]
+--EXPECT--
+Zm9v
+Zm9v


### PR DESCRIPTION
I'm using base64_encode a few times to bring data from backend to my JS code where it only is encoded on click, also binary strings of svg can be base64 encode for data string in img.