### PR TITLE
Fix null-safe operator test

### DIFF
--- a/tests/ExpressionParserTest.php
+++ b/tests/ExpressionParserTest.php
@@ -302,7 +302,7 @@ class ExpressionParserTest extends TestCase
      */
     public function testNullSafeOperator($template, $data, $expected)
     {
-        $env = new Environment(new ArrayLoader(['template' => $template]));
+        $env = new Environment(new ArrayLoader(['template' => $template]), ['strict_variables' => true]);
 
         $this->assertSame($expected, $env->render('template', $data));
     }


### PR DESCRIPTION
Noticed this while working on #4748.

Without `strict_variables`, the tests always pass, even when the null-safe operator is not used.