### PR TITLE
Add 'invoke' to filters index

### DIFF
--- a/doc/filters/index.rst
+++ b/doc/filters/index.rst
@@ -29,6 +29,7 @@ Filters
     html_to_markdown
     inline_css
     inky_to_html
+    invoke
     join
     json_encode
     keys


### PR DESCRIPTION
Missing from https://github.com/twigphp/Twig/pull/4518 I think.