### PR TITLE
use getShareDir as an indicator of Symfony version

### DIFF
--- a/extra/twig-extra-bundle/TwigExtraBundle.php
+++ b/extra/twig-extra-bundle/TwigExtraBundle.php
@@ -13,9 +13,10 @@ namespace Twig\Extra\TwigExtraBundle;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Twig\Extra\TwigExtraBundle\DependencyInjection\Compiler\MissingExtensionSuggestorPass;
 
-if (!method_exists(ContainerBuilder::class, 'getAutoconfiguredAttributes')) {
+if (method_exists(KernelInterface::class, 'getShareDir')) {
     class TwigExtraBundle extends Bundle
     {
         public function build(ContainerBuilder $container): void


### PR DESCRIPTION
Proposal to fix #4719 , replaces #4721 