### PR TITLE
:memo: Add `loop.parent` example

### DIFF
--- a/doc/tags/for.rst
+++ b/doc/tags/for.rst
@@ -74,6 +74,11 @@ Variable              Description
         {{ loop.index }} - {{ user.username }}
     {% endfor %}
 
+    {% set user = {'name': 'Fabien'} %}
+    {% for user in users %}
+        {{ loop.parent.user.name }} - {{ user.username }}
+    {% endfor %}
+
 .. note::
 
     The ``loop.length``, ``loop.revindex``, ``loop.revindex0``, and


### PR DESCRIPTION
The current wording does not give enough explanation to me. I had to find https://stackoverflow.com/questions/17534802/how-does-loop-parent-actually-work to understand its need.

I added an example with variable shadowing, should I add one with nested loops? such as:
```twig
{% for i in [1, 2, 3] %}
  {% for j in [1, 2, 3] %}
    {{ loop.parent.loop.index }} - {{ loop.index }}
  {% endfor %}
{% endfor %}
```