### PR TITLE
Document that the render function can throw \ErrorException

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -327,6 +327,7 @@ class Environment
      * @throws LoaderError  When the template cannot be found
      * @throws SyntaxError  When an error occurred during compilation
      * @throws RuntimeError When an error occurred during rendering
+     * @throws \ErrorException When there syntax/php error, i.e. array to string
      */
     public function render($name, array $context = []): string
     {


### PR DESCRIPTION
The twig `render` function can throw an exception of type `\ErrorException` in the case of errors such as an array to string conversion. This documents that its a valid exception that can be thrown. Otherwise, tools like phpstan complain that you are catching an exception that can never be thrown