### PR TITLE
Support __get for getAttribute

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1869,6 +1869,10 @@ final class CoreExtension extends AbstractExtension
         } elseif (isset($cache[$class]['__call'])) {
             $method = $item;
             $call = true;
+        } elseif (isset($cache[$class]['__get'])) {
+            $method = '__get';
+            $arguments = [$item];
+            $call = true;
         } else {
             if ($isDefinedTest) {
                 return false;


### PR DESCRIPTION
Allows object to use the  __get magic function to fetch attributes.

This is very convenient when using Entities or other objects.

Ideally we can also use __isset to be more precise with defined checks but I am not sure.
