### PR TITLE
Avoid errors when failing to guess the template info for an error

### DIFF
--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -148,6 +148,10 @@ class Error extends \Exception
             }
         }
 
+        if (null === $template) {
+            return; // Impossible to guess the info as the template was not found in the backtrace
+        }
+
         $r = new \ReflectionObject($template);
         $file = $r->getFileName();
 


### PR DESCRIPTION
Someone reported on the Symfony Slack a case where they get a TypeError in `new \ReflectionObject($template)` in the guessing logic instead of seeing the original error they have (the one for which guessing was attempted), making it impossible to know the original error: https://symfony-devs.slack.com/archives/C01FN4EQNLX/p1756762972076319?thread_ts=1756753204.711889&cid=C01FN4EQNLX
I don't have a reproducer for that case (the original case involve a Symfony form theme, where the form renderer does weird usages of Twig which might lead to the backtrace not containing the expected template).

Not guessing the template file path and the original template line is better than breaking the error reporting.