### PR TITLE
Add caution note for random function usage

### DIFF
--- a/doc/functions/random.rst
+++ b/doc/functions/random.rst
@@ -10,6 +10,11 @@ parameter type:
 * a random integer between the integer parameter (when negative) and 0 (inclusive).
 * a random integer between the first integer and the second integer parameter (inclusive).
 
+.. caution::
+
+    The ``random`` function does not produce cryptographically secure random numbers.
+    Do not use them for purposes that require returned values to be unguessable. 
+
 .. code-block:: twig
 
     {{ random(['apple', 'orange', 'citrus']) }} {# example output: orange #}


### PR DESCRIPTION
See https://www.php.net/manual/en/function.array-rand.php and https://www.php.net/manual/en/function.mt-rand.php. Users should know that the Twig function is a convenience feature, but unusable e.g. for serious gaming/gambling apps due to the potential predictability and limited value range.