### PR TITLE
[CommonMark] Update configuration keys + allow extra keys for extensions

### DIFF
--- a/extra/twig-extra-bundle/DependencyInjection/Configuration.php
+++ b/extra/twig-extra-bundle/DependencyInjection/Configuration.php
@@ -39,14 +39,14 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * Full configuration from {@link https://commonmark.thephpleague.com/2.3/configuration}.
+     * Full configuration from {@link https://commonmark.thephpleague.com/2.7/configuration}.
      */
     private function addCommonMarkConfiguration(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->children()
                 ->arrayNode('commonmark')
-                    ->ignoreExtraKeys()
+                    ->ignoreExtraKeys(false)
                     ->children()
                         ->arrayNode('renderer')
                             ->info('Array of options for rendering HTML.')
@@ -66,6 +66,10 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->integerNode('max_nesting_level')
                             ->info('The maximum nesting level for blocks.')
+                            ->defaultValue(\PHP_INT_MAX)
+                            ->end()
+                        ->integerNode('max_delimiters_per_line')
+                            ->info('The maximum number of strong/emphasis delimiters per line.')
                             ->defaultValue(\PHP_INT_MAX)
                             ->end()
                         ->arrayNode('slug_normalizer')


### PR DESCRIPTION
This PR adds missing keys from the current version of CommonMark (2.7).

It also fixes a bug where extra keys are removed. The original intent was to keep the extra keys, so extensions could be configured as well. Currently, these keys are removed, meaning extensions can not be configured.

Original PR #3737.