### PR TITLE
Fix the empty comment "{##}" being lexed as a documentation comment opening

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -95,6 +95,10 @@ class Lexer
             return;
         }
 
+        // when the comment closing tag starts with "#" (as "#}" does), the empty comment ("{##}")
+        // starts like a documentation comment ("{##"); make sure it keeps lexing as a comment
+        $emptyCommentLookahead = str_starts_with($this->options['tag_comment'][1], '#') ? '(?!'.preg_quote(substr($this->options['tag_comment'][1], 1), '#').')' : '';
+
         // when PHP 7.3 is the min version, we will be able to remove the '#' part in preg_quote as it's part of the default
         $this->regexes = [
             // }}
@@ -187,7 +191,7 @@ class Lexer
                     '|'.
                     preg_quote($this->options['tag_block'][0], '#'). // {%
                     '|'.
-                    preg_quote($this->options['tag_comment'][0].'#', '#'). // {##
+                    preg_quote($this->options['tag_comment'][0].'#', '#').$emptyCommentLookahead. // {## (but not the empty comment {##})
                     '|'.
                     preg_quote($this->options['tag_comment'][0], '#'). // {#
                 ')('.

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -349,6 +349,19 @@ TWIG, 'index')));
         $this->assertNull($body->getNode('4')->getDocumentation());
     }
 
+    public function testEmptyCommentIsNotLexedAsDocumentation(): void
+    {
+        $twig = new Environment(new ArrayLoader(), ['autoescape' => false]);
+        $module = $twig->parse($twig->tokenize(new Source(<<<'TWIG'
+{##}{{ answer }}
+{% block a %}x{##}{% endblock %}{% block b %}y{% endblock %}
+TWIG, 'index')));
+        $body = $module->getNode('body')->getNode('0');
+
+        $this->assertInstanceOf(PrintNode::class, $body->getNode('0'));
+        $this->assertNull($body->getNode('0')->getDocumentation());
+    }
+
     public function testInlineDocumentationBeforeATagNameIsIgnored(): void
     {
         $twig = new Environment(new ArrayLoader(), ['autoescape' => false]);
@@ -440,7 +453,7 @@ TWIG, 'index')));
     {
         $twig = new Environment(new ArrayLoader());
 
-        $this->expectDeprecation('Since twig/twig 3.29: Defining the macro "input" more than once in "index" is deprecated and will throw a SyntaxError in Twig 4.0 (first definition at line 1, second at line 1).');
+        $this->expectDeprecation('Since twig/twig 3.29: Defining the macro "input" more than once in "index" is deprecated and will throw a SyntaxError in Twig 4.0 (first definition at line 1, second at line 1). The last definition is used in Twig 3.');
 
         $module = $twig->parse($twig->tokenize(new Source('{## First #}{% macro input() %}{% endmacro %}{## Second #}{% macro input() %}{% endmacro %}', 'index')));
 


### PR DESCRIPTION
Since #4871, the empty comment `{##}` fails to lex: the source is `{#` immediately followed by the closing `#}`, but the lexer now reads it as the documentation comment opening `{##`, which steals the `#` belonging to the closing tag. The remaining input never contains a closer, so lexing fails with `Unclosed comment`, and in a larger template everything up to the next comment gets swallowed, which surfaces as confusing errors like `Expected endblock for block "form_row_render" (but "submit_row" given)`.

Minimal reproducer:

```php
(new \Twig\Environment(new \Twig\Loader\ArrayLoader()))->createTemplate('{##}')->render();
// Twig\Error\SyntaxError: Unclosed comment at line 1.
```

This is currently breaking the symfony/symfony 8.2 CI on every new run: the Twig bridge form themes use `{##}` as a line-joining trick (e.g. `bootstrap_3_horizontal_layout.html.twig`), so all form layout tests fail to compile ([example run](https://github.com/symfony/symfony/actions/runs/32267973483/job/96117211040), 547 errors).

The fix adds a negative lookahead to the documentation comment opening so that the exact sequence `{##}` keeps lexing as a regular (empty) comment. The lookahead is only built when the comment closing tag starts with `#`, so custom delimiters where the ambiguity cannot exist (and where an empty documentation comment would legitimately match the lookahead) are unaffected. `{###}` (an empty documentation comment) and `{##-#}` keep working.
