### PR TITLE
Fix html_attr dropping style declarations whose value is zero

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.29.0 (2026-XX-XX)
 
+ * Fix `html_attr` dropping `style` declarations whose value is `0`, `0.0` or `'0'`
  * Fix the `default` filter fallback emitting an undefined variable warning when it uses the null-safe operator
  * Fix the `matches` operator silently treating PCRE execution errors as non-matches
  * Add the `HtmlExtension::htmlAttrValue()` method to resolve a single HTML attribute value the way the `html_attr` function renders it

--- a/extra/html-extra/HtmlAttr/InlineStyle.php
+++ b/extra/html-extra/HtmlAttr/InlineStyle.php
@@ -55,7 +55,9 @@ final class InlineStyle implements MergeableInterface, AttributeValueInterface
     {
         $style = '';
         foreach ($this->value as $name => $value) {
-            if (empty($value) || true === $value) {
+            // `0`, `0.0` and `'0'` are valid CSS values, so only the values that carry
+            // no declaration at all are skipped here
+            if (null === $value || false === $value || true === $value || '' === $value || [] === $value) {
                 continue;
             }
             if (is_numeric($name)) {

--- a/extra/html-extra/Tests/HtmlAttrTest.php
+++ b/extra/html-extra/Tests/HtmlAttrTest.php
@@ -157,6 +157,27 @@ class HtmlAttrTest extends TestCase
             ],
         ];
 
+        yield 'zero style declaration values are printed' => [
+            'style="opacity: 0; z-index: 0; margin: 0;"',
+            [
+                ['style' => ['opacity' => 0, 'z-index' => '0', 'margin' => 0.0]],
+            ],
+        ];
+
+        yield 'null, false and empty string style declaration values are omitted' => [
+            'style="color: red;"',
+            [
+                ['style' => ['a' => null, 'b' => false, 'c' => '', 'd' => true, 'color' => 'red']],
+            ],
+        ];
+
+        yield 'style attribute is omitted when every declaration is omitted' => [
+            '',
+            [
+                ['style' => ['a' => null, 'b' => false, 'c' => '']],
+            ],
+        ];
+
         yield 'merging style attributes overrides by key' => [
             'style="color: blue; font-size: 14px;"',
             [


### PR DESCRIPTION
`InlineStyle::getValue()` skips a declaration when `empty($value)` is true. That also matches `0`, `0.0` and `'0'`, which are ordinary CSS values.

```twig
{{ html_attr({style: {opacity: 0}}) }}                    {# "" #}
{{ html_attr({style: {'flex-grow': 0, color: 'red'}}) }}  {# style="color: red;" #}
{{ html_attr({style: ['opacity: 0']}) }}                  {# style="opacity: 0;" #}
{{ html_attr({class: [0, 'a']}) }}                        {# class="0 a" #}
```

Same declaration, opposite result. The numeric-key branch never consults `empty()`, and the sibling `SeparatedTokenList::getValue()` already uses an explicit `null !== $v && false !== $v` test, so token lists keep a `0`. When every declaration is dropped the attribute is omitted entirely, so `{style: {opacity: 0}}` renders nothing at all, and `HtmlExtension::htmlAttrValue('style', ['opacity' => 0])` returns `null`.

Silently affects `opacity`, `z-index`, `margin`, `padding`, `border`, `flex-grow` and custom properties.

The guard now lists the values that carry no declaration. `null`, `false`, `''` and `true` still skip, and `[]` is kept in that list so empty arrays behave exactly as before.

`html_attr.rst` documents the `null`/`false`/`true` omission rules and says nothing about zero, so no doc change is needed. `HtmlAttrTest.php` already has a case named "zero is not treated as falsy", but only for a plain attribute value.

3 tests added. Reverting the fix fails the first; a naive `null`/`false`-only guard fails the other two.
