### PR TITLE
Ensure PrintNode is yielding string content

### DIFF
--- a/src/Node/PrintNode.php
+++ b/src/Node/PrintNode.php
@@ -36,7 +36,7 @@ class PrintNode extends Node implements NodeOutputInterface
 
         $compiler
             ->addDebugInfo($this)
-            ->write($expr->isGenerator() ? 'yield from ' : 'yield ')
+            ->write($expr->isGenerator() ? 'yield from ' : 'yield (string) ')
             ->subcompile($expr)
             ->raw(";\n")
         ;


### PR DESCRIPTION
Closes https://github.com/twigphp/Twig/issues/4765

TODO:
- [ ] add test preventing regression
- [ ] fix existing compilation tests asserting the compiled code
- [ ] figure out whether some optimizations are possible for cases where the compiler can be sure that the expression is already a string (mostly string literals for now, as even `EscaperRuntime::escape()` does not always return a string)