### PR TITLE
Allow Symfony 8 packages in Twig extra packages

### DIFF
--- a/extra/cache-extra/composer.json
+++ b/extra/cache-extra/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=8.1.0",
-        "symfony/cache": "^5.4|^6.4|^7.0",
+        "symfony/cache": "^5.4|^6.4|^7.0|^8.0",
         "twig/twig": "^3.21|^4.0"
     },
     "require-dev": {

--- a/extra/html-extra/composer.json
+++ b/extra/html-extra/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=8.1.0",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "symfony/mime": "^5.4|^6.4|^7.0",
+        "symfony/mime": "^5.4|^6.4|^7.0|^8.0",
         "twig/twig": "^3.13|^4.0"
     },
     "require-dev": {

--- a/extra/intl-extra/composer.json
+++ b/extra/intl-extra/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=8.1.0",
         "twig/twig": "^3.13|^4.0",
-        "symfony/intl": "^5.4|^6.4|^7.0"
+        "symfony/intl": "^5.4|^6.4|^7.0|^8.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^6.4|^7.0"

--- a/extra/string-extra/composer.json
+++ b/extra/string-extra/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=8.1.0",
-        "symfony/string": "^5.4|^6.4|^7.0",
+        "symfony/string": "^5.4|^6.4|^7.0|^8.0",
         "symfony/translation-contracts": "^1.1|^2|^3",
         "twig/twig": "^3.13|^4.0"
     },

--- a/extra/twig-extra-bundle/composer.json
+++ b/extra/twig-extra-bundle/composer.json
@@ -16,8 +16,8 @@
     ],
     "require": {
         "php": ">=8.1.0",
-        "symfony/framework-bundle": "^5.4|^6.4|^7.0",
-        "symfony/twig-bundle": "^5.4|^6.4|^7.0",
+        "symfony/framework-bundle": "^5.4|^6.4|^7.0|^8.0",
+        "symfony/twig-bundle": "^5.4|^6.4|^7.0|^8.0",
         "twig/twig": "^3.2|^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
I'm testing the upcoming Symfony 8 in some apps, and I have some issues with some Twig extra packages that don't allow installing Symfony 8 packages.