### PR TITLE
Coding standard suggestion about empty content

### DIFF
--- a/doc/coding_standards.rst
+++ b/doc/coding_standards.rst
@@ -11,12 +11,13 @@ When writing Twig templates, we recommend you to follow these official coding
 standards:
 
 * Put exactly one space after the start of a delimiter (``{{``, ``{%``,
-  and ``{#``) and before the end of a delimiter (``}}``, ``%}``, and ``#}``):
+  and ``{#``) and before the end of a delimiter (``}}``, ``%}``, and ``#}``)
+  if the content is non empty:
 
   .. code-block:: twig
 
     {{ user }}
-    {# comment #}
+    {# comment #} {##}
     {% if user %}{% endif %}
 
   When using the whitespace control character, do not put any spaces between
@@ -25,7 +26,7 @@ standards:
   .. code-block:: twig
 
     {{- user -}}
-    {#- comment -#}
+    {#- comment -#} {#--#}
     {%- if user -%}{%- endif -%}
 
 * Put exactly one space before and after the following operators:


### PR DESCRIPTION
Hi @fabpot 

As suggested by @stof https://github.com/symfony/symfony/pull/60761#discussion_r2140647490

This would allow writing `{#--#}` rather than `{#- -#}` when following the twig coding standard.