### PR TITLE
Update .gitattributes to exclude phpstan configs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,5 @@
 /.gitignore export-ignore
 /.php-cs-fixer.dist.php export-ignore
 /phpunit.xml.dist export-ignore
+/phpstan.neon.dist export-ignore
+/phpstan-baseline.neon export-ignore


### PR DESCRIPTION
They where added in https://github.com/twigphp/Twig/pull/4458

Versions >= 3.16.0 have the not needed files