### PR TITLE
add twig extra bundle missign return types

### DIFF
--- a/extra/twig-extra-bundle/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
+++ b/extra/twig-extra-bundle/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
@@ -17,8 +17,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class MissingExtensionSuggestorPass implements CompilerPassInterface
 {
-    /** @return void */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->getParameter('kernel.debug')) {
             $twigDefinition = $container->getDefinition('twig');

--- a/extra/twig-extra-bundle/DependencyInjection/TwigExtraExtension.php
+++ b/extra/twig-extra-bundle/DependencyInjection/TwigExtraExtension.php
@@ -23,8 +23,7 @@ use Twig\Extra\TwigExtraBundle\Extensions;
  */
 class TwigExtraExtension extends Extension
 {
-    /** @return void */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
         $configuration = $this->getConfiguration($configs, $container);

--- a/extra/twig-extra-bundle/TwigExtraBundle.php
+++ b/extra/twig-extra-bundle/TwigExtraBundle.php
@@ -17,8 +17,7 @@ use Twig\Extra\TwigExtraBundle\DependencyInjection\Compiler\MissingExtensionSugg
 
 class TwigExtraBundle extends Bundle
 {
-    /** @return void */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 


### PR DESCRIPTION
Add missing return type on the twig extra bundle for symfony integration. At the moment the unit tests for this bundle are failig on php 8.4.