### PR TITLE
Attach documentation comments to nodes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.29.0 (2026-XX-XX)
 
+ * Add documentation comments to attach metadata to nodes (experimental)
  * Add `TempestMarkdown` to use `tempest/markdown` as the `markdown_to_html` converter
  * Fix imported macros not resolving their own template-level macro imports
  * Add the `include_only` function to render a template without giving it access to the current context

--- a/doc/documentation_comments.rst
+++ b/doc/documentation_comments.rst
@@ -1,0 +1,192 @@
+.. _`twig-documentation-comments`:
+
+Documentation Comments
+======================
+
+.. versionadded:: 3.29
+
+    Documentation comments were added in Twig 3.29. This feature is
+    **experimental** and can change based on usage and feedback.
+
+Documentation comments describe template constructs and variable bindings.
+Tools such as IDEs, static analyzers and documentation generators can read this
+metadata through :ref:`node visitors <creating_extensions>`. Documentation
+comments do not affect rendering.
+
+Documenting Template Constructs
+-------------------------------
+
+A documentation comment before an output statement or a tag describes that
+construct:
+
+.. code-block:: twig
+
+    {## Displays the title of the current page. ##}
+    {{ page_title }}
+
+    {## Displays the main content of the page. ##}
+    {% block content %}
+        ...
+    {% endblock %}
+
+    {## Renders an HTML input. ##}
+    {% macro input(name, value = null) %}
+        ...
+    {% endmacro %}
+
+Documentation comments start with ``{##``. They can use the regular ``#}``
+closing marker or the symmetric ``##}`` marker:
+
+.. code-block:: twig
+
+    {## Uses the regular closing marker. #}
+    {% block regular %}{% endblock %}
+
+    {## Uses the symmetric closing marker. ##}
+    {% block symmetric %}{% endblock %}
+
+Whitespace control works like it does for regular comments. On the opening
+marker, ``-`` or ``~`` comes after ``{##``. With the symmetric closing marker,
+it comes before ``##}``:
+
+.. code-block:: twig
+
+    {##- Trims all whitespace before this comment. #}
+    {% block opening_trim %}{% endblock %}
+
+    {## Trims all whitespace after this comment. -##}
+    {% block closing_trim %}{% endblock %}
+
+Documenting Variable Bindings
+-----------------------------
+
+Inside a tag, an inline documentation comment starts with ``##`` and continues
+until the end of the line. It describes the variable binding that starts on the
+next line.
+
+Type Declarations
+~~~~~~~~~~~~~~~~~
+
+Use documentation comments in a :doc:`types <tags/types>` tag to describe the
+variables expected by a template:
+
+.. code-block:: twig
+
+    {% types {
+        ## Whether the answer is correct.
+        is_correct: 'boolean',
+
+        ## The number of points awarded for the answer.
+        score?: 'number',
+    } %}
+
+Assignments
+~~~~~~~~~~~
+
+Documentation comments can describe variables assigned by the :doc:`set
+<tags/set>` tag:
+
+.. code-block:: twig
+
+    {% set
+        ## The number of unread messages.
+        unread_count = messages|filter(message => not message.read)|length
+    %}
+
+Each target in a multiple assignment can have its own documentation:
+
+.. code-block:: twig
+
+    {% set
+        ## The user's given name.
+        first_name,
+        ## The user's family name.
+        last_name
+        = user.first_name, user.last_name
+    %}
+
+Loop Targets
+~~~~~~~~~~~~
+
+Documentation comments can describe the key and value introduced by a
+:doc:`for <tags/for>` loop:
+
+.. code-block:: twig
+
+    {% for
+        ## The product identifier.
+        product_id,
+        ## The product for the current iteration.
+        product
+        in products
+    %}
+        ...
+    {% endfor %}
+
+Macro Arguments
+~~~~~~~~~~~~~~~
+
+Documentation comments can describe individual macro arguments:
+
+.. code-block:: twig
+
+    {% macro input(
+        ## The HTML field name.
+        name,
+        ## The initial field value.
+        value = null,
+    ) %}
+        ...
+    {% endmacro %}
+
+Attachment Rules
+----------------
+
+A documentation comment is considered for the construct or variable binding
+that immediately follows it and attaches only when that position is supported.
+Consecutive documentation comments are combined and separated by newlines:
+
+.. code-block:: twig
+
+    {## Displays the main content. ##}
+    {## The layout renders this block between the header and footer. ##}
+    {% block content %}
+        ...
+    {% endblock %}
+
+Inline documentation comments consume the rest of their line. The documented
+construct or variable must therefore start on a later line:
+
+.. code-block:: twig
+
+    {% set ## The current page number.
+        page = 1
+    %}
+
+Documentation comments are attached on a best-effort basis where Twig can
+associate them directly with a construct or declaration. Comments in other
+positions remain regular comments and expose no metadata. In particular, they
+do not document ordinary variable reads, mapping keys, function arguments,
+named call arguments, assignment operators, destructuring assignments, arrow
+function arguments or variadic macro arguments.
+
+Reading Documentation from Nodes
+--------------------------------
+
+Node visitors can read documentation with ``Node::getDocumentation()``. Twig
+automatically attaches documentation before a custom tag to the node returned
+by its token parser. To support inline documentation, custom token parsers can
+pass the corresponding tokens to ``NodeDocumentation::add()``.
+
+The metadata is stored on the semantic node represented by the source:
+
+* output documentation is stored on the ``PrintNode``;
+* tag documentation is stored on the node produced by the tag;
+* block documentation is stored on the ``BlockNode``;
+* macro documentation is stored on the ``MacroNode``;
+* type documentation is stored on each ``TypeNode``;
+* variable-binding documentation is stored on the node representing its
+  assignment target.
+
+Documentation metadata belongs to its node and is not preserved when an
+optimization or a node visitor replaces that node.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,6 +7,7 @@ Twig
     intro
     installation
     templates
+    documentation_comments
     api
     advanced
     sandbox

--- a/src/Extension/CoreExtension.php
+++ b/src/Extension/CoreExtension.php
@@ -87,6 +87,7 @@ use Twig\Node\Expression\Unary\PosUnary;
 use Twig\Node\Expression\Unary\SpreadUnary;
 use Twig\Node\Node;
 use Twig\NodeVisitor\CorrectnessNodeVisitor;
+use Twig\NodeVisitor\DocumentationNodeVisitor;
 use Twig\Parser;
 use Twig\Sandbox\SecurityNotAllowedMethodError;
 use Twig\Sandbox\SecurityNotAllowedPropertyError;
@@ -332,6 +333,7 @@ final class CoreExtension extends AbstractExtension
     public function getNodeVisitors(): array
     {
         return [
+            new DocumentationNodeVisitor(),
             new CorrectnessNodeVisitor(),
         ];
     }

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -37,6 +37,8 @@ class Lexer
     private $position;
     private $positions;
     private $currentVarBlockLine;
+    /** @var list<string> */
+    private array $documentation = [];
     private array $openingBrackets = ['{', '(', '['];
     private array $closingBrackets = ['}', ')', ']'];
 
@@ -149,6 +151,21 @@ class Lexer
                 ')
             }sx',
 
+            // #} or ##}
+            'lex_documentation_comment' => '{
+                (?:'.
+                    preg_quote($this->options['whitespace_trim'].'#'.$this->options['tag_comment'][1], '#').'\s*\n?'. // -##}\s*\n?
+                    '|'.
+                    preg_quote($this->options['whitespace_line_trim'].'#'.$this->options['tag_comment'][1], '#').'['.$this->options['whitespace_line_chars'].']*'. // ~##}[ \t\0\x0B]*
+                    '|'.
+                    preg_quote($this->options['whitespace_trim'].$this->options['tag_comment'][1], '#').'\s*\n?'. // -#}\s*\n?
+                    '|'.
+                    preg_quote($this->options['whitespace_line_trim'].$this->options['tag_comment'][1], '#').'['.$this->options['whitespace_line_chars'].']*'. // ~#}[ \t\0\x0B]*
+                    '|'.
+                    preg_quote($this->options['tag_comment'][1], '#').'(?:\r\n?|\n)?'. // #}(?:\r\n?|\n)?
+                ')
+            }sx',
+
             // verbatim %}
             'lex_block_raw' => '{
                 \s*verbatim\s*
@@ -169,6 +186,8 @@ class Lexer
                     preg_quote($this->options['tag_variable'][0], '#'). // {{
                     '|'.
                     preg_quote($this->options['tag_block'][0], '#'). // {%
+                    '|'.
+                    preg_quote($this->options['tag_comment'][0].'#', '#'). // {##
                     '|'.
                     preg_quote($this->options['tag_comment'][0], '#'). // {#
                 ')('.
@@ -198,6 +217,7 @@ class Lexer
         $this->states = [];
         $this->brackets = [];
         $this->position = -1;
+        $this->documentation = [];
 
         // find all token starts in one go
         preg_match_all($this->regexes['lex_tokens_start'], $this->code, $matches, \PREG_OFFSET_CAPTURE);
@@ -277,6 +297,11 @@ class Lexer
         $this->moveCursor($textContent);
 
         switch ($this->positions[1][$this->position][0]) {
+            case $this->options['tag_comment'][0].'#':
+                $this->moveCursor($position[0]);
+                $this->lexComment(true);
+                break;
+
             case $this->options['tag_comment'][0]:
                 $this->moveCursor($position[0]);
                 $this->lexComment();
@@ -289,10 +314,12 @@ class Lexer
 
                 // raw data?
                 if (preg_match($this->regexes['lex_block_raw'], $this->code, $match, 0, $this->cursor)) {
+                    $this->documentation = [];
                     $this->moveCursor($match[0]);
                     $this->lexRawData();
                 // {% line \d+ %}
                 } elseif (preg_match($this->regexes['lex_block_line'], $this->code, $match, 0, $this->cursor)) {
+                    $this->documentation = [];
                     $this->moveCursor($match[0]);
                     $this->lineno = (int) $match[1];
                 } else {
@@ -382,6 +409,9 @@ class Lexer
         }
         // inline comment
         elseif (preg_match(self::REGEX_RAW_INLINE_COMMENT, $this->code, $match, 0, $this->cursor)) {
+            if (str_starts_with($match[0], '##')) {
+                $this->addDocumentation(substr($match[0], 2));
+            }
             $this->moveCursor($match[0]);
         }
         // unlexable
@@ -472,13 +502,24 @@ class Lexer
         $this->pushToken(Token::TEXT_TYPE, $this->normalizeNewlines($text), $offset);
     }
 
-    private function lexComment(): void
+    private function lexComment(bool $isDocumentation = false): void
     {
-        if (!preg_match($this->regexes['lex_comment'], $this->code, $match, \PREG_OFFSET_CAPTURE, $this->cursor)) {
+        $regex = $isDocumentation ? 'lex_documentation_comment' : 'lex_comment';
+        if (!preg_match($this->regexes[$regex], $this->code, $match, \PREG_OFFSET_CAPTURE, $this->cursor)) {
             throw new SyntaxError('Unclosed comment.', $this->lineno, $this->source);
         }
 
-        $this->moveCursor(substr($this->code, $this->cursor, $match[0][1] - $this->cursor).$match[0][0]);
+        $comment = substr($this->code, $this->cursor, $match[0][1] - $this->cursor);
+        if ($isDocumentation) {
+            $documentation = $comment;
+            // support a symmetric "##}" closing marker
+            if (str_ends_with($documentation, '#')) {
+                $documentation = substr($documentation, 0, -1);
+            }
+            $this->addDocumentation($documentation);
+        }
+
+        $this->moveCursor($comment.$match[0][0]);
     }
 
     private function lexString(): void
@@ -526,7 +567,20 @@ class Lexer
 
         // by default the token starts at the current cursor; callers that
         // emit a token after consuming it must pass an explicit offset
-        $this->tokens[] = new Token($type, $value, $lineno ?? $this->lineno, $offset ?? $this->cursor);
+        $documentation = null;
+        if ($this->documentation && (Token::TEXT_TYPE !== $type || '' !== trim($value))) {
+            $documentation = implode("\n", $this->documentation);
+            $this->documentation = [];
+        }
+
+        $this->tokens[] = new Token($type, $value, $lineno ?? $this->lineno, $offset ?? $this->cursor, $documentation);
+    }
+
+    private function addDocumentation(string $documentation): void
+    {
+        if ('' !== $documentation = trim($this->normalizeNewlines($documentation))) {
+            $this->documentation[] = $documentation;
+        }
     }
 
     private function moveCursor($text): void

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -35,6 +35,7 @@ class Node implements \Countable, \IteratorAggregate
     protected $tag;
 
     private $sourceContext;
+    private ?string $documentation = null;
     /** @var array<string, NameDeprecation> */
     private $nodeNameDeprecations = [];
     /** @var array<string, NameDeprecation> */
@@ -71,6 +72,10 @@ class Node implements \Countable, \IteratorAggregate
 
         if ($this->tag) {
             $repr .= \sprintf("\n  tag: %s", $this->tag);
+        }
+
+        if (null !== $this->documentation) {
+            $repr .= \sprintf("\n  documentation: %s", str_replace("\n", '\\n', $this->documentation));
         }
 
         $attributes = [];
@@ -127,6 +132,19 @@ class Node implements \Countable, \IteratorAggregate
     public function getNodeTag(): ?string
     {
         return $this->tag;
+    }
+
+    public function getDocumentation(): ?string
+    {
+        return $this->documentation;
+    }
+
+    /**
+     * @internal
+     */
+    public function setDocumentation(?string $documentation): void
+    {
+        $this->documentation = $documentation;
     }
 
     /**

--- a/src/Node/NodeDocumentation.php
+++ b/src/Node/NodeDocumentation.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Node;
+
+use Twig\Token;
+
+final class NodeDocumentation
+{
+    public static function add(Node $node, Token ...$tokens): void
+    {
+        $documentation = [];
+        foreach ($tokens as $token) {
+            if (null !== $comment = $token->getDocumentation()) {
+                $documentation[] = $comment;
+            }
+        }
+        if (null !== $comment = $node->getDocumentation()) {
+            $documentation[] = $comment;
+        }
+
+        if ($documentation) {
+            $node->setDocumentation(implode("\n", $documentation));
+        }
+    }
+
+    public static function move(Node $source, Node $target): void
+    {
+        if (null !== $documentation = $source->getDocumentation()) {
+            self::prepend($target, $documentation);
+            $source->setDocumentation(null);
+        }
+    }
+
+    private static function prepend(Node $node, string $documentation): void
+    {
+        if (null !== $currentDocumentation = $node->getDocumentation()) {
+            $documentation .= "\n".$currentDocumentation;
+        }
+
+        $node->setDocumentation($documentation);
+    }
+}

--- a/src/Node/TypeNode.php
+++ b/src/Node/TypeNode.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Node;
+
+use Twig\Attribute\YieldReady;
+
+/**
+ * Represents a type declaration node.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+#[YieldReady]
+final class TypeNode extends Node
+{
+    /**
+     * @internal
+     */
+    public function __construct(string $name, string $type, bool $optional, int $lineno)
+    {
+        parent::__construct([], ['name' => $name, 'type' => $type, 'optional' => $optional], $lineno);
+    }
+}

--- a/src/Node/TypesNode.php
+++ b/src/Node/TypesNode.php
@@ -27,7 +27,12 @@ class TypesNode extends Node
      */
     public function __construct(array $types, int $lineno)
     {
-        parent::__construct([], ['mapping' => $types], $lineno);
+        $nodes = [];
+        foreach ($types as $name => $type) {
+            $nodes[$name] = new TypeNode($name, $type['type'], $type['optional'], $lineno);
+        }
+
+        parent::__construct($nodes, ['mapping' => $types], $lineno);
     }
 
     public function compile(Compiler $compiler): void

--- a/src/NodeVisitor/DocumentationNodeVisitor.php
+++ b/src/NodeVisitor/DocumentationNodeVisitor.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\NodeVisitor;
+
+use Twig\Environment;
+use Twig\Node\BlockReferenceNode;
+use Twig\Node\MacroDeclarationNode;
+use Twig\Node\ModuleNode;
+use Twig\Node\Node;
+use Twig\Node\NodeDocumentation;
+
+/**
+ * @internal
+ */
+final class DocumentationNodeVisitor implements NodeVisitorInterface
+{
+    /** @var list<ModuleNode> */
+    private array $modules = [];
+    /** @var list<array<string, MacroDeclarationNode>> */
+    private array $macroDeclarations = [];
+
+    public function enterNode(Node $node, Environment $env): Node
+    {
+        if ($node instanceof ModuleNode) {
+            $this->modules[] = $node;
+            $this->macroDeclarations[] = [];
+        }
+
+        $module = end($this->modules);
+        if ($node instanceof BlockReferenceNode && $module->getNode('blocks')->hasNode($name = $node->getAttribute('name'))) {
+            NodeDocumentation::move($node, $module->getNode('blocks')->getNode($name)->getNode('0'));
+        }
+
+        if ($node instanceof MacroDeclarationNode && $module->getNode('macros')->hasNode($name = $node->getAttribute('name'))) {
+            $macro = $module->getNode('macros')->getNode($name);
+            $index = array_key_last($this->macroDeclarations);
+            if ($node->getTemplateLine() === $macro->getTemplateLine()) {
+                if (isset($this->macroDeclarations[$index][$name])) {
+                    $this->macroDeclarations[$index][$name]->setDocumentation(null);
+                }
+                $this->macroDeclarations[$index][$name] = $node;
+            } else {
+                $node->setDocumentation(null);
+            }
+        }
+
+        return $node;
+    }
+
+    public function leaveNode(Node $node, Environment $env): Node
+    {
+        if ($node instanceof ModuleNode) {
+            foreach (array_pop($this->macroDeclarations) as $name => $declaration) {
+                NodeDocumentation::move($declaration, $node->getNode('macros')->getNode($name));
+            }
+            array_pop($this->modules);
+        }
+
+        return $node;
+    }
+
+    public function getPriority(): int
+    {
+        return -512;
+    }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -31,6 +31,7 @@ use Twig\Node\MacroNode;
 use Twig\Node\MacrosNode;
 use Twig\Node\ModuleNode;
 use Twig\Node\Node;
+use Twig\Node\NodeDocumentation;
 use Twig\Node\Nodes;
 use Twig\Node\PrintNode;
 use Twig\Node\SkipLazyMacroImportsNode;
@@ -192,11 +193,13 @@ class Parser
                     $token = $this->stream->next();
                     $expr = $this->parseExpression();
                     $this->stream->expect(Token::VAR_END_TYPE);
-                    $rv[] = new PrintNode($expr, $token->getLine());
+                    $node = new PrintNode($expr, $token->getLine());
+                    NodeDocumentation::add($node, $token);
+                    $rv[] = $node;
                     break;
 
                 case $this->stream->getCurrent()->test(Token::BLOCK_START_TYPE):
-                    $this->stream->next();
+                    $startToken = $this->stream->next();
                     $token = $this->getCurrentToken();
 
                     if (!$token->test(Token::NAME_TYPE)) {
@@ -239,6 +242,7 @@ class Parser
                         trigger_deprecation('twig/twig', '3.12', 'Returning "null" from "%s" is deprecated and forbidden by "TokenParserInterface".', $subparser::class);
                     } else {
                         $node->setNodeTag($subparser->getTag());
+                        NodeDocumentation::add($node, $startToken);
                         $rv[] = $node;
                     }
                     break;
@@ -564,13 +568,25 @@ class Parser
 
     private function cleanupBodyForChildTemplates(Node $body): Node
     {
-        if ($body instanceof BlockReferenceNode || ($body instanceof TextNode && $body->isBlank())) {
+        if ($body instanceof BlockReferenceNode) {
+            $name = $body->getAttribute('name');
+            if (isset($this->blocks[$name])) {
+                NodeDocumentation::move($body, $this->blocks[$name]->getNode('0'));
+            }
+
+            return new EmptyNode();
+        }
+        if ($body instanceof TextNode && $body->isBlank()) {
             return new EmptyNode();
         }
 
         foreach ($body as $k => $node) {
             if ($node instanceof BlockReferenceNode) {
                 // as it has a parent, the block reference won't be used
+                $name = $node->getAttribute('name');
+                if (isset($this->blocks[$name])) {
+                    NodeDocumentation::move($node, $this->blocks[$name]->getNode('0'));
+                }
                 $body->removeNode($k);
             } elseif ($node instanceof TextNode && $node->isBlank()) {
                 // remove nodes considered as "empty"

--- a/src/Token.php
+++ b/src/Token.php
@@ -47,6 +47,7 @@ final class Token
         private $value,
         private int $lineno,
         private ?int $offset = null,
+        private ?string $documentation = null,
     ) {
         if (self::ARROW_TYPE === $type) {
             trigger_deprecation('twig/twig', '3.21', 'The "%s" token type is deprecated, "arrow" is now an operator.', self::ARROW_TYPE);
@@ -139,6 +140,11 @@ final class Token
     public function getOffset(): ?int
     {
         return $this->offset;
+    }
+
+    public function getDocumentation(): ?string
+    {
+        return $this->documentation;
     }
 
     /**

--- a/src/TokenParser/AbstractTokenParser.php
+++ b/src/TokenParser/AbstractTokenParser.php
@@ -13,6 +13,7 @@ namespace Twig\TokenParser;
 
 use Twig\Lexer;
 use Twig\Node\Expression\Variable\AssignContextVariable;
+use Twig\Node\NodeDocumentation;
 use Twig\Node\Nodes;
 use Twig\Parser;
 use Twig\Token;
@@ -54,7 +55,9 @@ abstract class AbstractTokenParser implements TokenParserInterface
             } else {
                 $stream->expect(Token::NAME_TYPE, null, 'Only variables can be assigned to');
             }
-            $targets[] = new AssignContextVariable($token->getValue(), $token->getLine());
+            $target = new AssignContextVariable($token->getValue(), $token->getLine());
+            NodeDocumentation::add($target, $token);
+            $targets[] = $target;
 
             if (!$stream->nextIf(Token::PUNCTUATION_TYPE, ',')) {
                 break;

--- a/src/TokenParser/MacroTokenParser.php
+++ b/src/TokenParser/MacroTokenParser.php
@@ -22,6 +22,7 @@ use Twig\Node\Expression\Variable\LocalVariable;
 use Twig\Node\MacroDeclarationNode;
 use Twig\Node\MacroNode;
 use Twig\Node\Node;
+use Twig\Node\NodeDocumentation;
 use Twig\Token;
 
 /**
@@ -106,7 +107,8 @@ final class MacroTokenParser extends AbstractTokenParser
             }
 
             $token = $stream->expect(Token::NAME_TYPE, null, 'An argument must be a name');
-            $name = new LocalVariable($token->getValue(), $this->parser->getCurrentToken()->getLine());
+            $name = new LocalVariable($token->getValue(), $token->getLine());
+            NodeDocumentation::add($name, $token);
             if ($token = $stream->nextIf(Token::OPERATOR_TYPE, '=')) {
                 $default = $this->parser->parseExpression();
             } else {

--- a/src/TokenParser/TypesTokenParser.php
+++ b/src/TokenParser/TypesTokenParser.php
@@ -13,6 +13,8 @@ namespace Twig\TokenParser;
 
 use Twig\Error\SyntaxError;
 use Twig\Node\Node;
+use Twig\Node\NodeDocumentation;
+use Twig\Node\TypeNode;
 use Twig\Node\TypesNode;
 use Twig\Token;
 use Twig\TokenStream;
@@ -31,14 +33,19 @@ final class TypesTokenParser extends AbstractTokenParser
     public function parse(Token $token): Node
     {
         $stream = $this->parser->getStream();
-        $types = $this->parseSimpleMappingExpression($stream);
+        [$types, $nodes] = $this->parseSimpleMappingExpression($stream);
         $stream->expect(Token::BLOCK_END_TYPE);
 
-        return new TypesNode($types, $token->getLine());
+        $node = new TypesNode($types, $token->getLine());
+        foreach ($nodes as $name => $type) {
+            $node->setNode($name, $type);
+        }
+
+        return $node;
     }
 
     /**
-     * @return array<string, array{type: string, optional: bool}>
+     * @return array{array<string, array{type: string, optional: bool}>, array<string, TypeNode>}
      *
      * @throws SyntaxError
      */
@@ -46,6 +53,7 @@ final class TypesTokenParser extends AbstractTokenParser
     {
         $enclosed = null !== $stream->nextIf(Token::PUNCTUATION_TYPE, '{');
         $types = [];
+        $nodes = [];
         $first = true;
         while (!($stream->test(Token::PUNCTUATION_TYPE, '}') || $stream->test(Token::BLOCK_END_TYPE))) {
             if (!$first) {
@@ -73,13 +81,16 @@ final class TypesTokenParser extends AbstractTokenParser
                 'type' => $valueToken->getValue(),
                 'optional' => $isOptional,
             ];
+            $node = new TypeNode($nameToken->getValue(), $valueToken->getValue(), $isOptional, $nameToken->getLine());
+            NodeDocumentation::add($node, $nameToken);
+            $nodes[$nameToken->getValue()] = $node;
         }
 
         if ($enclosed) {
             $stream->expect(Token::PUNCTUATION_TYPE, '}', 'An opened mapping is not properly closed');
         }
 
-        return $types;
+        return [$types, $nodes];
     }
 
     public function getTag(): string

--- a/tests/Node/NodeTest.php
+++ b/tests/Node/NodeTest.php
@@ -74,6 +74,17 @@ Twig\Tests\Node\NodeForTest
 EOF, (string) $node);
     }
 
+    public function testToStringWithDocumentation(): void
+    {
+        $node = new NodeForTest();
+        $node->setDocumentation("First line\nSecond line");
+
+        $this->assertSame(<<<'EOF'
+Twig\Tests\Node\NodeForTest
+  documentation: First line\nSecond line
+EOF, (string) $node);
+    }
+
     public function testAttributeDeprecationIgnore(): void
     {
         $node = new NodeForTest([], ['foo' => false]);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -28,13 +28,22 @@ use Twig\Environment;
 use Twig\Error\SyntaxError;
 use Twig\Lexer;
 use Twig\Loader\ArrayLoader;
+use Twig\Node\BlockNode;
+use Twig\Node\BlockReferenceNode;
+use Twig\Node\DoNode;
 use Twig\Node\EmptyNode;
+use Twig\Node\Expression\BlockReferenceExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\Node\Expression\MacroReferenceExpression;
+use Twig\Node\ForNode;
+use Twig\Node\IfNode;
 use Twig\Node\MacroDeclarationNode;
+use Twig\Node\MacroNode;
 use Twig\Node\Node;
+use Twig\Node\PrintNode;
 use Twig\Node\TextNode;
+use Twig\NodeVisitor\NodeVisitorInterface;
 use Twig\Parser;
 use Twig\Source;
 use Twig\Token;
@@ -304,6 +313,143 @@ EOF, 'index')));
         $this->assertInstanceOf(EmptyNode::class, $body);
     }
 
+    public function testCleanupBodyAcceptsAnUnregisteredBlockReference(): void
+    {
+        $twig = new Environment(new ArrayLoader());
+        $twig->addTokenParser(new UnregisteredBlockReferenceTokenParser());
+
+        $node = $twig->parse($twig->tokenize(new Source('{% unregistered_block_reference %}', 'index')));
+
+        $this->assertInstanceOf(EmptyNode::class, $node->getNode('body')->getNode('0'));
+    }
+
+    public function testDocumentationIsAttachedToNodes(): void
+    {
+        $twig = new Environment(new ArrayLoader(), ['autoescape' => false]);
+        $module = $twig->parse($twig->tokenize(new Source(<<<'TWIG'
+{## Printed expression #}
+{{ answer }}
+{## Conditional tag #}
+{% if enabled %}Enabled{% endif %}
+{## Do tag #}
+{% do max() %}
+{## Text node #}
+Text
+TWIG, 'index')));
+        $body = $module->getNode('body')->getNode('0');
+
+        $this->assertInstanceOf(PrintNode::class, $body->getNode('0'));
+        $this->assertSame('Printed expression', $body->getNode('0')->getDocumentation());
+        $this->assertNull($body->getNode('0')->getNode('expr')->getDocumentation());
+        $this->assertInstanceOf(IfNode::class, $body->getNode('2'));
+        $this->assertSame('Conditional tag', $body->getNode('2')->getDocumentation());
+        $this->assertInstanceOf(DoNode::class, $body->getNode('3'));
+        $this->assertSame('Do tag', $body->getNode('3')->getDocumentation());
+        $this->assertInstanceOf(TextNode::class, $body->getNode('4'));
+        $this->assertNull($body->getNode('4')->getDocumentation());
+    }
+
+    public function testInlineDocumentationBeforeATagNameIsIgnored(): void
+    {
+        $twig = new Environment(new ArrayLoader(), ['autoescape' => false]);
+        $module = $twig->parse($twig->tokenize(new Source("{% ## Not tag documentation\ndo max() %}", 'index')));
+
+        $this->assertNull($module->getNode('body')->getNode('0')->getDocumentation());
+    }
+
+    public function testDocumentationIsAvailableToNodeVisitors(): void
+    {
+        $visitor = new DocumentationReadingNodeVisitor();
+        $twig = new Environment(new ArrayLoader());
+        $twig->addNodeVisitor($visitor);
+
+        $twig->parse($twig->tokenize(new Source('{## Block documentation #}{% block content %}{% endblock %}{## Macro documentation #}{% macro input() %}{% endmacro %}', 'index')));
+
+        $this->assertSame([
+            BlockNode::class => 'Block documentation',
+            MacroNode::class => 'Macro documentation',
+        ], $visitor->documentation);
+    }
+
+    public function testDocumentationIsRemovedFromUnsupportedOptimizedNodes(): void
+    {
+        $twig = new Environment(new ArrayLoader(), ['autoescape' => false]);
+        $module = $twig->parse($twig->tokenize(new Source(<<<'TWIG'
+{## Text node #}
+{{ 'Hello' }}
+{## Block reference #}
+{{ block('content') }}
+{% block content %}Content{% endblock %}
+TWIG, 'index')));
+        $body = $module->getNode('body')->getNode('0');
+
+        $this->assertInstanceOf(TextNode::class, $body->getNode('0'));
+        $this->assertNull($body->getNode('0')->getDocumentation());
+        $this->assertInstanceOf(BlockReferenceExpression::class, $body->getNode('2'));
+        $this->assertNull($body->getNode('2')->getDocumentation());
+    }
+
+    public function testDocumentationIsAttachedToAssignmentTargets(): void
+    {
+        $twig = new Environment(new ArrayLoader(), ['autoescape' => false, 'optimizations' => 0]);
+        $module = $twig->parse($twig->tokenize(new Source(<<<'TWIG'
+{% set ## First name
+    first_name, ## Last name
+    last_name = user.first_name, user.last_name
+%}
+{% for ## Product identifier
+    product_id, ## Product
+    product in products
+%}{% endfor %}
+TWIG, 'index')));
+        $body = $module->getNode('body')->getNode('0');
+
+        $this->assertSame('First name', $body->getNode('0')->getNode('names')->getNode('0')->getDocumentation());
+        $this->assertSame('Last name', $body->getNode('0')->getNode('names')->getNode('1')->getDocumentation());
+
+        $for = $body->getNode('1');
+        $this->assertInstanceOf(ForNode::class, $for);
+        $this->assertSame('Product identifier', $for->getNode('key_target')->getDocumentation());
+        $this->assertSame('Product', $for->getNode('value_target')->getDocumentation());
+    }
+
+    public function testDocumentationIsAttachedToMacroNode(): void
+    {
+        $twig = new Environment(new ArrayLoader());
+        $module = $twig->parse($twig->tokenize(new Source("{## Input macro #}\n{% macro input() %}{% endmacro %}", 'index')));
+
+        $this->assertSame('Input macro', $module->getNode('macros')->getNode('input')->getDocumentation());
+
+        $module = $twig->parse($twig->tokenize(new Source("{## Input macro #}\n{% macro input(## Name argument\nname, ## Value argument\nvalue) %}{% endmacro %}", 'index')));
+        $declaration = $module->getNode('body')->getNode('0');
+        $macro = $module->getNode('macros')->getNode('input');
+
+        $this->assertNull($declaration->getDocumentation());
+        $this->assertSame('Input macro', $macro->getDocumentation());
+        $this->assertSame('Name argument', $macro->getNode('arguments')->getNode('0')->getDocumentation());
+        $this->assertSame(3, $macro->getNode('arguments')->getNode('0')->getTemplateLine());
+        $this->assertSame('Value argument', $macro->getNode('arguments')->getNode('2')->getDocumentation());
+        $this->assertSame(4, $macro->getNode('arguments')->getNode('2')->getTemplateLine());
+    }
+
+    /**
+     * @group legacy
+     */
+    #[Group('legacy')]
+    public function testDuplicateMacroKeepsOnlyTheLastDocumentation(): void
+    {
+        $twig = new Environment(new ArrayLoader());
+
+        $this->expectDeprecation('Since twig/twig 3.29: Defining the macro "input" more than once in "index" is deprecated and will throw a SyntaxError in Twig 4.0 (first definition at line 1, second at line 1).');
+
+        $module = $twig->parse($twig->tokenize(new Source('{## First #}{% macro input() %}{% endmacro %}{## Second #}{% macro input() %}{% endmacro %}', 'index')));
+
+        $this->assertSame('Second', $module->getNode('macros')->getNode('input')->getDocumentation());
+        foreach ($module->getNode('body')->getNode('0') as $declaration) {
+            $this->assertNull($declaration->getDocumentation());
+        }
+    }
+
     public function testBodyForParentTemplates(): void
     {
         $twig = new Environment(new ArrayLoader());
@@ -359,6 +505,30 @@ EOF, 'index')));
     }
 }
 
+class DocumentationReadingNodeVisitor implements NodeVisitorInterface
+{
+    public array $documentation = [];
+
+    public function enterNode(Node $node, Environment $env): Node
+    {
+        if (($node instanceof BlockNode || $node instanceof MacroNode) && null !== $documentation = $node->getDocumentation()) {
+            $this->documentation[$node::class] = $documentation;
+        }
+
+        return $node;
+    }
+
+    public function leaveNode(Node $node, Environment $env): ?Node
+    {
+        return $node;
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+}
+
 class TestTokenParser extends AbstractTokenParser
 {
     public function parse(Token $token): Node
@@ -380,6 +550,22 @@ class TestTokenParser extends AbstractTokenParser
     public function getTag(): string
     {
         return 'test';
+    }
+}
+
+class UnregisteredBlockReferenceTokenParser extends AbstractTokenParser
+{
+    public function parse(Token $token): Node
+    {
+        $this->parser->setParent(new ConstantExpression('base', $token->getLine()), false);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
+
+        return new BlockReferenceNode('missing', $token->getLine());
+    }
+
+    public function getTag(): string
+    {
+        return 'unregistered_block_reference';
     }
 }
 

--- a/tests/TokenParser/BlockTokenParserTest.php
+++ b/tests/TokenParser/BlockTokenParserTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Tests\TokenParser;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Error\SyntaxError;
+use Twig\Loader\ArrayLoader;
+use Twig\Node\BlockNode;
+use Twig\Node\BlockReferenceNode;
+use Twig\Node\DoNode;
+use Twig\Parser;
+use Twig\Source;
+
+class BlockTokenParserTest extends TestCase
+{
+    /** @dataProvider provideDocumentedBlocks */
+    #[DataProvider('provideDocumentedBlocks')]
+    public function testDocumentation(string $template, ?string $expected): void
+    {
+        $this->assertSame($expected, $this->parseBlock($template)->getDocumentation());
+    }
+
+    /** @dataProvider provideDocumentationWhitespaceControl */
+    #[DataProvider('provideDocumentationWhitespaceControl')]
+    public function testDocumentationWhitespaceControl(string $template, string $expectedOutput): void
+    {
+        $env = new Environment(new ArrayLoader(['index' => $template]), ['autoescape' => false, 'optimizations' => 0]);
+        $module = $env->parse($env->tokenize(new Source($template, 'index')));
+
+        $this->assertSame('The main content', $module->getNode('blocks')->getNode('content')->getNode('0')->getDocumentation());
+        $this->assertSame($expectedOutput, $env->render('index'));
+    }
+
+    public static function provideDocumentationWhitespaceControl(): iterable
+    {
+        yield 'opening whitespace trim marker' => [
+            "A \n{##- The main content #}\n{% block content %}B{% endblock %}",
+            'AB',
+        ];
+        yield 'opening line whitespace trim marker' => [
+            "A \n  {##~ The main content #}\n{% block content %}B{% endblock %}",
+            "A \nB",
+        ];
+        yield 'closing whitespace trim marker' => [
+            "A{## The main content -##}\n  {% block content %}B{% endblock %}",
+            'AB',
+        ];
+        yield 'closing line whitespace trim marker' => [
+            "A{## The main content ~##}  \n{% block content %}B{% endblock %}",
+            "A\nB",
+        ];
+    }
+
+    public function testDocumentationIsMovedFromTheBlockReference(): void
+    {
+        $env = new Environment(new ArrayLoader(), ['autoescape' => false, 'optimizations' => 0]);
+        $module = $env->parse($env->tokenize(new Source("{## The main content #}\n{% block content %}Hello{% endblock %}", 'index')));
+        $reference = $module->getNode('body')->getNode('0');
+
+        $this->assertInstanceOf(BlockReferenceNode::class, $reference);
+        $this->assertNull($reference->getDocumentation());
+        $this->assertSame('The main content', $module->getNode('blocks')->getNode('content')->getNode('0')->getDocumentation());
+    }
+
+    public function testDocumentationIsPreservedInChildTemplates(): void
+    {
+        $env = new Environment(new ArrayLoader(), ['autoescape' => false, 'optimizations' => 0]);
+        $module = $env->parse($env->tokenize(new Source("{% extends 'base' %}\n{## The main content #}\n{% block content %}Hello{% endblock %}", 'index')));
+
+        $this->assertSame('The main content', $module->getNode('blocks')->getNode('content')->getNode('0')->getDocumentation());
+    }
+
+    public static function provideDocumentedBlocks(): iterable
+    {
+        yield 'documentation comment before block' => [
+            "{## The main content #}\n{% block content %}Hello{% endblock %}",
+            'The main content',
+        ];
+        yield 'symmetric closing marker' => [
+            "{## The main content ##}\n{% block content %}Hello{% endblock %}",
+            'The main content',
+        ];
+        yield 'multiple documentation comments' => [
+            "{## The main content #}\n{## Displayed on every page #}\n{% block content %}Hello{% endblock %}",
+            "The main content\nDisplayed on every page",
+        ];
+        yield 'empty documentation comment' => [
+            "{## #}\n{% block content %}Hello{% endblock %}",
+            null,
+        ];
+        yield 'zero documentation comment' => [
+            "{## 0 #}\n{% block content %}Hello{% endblock %}",
+            '0',
+        ];
+        yield 'regular comment' => [
+            "{# The main content #}\n{% block content %}Hello{% endblock %}",
+            null,
+        ];
+        yield 'unrelated documentation comment' => [
+            "{## Not block documentation #}\nHello\n{% block content %}Hello{% endblock %}",
+            null,
+        ];
+    }
+
+    /**
+     * @dataProvider provideDocumentationBoundaries
+     */
+    #[DataProvider('provideDocumentationBoundaries')]
+    public function testDocumentationDoesNotCrossSpecialConstructs(string $template): void
+    {
+        $twig = new Environment(new ArrayLoader(), ['autoescape' => false, 'optimizations' => 0]);
+        $module = $twig->parse($twig->tokenize(new Source($template, 'index')));
+        $body = $module->getNode('body')->getNode('0');
+        $node = $body instanceof DoNode ? $body : $body->getNode('1');
+
+        $this->assertNull($node->getDocumentation());
+    }
+
+    public static function provideDocumentationBoundaries(): iterable
+    {
+        yield 'line tag' => ["{## Not do documentation #}\n{% line 10 %}{% do max() %}"];
+        yield 'empty verbatim tag' => ["{## Not do documentation #}\n{% verbatim %}{% endverbatim %}{% do max() %}"];
+        yield 'whitespace verbatim tag' => ["{## Not do documentation #}\n{% verbatim %} {% endverbatim %}{% do max() %}"];
+    }
+
+    public function testShortcutAssignmentNamedDocsRemainsValid(): void
+    {
+        $twig = new Environment(new ArrayLoader(['index' => '{% block title docs="The page title" %}']));
+
+        $this->assertSame('The page title', $twig->render('index'));
+    }
+
+    public function testDocumentationCommentRequiresALineBreak(): void
+    {
+        $twig = new Environment(new ArrayLoader(['index' => '{% block ## Description %}Hello{% endblock %}']));
+
+        $this->expectException(SyntaxError::class);
+
+        $twig->render('index');
+    }
+
+    private function parseBlock(string $template): BlockNode
+    {
+        $env = new Environment(new ArrayLoader(), ['cache' => false, 'autoescape' => false]);
+        $stream = $env->tokenize(new Source($template, ''));
+        $parser = new Parser($env);
+
+        return $parser->parse($stream)->getNode('blocks')->getNode('content')->getNode('0');
+    }
+}

--- a/tests/TokenParser/TypesTokenParserTest.php
+++ b/tests/TokenParser/TypesTokenParserTest.php
@@ -30,7 +30,21 @@ class TypesTokenParserTest extends TestCase
 
         $typesNode = $parser->parse($stream)->getNode('body')->getNode('0');
 
-        self::assertEquals($expected, $typesNode->getAttribute('mapping'));
+        self::assertSame($expected, $typesNode->getAttribute('mapping'));
+    }
+
+    public function testDocumentationIsAttachedToTypeNodes(): void
+    {
+        $env = new Environment(new ArrayLoader(), ['cache' => false, 'autoescape' => false]);
+        $stream = $env->tokenize(new Source("{% types {\n## The foo variable\nfoo: 'foo',\n## The bar variable\nbar?: 'bar',\n} %}", ''));
+        $parser = new Parser($env);
+
+        $typesNode = $parser->parse($stream)->getNode('body')->getNode('0');
+
+        self::assertSame('The foo variable', $typesNode->getNode('foo')->getDocumentation());
+        self::assertSame(3, $typesNode->getNode('foo')->getTemplateLine());
+        self::assertSame('The bar variable', $typesNode->getNode('bar')->getDocumentation());
+        self::assertSame(5, $typesNode->getNode('bar')->getTemplateLine());
     }
 
     public static function getMappingTests(): array
@@ -82,6 +96,34 @@ class TypesTokenParserTest extends TestCase
                 [
                     'foo' => ['type' => 'foo', 'optional' => false],
                     'bar' => ['type' => 'bar', 'optional' => false],
+                ],
+            ],
+
+            // documentation comments before types
+            [
+                "{% types {\n## The foo variable\n## Used by the header\nfoo: \"bar\"\n} %}",
+                [
+                    'foo' => [
+                        'type' => 'bar',
+                        'optional' => false,
+                    ],
+                ],
+            ],
+
+            // inline documentation comments
+            [
+                "{% types {\n## The foo variable\nfoo: \"foo\",\n## The bar variable\nbar?: \"bar\",\n} %}",
+                [
+                    'foo' => ['type' => 'foo', 'optional' => false],
+                    'bar' => ['type' => 'bar', 'optional' => true],
+                ],
+            ],
+
+            // regular comments
+            [
+                "{% types {\n# Not documentation\nfoo: \"bar\",\n} %}",
+                [
+                    'foo' => ['type' => 'bar', 'optional' => false],
                 ],
             ],
         ];


### PR DESCRIPTION
Alternatives to #4870

To avoid BC breaks, I have another idea, using `##` as a new syntax, a bit like `/** */` in PHP vs `/* */`.

"Documentation" is attached as metadata to the next relevant node:

```twig
{## The main content displayed on the page #}
{% block content %}
    ...
{% endblock %}
```

Documentation comments can also describe variables declared with the `types` tag:

```twig
{% types {
    ## The unique identifier of the article
    id: 'string',

    ## Whether the article should be highlighted
    featured?: 'boolean',
} %}
```

Node visitors can access this metadata through `Node::getDocumentation()`, allowing IDEs, static analyzers, and documentation generators to consume it without affecting template rendering. Documentation is preserved when visitors or optimizations replace nodes.

Closes #4768
Closes #4870
