### PR TITLE
Fix a macro imported from another template failing to call a macro it imports itself

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.29.0 (2026-XX-XX)
 
+ * Fix a macro imported from another template failing to call a macro it imports itself
  * Add the `Twig\Sandbox\SandboxInterface` interface and `Twig\Sandbox\Sandbox` class to render untrusted templates through a dedicated, always-sandboxed environment crafted for it
  * Add the `Twig\Extension\SandboxBridgeExtension` to render sandboxed templates from trusted templates with an explicit output escaping strategy
  * Extract the sandbox runtime enforcement into a new internal `Twig\Sandbox\SecurityChecker` class used by compiled templates and `CoreExtension`

--- a/src/Node/ModuleNode.php
+++ b/src/Node/ModuleNode.php
@@ -16,6 +16,7 @@ use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\Variable\AssignMacroVariable;
 use Twig\Source;
 
 /**
@@ -395,6 +396,49 @@ final class ModuleNode extends Node implements CoercesChildrenToStringInterface
     protected function compileMacros(Compiler $compiler): void
     {
         $compiler->subcompile($this->getNode('macros'));
+
+        if (!\count($this->getNode('macros'))) {
+            return;
+        }
+
+        $imports = [];
+        $this->collectGlobalImports($this->getNode('body'), $imports);
+        if (!$imports) {
+            return;
+        }
+
+        $compiler
+            ->write("protected function loadMacroImports(): void\n", "{\n")
+            ->indent()
+            ->write("\$macros = \$this->macros;\n")
+            ->write("\$context = \$this->env->getGlobals();\n")
+        ;
+        foreach ($imports as $import) {
+            $compiler->subcompile($import);
+        }
+        $compiler
+            ->outdent()
+            ->write("}\n\n")
+        ;
+    }
+
+    /**
+     * @param ImportNode[] $imports
+     */
+    private function collectGlobalImports(Node $node, array &$imports): void
+    {
+        foreach ($node as $child) {
+            if ($child instanceof ImportNode) {
+                $var = $child->getNode('var');
+                if ($var instanceof AssignMacroVariable && $var->getAttribute('global')) {
+                    $imports[] = $child;
+                }
+
+                continue;
+            }
+
+            $this->collectGlobalImports($child, $imports);
+        }
     }
 
     protected function compileGetTemplateName(Compiler $compiler): void

--- a/src/Template.php
+++ b/src/Template.php
@@ -512,7 +512,12 @@ abstract class Template
      */
     public function getMacroNamespace(): MacroNamespace
     {
-        return $this->macroNamespace ??= new MacroNamespace($this, $this->loadDeclaredMacros());
+        if (null === $this->macroNamespace) {
+            $this->macroNamespace = new MacroNamespace($this, $this->loadDeclaredMacros());
+            $this->loadMacroImports();
+        }
+
+        return $this->macroNamespace;
     }
 
     /**
@@ -521,6 +526,15 @@ abstract class Template
     protected function loadDeclaredMacros(): array
     {
         return [];
+    }
+
+    /**
+     * Resolves the imports the declared macros rely on, so they work even when the template is not displayed.
+     *
+     * @internal
+     */
+    protected function loadMacroImports(): void
+    {
     }
 
     /**

--- a/tests/Fixtures/tags/macro/from_nested_macro_imports.test
+++ b/tests/Fixtures/tags/macro/from_nested_macro_imports.test
@@ -1,0 +1,14 @@
+--TEST--
+"from" tag with a macro that calls a macro imported in another template
+--TEMPLATE--
+{% from "macros2.twig" import macro2 %}
+{{ macro2() }}
+--TEMPLATE(macros2.twig)--
+{% from "macros1.twig" import macro1 %}
+{% macro macro2() %}[{{ macro1() }}]{% endmacro %}
+--TEMPLATE(macros1.twig)--
+{% macro macro1() %}ok{% endmacro %}
+--DATA--
+return []
+--EXPECT--
+[ok]

--- a/tests/Fixtures/tags/macro/import_nested_macro_imports.test
+++ b/tests/Fixtures/tags/macro/import_nested_macro_imports.test
@@ -1,0 +1,14 @@
+--TEST--
+"import" tag with a macro that calls a macro imported in another template
+--TEMPLATE--
+{% import "macros2.twig" as macros2 %}
+{{ macros2.macro2() }}
+--TEMPLATE(macros2.twig)--
+{% import "macros1.twig" as macros1 %}
+{% macro macro2() %}[{{ macros1.macro1() }}]{% endmacro %}
+--TEMPLATE(macros1.twig)--
+{% macro macro1() %}ok{% endmacro %}
+--DATA--
+return []
+--EXPECT--
+[ok]


### PR DESCRIPTION
A macro imported from another template failed with a null error when it called a macro that its own template imports from a third template. Those second-level imports were only resolved while displaying the defining template, so its macro registry stayed empty when the macro ran on its own. The compiled template now also resolves them when its macro namespace is loaded.

Fixes #4879