### PR TITLE
Avoid ord deprecation notice in PHP 8.5

### DIFF
--- a/src/Runtime/EscaperRuntime.php
+++ b/src/Runtime/EscaperRuntime.php
@@ -272,7 +272,7 @@ final class EscaperRuntime implements RuntimeExtensionInterface
                      * @license   https://framework.zend.com/license/new-bsd New BSD License
                      */
                     $chr = $matches[0];
-                    $ord = \ord($chr);
+                    $ord = \ord($chr[0]);
 
                     /*
                     * The following replaces characters undefined in HTML with the


### PR DESCRIPTION
Change the one usage of `ord()` in Twig where a multibyte character can trigger the new deprecation in PHP 8.5, which is in the `html_attr` escape functionality in EscaperRuntime, currently leading to:

```
ord(): Providing a string that is not one byte long is deprecated. Use ord($str[0]) instead"
```

This small change fixes it. There are no other usages of `ord()` in Twig which lead to this deprecation notice.