### PR TITLE
Add missing use statements in ExtensionInterface

### DIFF
--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -11,8 +11,11 @@
 
 namespace Twig\Extension;
 
+use Twig\ExpressionParser;
 use Twig\ExpressionParser\ExpressionParserInterface;
 use Twig\ExpressionParser\PrecedenceChange;
+use Twig\Node\Expression\Binary\AbstractBinary;
+use Twig\Node\Expression\Unary\AbstractUnary;
 use Twig\NodeVisitor\NodeVisitorInterface;
 use Twig\TokenParser\TokenParserInterface;
 use Twig\TwigFilter;


### PR DESCRIPTION
Fixes #4677 

Note: The classes were used specifically in a `@psalm-return` doc statement. But as the repository does not have any psalm config, and does not check it in the CI, this seems to have gone unnoticed for a few months.
