### PR TITLE
Release destructuring temporaries after assignment

### DIFF
--- a/src/Node/Expression/Binary/ObjectDestructuringSetBinary.php
+++ b/src/Node/Expression/Binary/ObjectDestructuringSetBinary.php
@@ -54,7 +54,7 @@ class ObjectDestructuringSetBinary extends AbstractBinary
     {
         $compiler->addDebugInfo($this);
         $var = '$'.$compiler->getVarName();
-        $compiler->raw('[');
+        $compiler->raw('[[');
         foreach ($this->mappings as $i => $mapping) {
             if ($i) {
                 $compiler->raw(', ');
@@ -74,7 +74,7 @@ class ObjectDestructuringSetBinary extends AbstractBinary
             }
             $compiler->raw(', ')->repr($mapping['property'])->raw(', [], \\Twig\\Template::ANY_CALL, false, false, ')->repr($compiler->getEnvironment()->hasExtension(SandboxExtension::class))->raw(', ')->repr($this->getNode('right')->getTemplateLine())->raw(')');
         }
-        $compiler->raw(']');
+        $compiler->raw('], '.$var.' = null][0]');
     }
 
     public function operator(Compiler $compiler): Compiler

--- a/src/Node/Expression/Binary/SequenceDestructuringSetBinary.php
+++ b/src/Node/Expression/Binary/SequenceDestructuringSetBinary.php
@@ -50,7 +50,7 @@ class SequenceDestructuringSetBinary extends AbstractBinary
         $compiler->addDebugInfo($this);
         $var = '$'.$compiler->getVarName();
         $compiler
-            ->raw('(('.$var.' = ')
+            ->raw('[(('.$var.' = ')
             ->subcompile($this->getNode('right'))
             ->raw(') instanceof \Traversable ? CoreExtension::destructureSequence($context, ')
             ->repr($this->variables)
@@ -67,7 +67,7 @@ class SequenceDestructuringSetBinary extends AbstractBinary
         $compiler
             ->raw('] = array_pad('.$var.', ')
             ->repr(\count($this->variables))
-            ->raw(', null)))')
+            ->raw(', null))), '.$var.' = null][0]')
         ;
     }
 

--- a/tests/Node/Expression/Binary/ObjectDestructuringSetTest.php
+++ b/tests/Node/Expression/Binary/ObjectDestructuringSetTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Tests\Node\Expression\Binary;
+
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Expression\Binary\ObjectDestructuringSetBinary;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\Variable\AssignContextVariable;
+use Twig\Node\Expression\Variable\ContextVariable;
+use Twig\Test\NodeTestCase;
+
+class ObjectDestructuringSetTest extends NodeTestCase
+{
+    public static function provideTests(): iterable
+    {
+        $left = new ArrayExpression([], 1);
+        $left->addElement(new AssignContextVariable('name', 1), new ConstantExpression('name', 1));
+        $left->addElement(new AssignContextVariable('address', 1), new ConstantExpression('email', 1));
+        $node = new ObjectDestructuringSetBinary($left, new ContextVariable('user', 1), 1);
+
+        return [
+            [$node, <<<'EOF'
+// line 1
+[[$context["name"], $context["address"]] = [CoreExtension::getAttribute($this->env, $this->source, ($_v0 = ($context["user"] ?? null)), "name", [], \Twig\Template::ANY_CALL, false, false, false, 1), CoreExtension::getAttribute($this->env, $this->source, $_v0, "email", [], \Twig\Template::ANY_CALL, false, false, false, 1)], $_v0 = null][0]
+EOF
+            ],
+        ];
+    }
+}

--- a/tests/Node/Expression/Binary/SequenceDestructuringSetTest.php
+++ b/tests/Node/Expression/Binary/SequenceDestructuringSetTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Tests\Node\Expression\Binary;
+
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Expression\Binary\SequenceDestructuringSetBinary;
+use Twig\Node\Expression\EmptyExpression;
+use Twig\Node\Expression\Variable\AssignContextVariable;
+use Twig\Node\Expression\Variable\ContextVariable;
+use Twig\Test\NodeTestCase;
+
+class SequenceDestructuringSetTest extends NodeTestCase
+{
+    public static function provideTests(): iterable
+    {
+        $left = new ArrayExpression([], 1);
+        $left->addElement(new AssignContextVariable('first', 1));
+        $left->addElement(new EmptyExpression(1));
+        $left->addElement(new AssignContextVariable('third', 1));
+        $node = new SequenceDestructuringSetBinary($left, new ContextVariable('values', 1), 1);
+
+        return [
+            [$node, <<<'EOF'
+// line 1
+[(($_v0 = ($context["values"] ?? null)) instanceof \Traversable ? CoreExtension::destructureSequence($context, [0 => "first", 1 => null, 2 => "third"], $_v0) : ([$context["first"], , $context["third"]] = array_pad($_v0, 3, null))), $_v0 = null][0]
+EOF
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
The compiled destructuring code kept the right-hand side alive in a hidden local until the end of rendering, wasting memory on large arrays and iterators. The temporary is now cleared as part of the compiled expression.

The way it works:

For this Twig expression:

```twig
{% do {name, email: address} = user %}
```

The previous generated expression was conceptually:

```php
[$context["name"], $context["address"]] = [
    getAttribute($_v0 = $context["user"], "name"),
    getAttribute($_v0, "email"),
];
```

The branch now generates:

```php
[
    [$context["name"], $context["address"]] = [
        getAttribute($_v0 = $context["user"], "name"),
        getAttribute($_v0, "email"),
    ],
    $_v0 = null,
][0]
```

The important wrapper is:

```php
[$originalExpression, $_v0 = null][0]
```

PHP evaluates array elements from left to right:

1. The original destructuring assignment runs.
2. The temporary variable is set to `null`, releasing its reference.
3. `[0]` returns the result of the original expression.

This preserves Twig’s rule that a destructuring expression returns its right-hand value.
