### PR TITLE
Improve documentation examples for `enum` and `enum_cases`

### DIFF
--- a/doc/functions/enum.rst
+++ b/doc/functions/enum.rst
@@ -10,15 +10,21 @@
 .. code-block:: twig
 
     {# display one specific case of a backed enum #}
-    {{ enum('App\\MyEnum').SomeCase.value }}
+    {{ enum('App\\CardSuite').Clubs.value }} {# "clubs" #}
 
     {# get all cases of an enum #}
-    {% for case in enum('App\\MyEnum').cases %}
+    {% for case in enum('App\\CardSuite').cases %}
         {{ case.value }}
     {% endfor %}
+    {# "clubs", "spades", "hearts", "diamonds" #}
+
+    {# get a specific case of an enum by value #}
+    {% set card_suite = enum('App\\CardSuite').from('hearts') %}
+    {{ card_suite.name }} {# "Hearts" #}
+    {{ card_suite.value }} {# "hearts" #}
 
     {# call any methods of the enum class #}
-    {{ enum('App\\MyEnum').someMethod() }}
+    {{ enum('App\\CardSuite').someMethod() }}
 
 When using a string literal for the ``enum`` argument, it will be validated during compile time to be a valid enum name.
 

--- a/doc/functions/enum_cases.rst
+++ b/doc/functions/enum_cases.rst
@@ -9,9 +9,10 @@
 
 .. code-block:: twig
 
-    {% for case in enum_cases('App\\MyEnum') %}
+    {% for case in enum_cases('App\\CardSuite') %}
         {{ case.value }}
     {% endfor %}
+    {# "clubs", "spades", "hearts", "diamonds" #}
 
 When using a string literal for the ``enum`` argument, it will be validated during compile time to be a valid enum name.
 


### PR DESCRIPTION
It may be obvious, but I first thought initializing an BackendEnum with a specific value could be possible with `enum(FQCN, value)`, but it does not, it always returns the first case  instance (if exists).

Instead, `enum(FQCN).from(value)` must be used, and I think it's worth to improve `enum()` examples.