### PR TITLE
Add ext-intl requirement to composer.json

### DIFF
--- a/extra/intl-extra/composer.json
+++ b/extra/intl-extra/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "php": ">=8.1.0",
         "twig/twig": "^3.13|^4.0",
-        "symfony/intl": "^5.4|^6.4|^7.0"
+        "symfony/intl": "^5.4|^6.4|^7.0",
+        "ext-intl": "*"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^6.4|^7.0"


### PR DESCRIPTION
intl-extra makes use of the `IntlDateFormatter` class, which is only available in the `intl` extension of PHP. However, this dependency is not noted in `composer.json`, which means installation succeeds, but usage fails with a rather mysterious error:

```
PHP Fatal error:  Uncaught Error: Class "IntlDateFormatter" not found
```

To avoid this misunderstanding, add an explicit dependency on `intl` to composer.json, to make composer complain that the dependency is not met during installation.

Fixes #4702.