### PR TITLE
doc: Add missing toctree entries and fix ordering

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,7 @@ Twig
     deprecated
     recipes
     coding_standards
+    operators_precedence
     tags/index
     filters/index
     functions/index

--- a/doc/tags/index.rst
+++ b/doc/tags/index.rst
@@ -12,10 +12,10 @@ Tags
     do
     embed
     extends
-    guard
     flush
     for
     from
+    guard
     if
     import
     include

--- a/doc/tests/index.rst
+++ b/doc/tests/index.rst
@@ -10,6 +10,8 @@ Tests
     empty
     even
     iterable
+    mapping
     null
     odd
     sameas
+    sequence


### PR DESCRIPTION
- Add missing `sequence` and `mapping` to tests/index.rst toctree
- Fix alphabetical ordering of `guard`/`flush` in tags/index.rst
- Add orphaned `operators_precedence` to main index.rst toctree