### PR TITLE
Fix path when possible when an exception occurs

### DIFF
--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -122,8 +122,12 @@ class Error extends \Exception
         if ($punctuation = '.' === $last || '?' === $last ? $last : '') {
             $this->message = substr($this->message, 0, -1);
         }
-        if ($this->source && $this->source->getName()) {
-            $this->message .= \sprintf(' in "%s"', $this->source->getName());
+        if ($this->source) {
+            if ($this->source->getPath()) {
+                $this->message .= \sprintf(' in "%s"', $this->source->getPath());
+            } else if ($this->source->getName()) {
+                $this->message .= \sprintf(' in "%s"', $this->source->getName());
+            }
         }
         if ($this->lineno > 0) {
             $this->message .= \sprintf(' at line %d', $this->lineno);


### PR DESCRIPTION
I found an error in the integration between Twig and Symfony
If a template throw an error, Symfony will enhance the message.
If a path is found in the message, it'll turn it to a link

![image](https://github.com/user-attachments/assets/9f0d6319-8323-492e-a914-16e7a5ee40fb)



https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php#L304-L307
https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/ErrorHandler/Resources/views/exception.html.php#L18

However, in twig, we don't put an absolute path, but a relative one.
So it does not work. This PR puts an absolute link if possible


>[!CAUTION]
> I did not updated the test yet, I'm waiting for feedback