### PR TITLE
Add throw tag to parse methods

### DIFF
--- a/src/ExpressionParser/InfixExpressionParserInterface.php
+++ b/src/ExpressionParser/InfixExpressionParserInterface.php
@@ -11,12 +11,16 @@
 
 namespace Twig\ExpressionParser;
 
+use Twig\Error\SyntaxError;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Parser;
 use Twig\Token;
 
 interface InfixExpressionParserInterface extends ExpressionParserInterface
 {
+    /**
+     * @throws SyntaxError
+     */
     public function parse(Parser $parser, AbstractExpression $left, Token $token): AbstractExpression;
 
     public function getAssociativity(): InfixAssociativity;

--- a/src/ExpressionParser/PrefixExpressionParserInterface.php
+++ b/src/ExpressionParser/PrefixExpressionParserInterface.php
@@ -11,11 +11,15 @@
 
 namespace Twig\ExpressionParser;
 
+use Twig\Error\SyntaxError;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Parser;
 use Twig\Token;
 
 interface PrefixExpressionParserInterface extends ExpressionParserInterface
 {
+    /**
+     * @throws SyntaxError
+     */
     public function parse(Parser $parser, Token $token): AbstractExpression;
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -76,6 +76,9 @@ class Parser
         return \sprintf('__internal_parse_%d', $this->varNameSalt++);
     }
 
+    /**
+     * @throws SyntaxError
+     */
     public function parse(TokenStream $stream, $test = null, bool $dropNeedle = false): ModuleNode
     {
         $vars = get_object_vars($this);
@@ -158,6 +161,9 @@ class Parser
         }
     }
 
+    /**
+     * @throws SyntaxError
+     */
     public function subparse($test, bool $dropNeedle = false): Node
     {
         $lineno = $this->getCurrentToken()->getLine();


### PR DESCRIPTION
Hi @fabpot, with PHPStan improving every day his exception checking, it's useful to have well documented method.

I didn't update all of them (there are too many), and focus on the one I have issue with:
- Almost all the InfixExpressionParserInterface/PrefixExpressionParserInterface implements throws a SyntaxError in parse method
- Parser::parse method is catching SyntaxError and rethrowing them so it should be added to the phpdoc
- Since Parser::parse catch Parser::subparse, it would be useful to add the phpdoc to subparse