### PR TITLE
Fix array typehint for $variants in HtmlExtension

### DIFF
--- a/extra/html-extra/HtmlExtension.php
+++ b/extra/html-extra/HtmlExtension.php
@@ -115,7 +115,7 @@ final class HtmlExtension extends AbstractExtension
 
     /**
      * @param string|list<string|null> $base
-     * @param array<string, array<string, string|array<string>> $variants
+     * @param array<string, array<string, string|array<string>>> $variants
      * @param array<array<string, string|array<string>>> $compoundVariants
      * @param array<string, string>                      $defaultVariant
      *


### PR DESCRIPTION
This PR corrects the array typehint for the `$variants` parameter in the `HtmlExtension::htmlCva` method. It was missing a closing angle bracket (`>`).