### PR TITLE
Stop reporting a skipped test in IntegrationTestCase when there is no legacy test to run

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.27.2 (2026-XX-XX)
 
+ * Stop reporting a skipped test in `IntegrationTestCase` when there is no legacy test to run
  * Make the `IntegrationTestCase` and `NodeTestCase` test helpers compatible with PHPUnit 11
  * Cast printed expressions to string so values that cannot be converted to a string (arrays, non-`Stringable` objects, ...) report a usable stack trace at the print location
  * Skip the sandbox `__toString` check on arguments whose PHP parameter type cannot implicitly coerce to string

--- a/src/Test/IntegrationTestCase.php
+++ b/src/Test/IntegrationTestCase.php
@@ -233,7 +233,10 @@ abstract class IntegrationTestCase extends TestCase
     protected function doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
     {
         if (!$outputs) {
-            $this->markTestSkipped('no tests to run');
+            // dummy test added by assembleTests() when there is no (legacy) test to run
+            $this->expectNotToPerformAssertions();
+
+            return;
         }
 
         if ($condition) {


### PR DESCRIPTION
Closes #4635