### PR TITLE
EmptyInterface

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1419,6 +1419,10 @@ final class CoreExtension extends AbstractExtension
      */
     public static function testEmpty($value): bool
     {
+        if ($value instanceof EmptyInterface) {
+            return $value->getIsEmpty();
+        }
+
         if ($value instanceof \Countable) {
             return 0 === \count($value);
         }

--- a/src/Extension/EmptyInterface.php
+++ b/src/Extension/EmptyInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Extension;
+
+/**
+ * Allows objects to declare whether they should be considered empty.
+ *
+ * @author Brandon Kelly <brandon@pixelandtonic.com>
+ * @since 3.24.1
+ */
+interface EmptyInterface
+{
+    /**
+     * @return bool
+     */
+    public function getIsEmpty(): bool;
+}


### PR DESCRIPTION
Adds a new `EmptyInterface` that any object could implement, giving it control over what `CoreExtension::testEmpty()` returns for it.

For example, if an object’s simple existence should be counted as not empty, it could do:

```php
use Twig\Extension\EmptyInterface;

class MyClass implements EmptyInterface
{
    // ...

    public function getIsEmpty(): bool
    {
        return false;
    }
}
```

This will help with issues like craftcms/cms#18727, where `empty` tests and the `default` filter can cause performance issues simply by traversing over all the existing properties (many of which may cause DB queries, etc.).