### PR TITLE
Reuse assignment targets parsed for the for tag

### DIFF
--- a/src/TokenParser/ForTokenParser.php
+++ b/src/TokenParser/ForTokenParser.php
@@ -52,13 +52,11 @@ final class ForTokenParser extends AbstractTokenParser
 
         if (\count($targets) > 1) {
             $keyTarget = $targets->getNode('0');
-            $keyTarget = new AssignContextVariable($keyTarget->getAttribute('name'), $keyTarget->getTemplateLine());
             $valueTarget = $targets->getNode('1');
         } else {
             $keyTarget = new AssignContextVariable('_key', $lineno);
             $valueTarget = $targets->getNode('0');
         }
-        $valueTarget = new AssignContextVariable($valueTarget->getAttribute('name'), $valueTarget->getTemplateLine());
 
         return new ForNode($keyTarget, $valueTarget, $seq, null, $body, $else, $lineno);
     }


### PR DESCRIPTION
`ForTokenParser` rebuilds the loop targets returned by `parseAssignmentExpression()` into new `AssignContextVariable` instances, copying only the name and line number. But the parsed targets are already `AssignContextVariable` nodes with exactly those values, so the rebuild is a no-op left over from older Twig versions where for-targets were parsed as general expressions and needed normalizing.

Reusing the parsed nodes directly removes dead code, and makes the parser more robust: any metadata attached to the targets during parsing (now or in the future) is preserved instead of being silently dropped.
