### PR TITLE
Fix tiny typo in CI step name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
             - name: "PHPUnit version"
               run: vendor/bin/simple-phpunit --version
 
-            - name: "Prevent installing symfony/translation-contract 3.0"
+            - name: "Prevent installing symfony/translation-contracts 3.0"
               if: "matrix.extension == 'twig-extra-bundle'"
               working-directory: extra/${{ matrix.extension }}
               run: "composer require --no-update 'symfony/translation-contracts:^1.1|^2.0'"


### PR DESCRIPTION
Just a nano-typo there in a step name

`symfony/translation-contract`+`s`