### PR TITLE
Update u.rst to clarify truncate method's third argument behavior

### DIFF
--- a/doc/filters/u.rst
+++ b/doc/filters/u.rst
@@ -31,7 +31,7 @@ Truncating a string:
     {{ 'Lorem ipsum'|u.truncate(8, '...') }}
     Lorem...
 
-The ``truncate`` method also accepts a third argument to preserve whole words:
+By default, ``truncate`` cuts text at the exact length. Pass ``false`` as the third argument to preserve whole words:
 
 .. code-block:: twig
 


### PR DESCRIPTION
Current wording "to preserve whole words" suggests setting the argument to ``true`` preserves words. However, the parameter is ``$cut`` (defaults to ``true`` for cutting at exact length), and ``false`` is required to preserve whole words.