### PR TITLE
Update date.rst: Fixing `null` return value

### DIFF
--- a/doc/functions/date.rst
+++ b/doc/functions/date.rst
@@ -19,7 +19,7 @@ You can pass a timezone as the second argument:
         {# do something #}
     {% endif %}
 
-If no argument is passed, the function returns the current date:
+If no argument is passed, the ``date`` function returns ``null``:
 
 .. code-block:: html+twig
 


### PR DESCRIPTION
Page: https://twig.symfony.com/doc/3.x/functions/date.html

I'm getting `null` - isn't this the default behavior?

If you merge this, maybe the example should be changed too, since `somedate < null` isn't obviously true.
Plus (more important): The recommended way to actually get the current date should be shown ;-)