### PR TITLE
Fix duplicate macro deprecation wording

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -309,7 +309,7 @@ class Parser
     public function setMacro(string $name, MacroNode $node): void
     {
         if (isset($this->macros[$name])) {
-            trigger_deprecation('twig/twig', '3.29', 'Defining the macro "%s" more than once in "%s" is deprecated and will throw a SyntaxError in Twig 4.0 (first definition at line %d, second at line %d). The last definition is used in Twig 3.', $name, $this->stream->getSourceContext()->getName(), $this->macros[$name]->getTemplateLine(), $node->getTemplateLine());
+            trigger_deprecation('twig/twig', '3.29', 'Defining the macro "%s" more than once in "%s" is deprecated and will throw a SyntaxError in Twig 4.0 (previous definition at line %d, new definition at line %d). The last definition is used in Twig 3.', $name, $this->stream->getSourceContext()->getName(), $this->macros[$name]->getTemplateLine(), $node->getTemplateLine());
         }
 
         $this->macros[$name] = $node;

--- a/tests/Fixtures/macros/duplicate_definition.legacy.test
+++ b/tests/Fixtures/macros/duplicate_definition.legacy.test
@@ -1,7 +1,7 @@
 --TEST--
 Defining a macro more than once is deprecated
 --DEPRECATION--
-Since twig/twig 3.29: Defining the macro "greet" more than once in "index.twig" is deprecated and will throw a SyntaxError in Twig 4.0 (first definition at line 3, second at line 4). The last definition is used in Twig 3.
+Since twig/twig 3.29: Defining the macro "greet" more than once in "index.twig" is deprecated and will throw a SyntaxError in Twig 4.0 (previous definition at line 3, new definition at line 4). The last definition is used in Twig 3.
 --TEMPLATE--
 {% import _self as macros %}
 {% macro greet() %}first{% endmacro %}

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -453,7 +453,7 @@ TWIG, 'index')));
     {
         $twig = new Environment(new ArrayLoader());
 
-        $this->expectDeprecation('Since twig/twig 3.29: Defining the macro "input" more than once in "index" is deprecated and will throw a SyntaxError in Twig 4.0 (first definition at line 1, second at line 1). The last definition is used in Twig 3.');
+        $this->expectDeprecation('Since twig/twig 3.29: Defining the macro "input" more than once in "index" is deprecated and will throw a SyntaxError in Twig 4.0 (previous definition at line 1, new definition at line 1). The last definition is used in Twig 3.');
 
         $module = $twig->parse($twig->tokenize(new Source('{## First #}{% macro input() %}{% endmacro %}{## Second #}{% macro input() %}{% endmacro %}', 'index')));
 
@@ -461,6 +461,20 @@ TWIG, 'index')));
         foreach ($module->getNode('body')->getNode('0') as $declaration) {
             $this->assertNull($declaration->getDocumentation());
         }
+    }
+
+    /**
+     * @group legacy
+     */
+    #[Group('legacy')]
+    public function testDuplicateMacroDeprecationsReferToPreviousDefinition(): void
+    {
+        $twig = new Environment(new ArrayLoader());
+
+        $this->expectDeprecation('Since twig/twig 3.29: Defining the macro "input" more than once in "index" is deprecated and will throw a SyntaxError in Twig 4.0 (previous definition at line 1, new definition at line 2). The last definition is used in Twig 3.');
+        $this->expectDeprecation('Since twig/twig 3.29: Defining the macro "input" more than once in "index" is deprecated and will throw a SyntaxError in Twig 4.0 (previous definition at line 2, new definition at line 3). The last definition is used in Twig 3.');
+
+        $twig->parse($twig->tokenize(new Source("{% macro input() %}{% endmacro %}\n{% macro input() %}{% endmacro %}\n{% macro input() %}{% endmacro %}", 'index')));
     }
 
     public function testBodyForParentTemplates(): void


### PR DESCRIPTION
With three or more definitions of the same macro, the deprecation mislabeled the previous duplicate as the "first definition"; it now reports "previous definition" and "new definition" lines accurately.
