### PR TITLE
Remove obsolete PHP 8.0 workaround for Closure::__invoke attribute access

### DIFF
--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -1795,10 +1795,6 @@ final class CoreExtension extends AbstractExtension
 
             static $propertyCheckers = [];
 
-            if ($object instanceof \Closure && '__invoke' === $item) {
-                return $isDefinedTest ? true : $object();
-            }
-
             if (isset($object->$item)
                 || ($propertyCheckers[$object::class][$item] ??= self::getPropertyChecker($object::class, $item))($object, $item)
             ) {


### PR DESCRIPTION
The removed code was needed for `isset($closure->__invoke)` to work with PHP pre-8.0 (to avoid a fatal error):

 * 7.4: Fatal error: Uncaught Error: Closure object cannot have properties
 * 8.0: Fatal error: Uncaught Error: Closure object cannot have properties
 * 8.1+: bool(false) clean, no error
