### PR TITLE
Fix version in deprecation message for tag usage outside of root template

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -303,7 +303,7 @@ Templates
 
 * Using a ``macro``, ``extends``, or ``use`` tag outside the root of a template
   (for instance nested under an ``if`` or inside a ``block`` or ``macro``) is
-  deprecated as of Twig 3.27 and will throw in Twig 4.0. These tags have a
+  deprecated as of Twig 3.28 and will throw in Twig 4.0. These tags have a
   global effect on the template and must be declared at the root of its body.
 
 Filters

--- a/src/NodeVisitor/CorrectnessNodeVisitor.php
+++ b/src/NodeVisitor/CorrectnessNodeVisitor.php
@@ -159,7 +159,7 @@ final class CorrectnessNodeVisitor implements NodeVisitorInterface
         }
 
         if (!isset($this->rootNodes[$node])) {
-            trigger_deprecation('twig/twig', '3.27', 'Using the "%s" tag outside the root of a template is deprecated in %s at line %d.', $node->getNodeTag(), $node->getSourceContext()->getName(), $node->getTemplateLine());
+            trigger_deprecation('twig/twig', '3.28', 'Using the "%s" tag outside the root of a template is deprecated in %s at line %d.', $node->getNodeTag(), $node->getSourceContext()->getName(), $node->getTemplateLine());
         }
     }
 

--- a/tests/Fixtures/tags/inheritance/extends_in_condition.legacy.test
+++ b/tests/Fixtures/tags/inheritance/extends_in_condition.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "extends" tag in a condition
 --DEPRECATION--
-Since twig/twig 3.27: Using the "extends" tag outside the root of a template is deprecated in index.twig at line 3.
+Since twig/twig 3.28: Using the "extends" tag outside the root of a template is deprecated in index.twig at line 3.
 --TEMPLATE--
 {% if false %}
     {% extends "base.twig" %}

--- a/tests/Fixtures/tags/inheritance/use_in_condition.legacy.test
+++ b/tests/Fixtures/tags/inheritance/use_in_condition.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "use" tag in a condition
 --DEPRECATION--
-Since twig/twig 3.27: Using the "use" tag outside the root of a template is deprecated in index.twig at line 3.
+Since twig/twig 3.28: Using the "use" tag outside the root of a template is deprecated in index.twig at line 3.
 --TEMPLATE--
 {% if false %}
     {% use "base.twig" %}

--- a/tests/Fixtures/tags/inheritance/use_in_macro.legacy.test
+++ b/tests/Fixtures/tags/inheritance/use_in_macro.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "use" tag in a macro
 --DEPRECATION--
-Since twig/twig 3.27: Using the "use" tag outside the root of a template is deprecated in index.twig at line 3.
+Since twig/twig 3.28: Using the "use" tag outside the root of a template is deprecated in index.twig at line 3.
 --TEMPLATE--
 {% macro input(name, value, type, size) %}
     {% use "base.twig" %}

--- a/tests/Fixtures/tags/macro/macro_in_block.legacy.test
+++ b/tests/Fixtures/tags/macro/macro_in_block.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "macro" tag in a block
 --DEPRECATION--
-Since twig/twig 3.27: Using the "macro" tag outside the root of a template is deprecated in index.twig at line 3.
+Since twig/twig 3.28: Using the "macro" tag outside the root of a template is deprecated in index.twig at line 3.
 --TEMPLATE--
 {% block foo %}
     {% macro input(name, value, type, size) %}

--- a/tests/Fixtures/tags/macro/macro_in_condition.legacy.test
+++ b/tests/Fixtures/tags/macro/macro_in_condition.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 "macro" tag in a condition
 --DEPRECATION--
-Since twig/twig 3.27: Using the "macro" tag outside the root of a template is deprecated in index.twig at line 3.
+Since twig/twig 3.28: Using the "macro" tag outside the root of a template is deprecated in index.twig at line 3.
 --TEMPLATE--
 {% if false %}
     {% macro input(name, value, type, size) %}


### PR DESCRIPTION
#4292 has been introduced in 3.28 and related deprecations are shown for this version in changelog file

But in some part of code including deprecation message, it's about 3.27, this is confusing when upgrading Twig