### PR TITLE
Allow Markup to be marked as safe for escaping

### DIFF
--- a/src/Markup.php
+++ b/src/Markup.php
@@ -20,11 +20,16 @@ class Markup implements \Countable, \JsonSerializable, \Stringable
 {
     private $content;
     private ?string $charset;
+    private array $options;
 
-    public function __construct($content, $charset)
+    public function __construct($content, $charset, array $options = [])
     {
         $this->content = (string) $content;
         $this->charset = $charset;
+
+        $this->options = array_merge([
+            'is_safe' => null,
+        ], $options);
     }
 
     public function __toString(): string
@@ -35,6 +40,11 @@ class Markup implements \Countable, \JsonSerializable, \Stringable
     public function getCharset(): string
     {
         return $this->charset;
+    }
+
+    public function getSafe(): array|null
+    {
+        return $this->options['is_safe'] ?? null;
     }
 
     /**

--- a/src/Runtime/EscaperRuntime.php
+++ b/src/Runtime/EscaperRuntime.php
@@ -99,7 +99,7 @@ final class EscaperRuntime implements RuntimeExtensionInterface
      */
     public function escape($string, string $strategy = 'html', ?string $charset = null, bool $autoescape = false)
     {
-        if ($autoescape && $string instanceof Markup) {
+        if ($autoescape && $string instanceof Markup && (null === $string->getSafe() || \in_array($strategy, $string->getSafe(), true))) {
             return $string;
         }
 


### PR DESCRIPTION
Draft implementation of https://github.com/twigphp/Twig/issues/4754

Let's keep the discussion on _why and how_ to the original issue, but feel free to discuss the suggested code changes here 😊 

/cc @Toflar