### PR TITLE
Fix CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -70,6 +70,7 @@
 
 # 3.18.0 (2024-12-29)
 
+ * Support for invoking closures
  * Fix unary operator precedence change
  * Ignore `SyntaxError` exceptions from undefined handlers when using the `guard` tag
  * Add a way to stream template rendering (`TemplateWrapper::stream()` and `TemplateWrapper::streamBlock()`)
@@ -78,7 +79,6 @@
 
  * Fix the null coalescing operator when the test returns null
  * Fix the Elvis operator when used as '? :' instead of '?:'
- * Support for invoking closures
 
 # 3.17.0 (2024-12-10)
 


### PR DESCRIPTION
Commit [Support for invoking closures](https://github.com/twigphp/Twig/commit/918f52e818f7c56e90ec462ae90b230da244a7ed) was added after release 3.17.1 https://github.com/twigphp/Twig/commits/v3.18.0