### PR TITLE
Fix typo in documentation

### DIFF
--- a/doc/filters/slug.rst
+++ b/doc/filters/slug.rst
@@ -37,7 +37,7 @@ The ``slug`` filter uses the method by the same name in Symfony's
 
     .. code-block:: bash
 
-        $ composer require twig/string-extra
+        $ composer require symfony/string
 
     Then, on Symfony projects, install the ``twig/extra-bundle``:
 


### PR DESCRIPTION
This pull request fixes a small typographical error in the documentation.

- No functional code changes were made.
- Only text was updated.