### PR TITLE
Fix opcache preload warning for unlinked anonymous class

### DIFF
--- a/src/ExtensionSet.php
+++ b/src/ExtensionSet.php
@@ -27,6 +27,10 @@ use Twig\Node\Expression\AbstractExpression;
 use Twig\NodeVisitor\NodeVisitorInterface;
 use Twig\TokenParser\TokenParserInterface;
 
+// Help opcache.preload discover always-needed symbols
+// @see https://github.com/php/php-src/issues/10131
+class_exists(BinaryOperatorExpressionParser::class);
+
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  *


### PR DESCRIPTION
This fixes PHP opcache preload warning, caused by https://github.com/php/php-src/issues/10131 .  The warning is now produced when the preload is initiated.

> Can't preload unlinked class Twig\ExpressionParser\Infix\BinaryOperatorExpressionParser@anonymous: Unknown parent Twig\ExpressionParser\Infix\BinaryOperatorExpressionParser 

This started with Twig 3.21, when the anonymous class started to be used in ExtensionSet.

This is a similar woraround as is already used in a TwigBridge, as suggested by @nicolas-grekas here https://github.com/symfony/symfony/pull/38533
Also similar fix is in API platform: https://github.com/api-platform/core/pull/3827