### PR TITLE
Throw when list formatting fails

### DIFF
--- a/extra/intl-extra/IntlExtension.php
+++ b/extra/intl-extra/IntlExtension.php
@@ -451,7 +451,12 @@ final class IntlExtension extends AbstractExtension
             throw new RuntimeError('The "format_list" filter requires the "IntlListFormatter" class, which is available since PHP 8.5.');
         }
 
-        return $this->createListFormatter($locale, $type, $width)->format($strings);
+        $formatter = $this->createListFormatter($locale, $type, $width);
+        if (false === $ret = $formatter->format($strings)) {
+            throw new RuntimeError(\sprintf('Unable to format the given list: %s', $formatter->getErrorMessage()));
+        }
+
+        return $ret;
     }
 
     private function createDateFormatter(?string $locale, ?string $dateFormat, ?string $timeFormat, string $pattern, ?\DateTimeZone $timezone, ?string $calendar): \IntlDateFormatter

--- a/extra/intl-extra/Tests/IntlExtensionTest.php
+++ b/extra/intl-extra/Tests/IntlExtensionTest.php
@@ -13,6 +13,7 @@ namespace Twig\Extra\Intl\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
+use Twig\Error\RuntimeError;
 use Twig\Extension\CoreExtension;
 use Twig\Extra\Intl\IntlExtension;
 use Twig\Loader\ArrayLoader;
@@ -222,5 +223,23 @@ class IntlExtensionTest extends TestCase
         $cache = (new \ReflectionProperty(IntlExtension::class, 'numberFormatters'))->getValue($ext);
         $this->assertLessThanOrEqual(100, \count($cache));
         $this->assertGreaterThan(1, \count($cache));
+    }
+
+    public function testFormatListThrowsOnFailure(): void
+    {
+        if (!class_exists('IntlListFormatter')) {
+            $this->markTestSkipped('IntlListFormatter is not available.');
+        }
+
+        $strings = ['Alice', "\xB1\x31"];
+        $formatter = new \IntlListFormatter('en', \IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_WIDE);
+        if (false !== $formatter->format($strings)) {
+            $this->markTestSkipped('IntlListFormatter accepts the malformed UTF-8 input.');
+        }
+
+        $this->expectException(RuntimeError::class);
+        $this->expectExceptionMessage('Unable to format the given list: '.$formatter->getErrorMessage());
+
+        (new IntlExtension())->formatList($strings, locale: 'en');
     }
 }


### PR DESCRIPTION
`format_list` silently returned an empty string when `IntlListFormatter` fails (for instance on malformed UTF-8); it now throws a `RuntimeError` with the formatter's error message.
